### PR TITLE
[feature] 파일저장소 S3로 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,11 @@ out/
 ### VS Code ###
 .vscode/
 
-### local Image Path ###
+# local Image Path #
 upload_images/
+
+# AWS and Local Setting #
+src/main/resources/application-dev.properties
+src/main/resources/application-prod.properties
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.jsoup:jsoup:1.18.1' // utext XSS공격 방지
-	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4' // AWS
+	// AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
@@ -28,7 +28,14 @@ public class EditorImageController {
 
             // 2. CKEditor 5 전용 성공 응답 규격
             response.put("uploaded", true);
-            response.put("url", "/images/" + savedFileName); // WebConfig 리소스 매핑 주소
+
+            if (savedFileName.startsWith("http")) {
+                // S3방식
+                response.put("url", savedFileName);
+            } else {
+                // local방식, WebConfig 리소스 매핑 주소
+                response.put("url", "/images/" + savedFileName);
+            }
 
         } catch (Exception e) {
             // 3. 에러 발생 시 실패 응답 규격

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -81,12 +81,16 @@ public class PostService {
     @Transactional
     public void deletePost(Long id) {
         // 게시글 조회
+
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("삭제하려는 게시글이 존재하지 않습니다. id=" + id));
 
+        log.info("파일 삭제 요청 id: {}", id);
         // 이미지 삭제: 해당 게시글 content에서 이미지 파일명들 추출 후 물리적 삭제
         List<String> fileNames = extractFileNamesFromContent(post.getContent());
+
         for (String fileName : fileNames) {
+            log.info("파일 삭제 요청 fileName: {}", fileName);
             fileService.deleteFile(fileName);
         }
 
@@ -97,15 +101,25 @@ public class PostService {
     // HTML 문자열에서 파일명만 추출하는 메서드
     private List<String> extractFileNamesFromContent(String content) {
         List<String> fileNames = new ArrayList<>();
-        if (content == null)
+        if (content == null || content.isBlank())
             return fileNames;
 
-        // /images/ 뒤에 오는 파일명 패턴을 찾음 (정규표현식)
-        Pattern pattern = Pattern.compile("/images/([^\"'>\\s]+)");
+        // /images/ 뒤에 오는 파일명 패턴 혹은 http:로 시작하는 S3경로 찾음 (정규표현식)
+        Pattern pattern = Pattern.compile(
+                "/images/([^\"'>\\s]+)|(https://[a-zA-Z0-9.-]+\\.s3\\.[a-zA-Z0-9-]+\\.amazonaws\\.com/[^\"'>\\s]+)");
         Matcher matcher = pattern.matcher(content);
 
         while (matcher.find()) {
-            fileNames.add(matcher.group(1)); // 첫 번째 괄호 안의 파일명 부분만 저장
+            String localFileName = matcher.group(1); // 로컬 파일명 (uuid-test.jpg)
+            String s3FullUrl = matcher.group(2); // S3 전체 URL
+
+            if (localFileName != null) {
+                // 로컬 환경일 때: "uuid-test.jpg"만 추가
+                fileNames.add(localFileName);
+            } else if (s3FullUrl != null) {
+                // S3 환경일 때: 전체 URL 추가 (이미 만들어둔 URI 파싱 로직 활용)
+                fileNames.add(s3FullUrl);
+            }
         }
         return fileNames;
     }

--- a/src/main/java/com/finance/finportfolio/global/config/S3Config.java
+++ b/src/main/java/com/finance/finportfolio/global/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.finance.finportfolio.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+@Profile("dev")
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean // 다른 클래스 의존성 주입용
+    public AmazonS3 amazonS3() {
+        // 1. 발급받은 키를 사용하여 자격 증명 객체 생성
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        // 2. S3 클라이언트 빌더를 통해 리전과 자격 증명을 설정하고 객체 생성
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials)) // 고정 키 방식인데 EC2 배포시 동적으로 변경!
+                .build();
+    }
+}

--- a/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
+++ b/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.filter.HiddenHttpMethodFilter;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
+@Profile("local")
 public class WebConfig implements WebMvcConfigurer {
 
     // 이미지 업로드 경로 주소 환경변수로 받아옴

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileHandler.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -12,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component // 스프링 빈으로 등록하여 Service에서 가져다 쓸 수 있게 함
+@Profile("local")
 public class LocalFileHandler {
 
     @Value("${file.upload-dir:upload_images}")
@@ -24,10 +26,7 @@ public class LocalFileHandler {
 
     // 물리적 이미지 파일 저장
     public void uploadFile(MultipartFile file, String savedFileName) {
-        // 방어 코드: 파일이 아예 없거나(null) 비어있는 경우 처리
-        if (file == null || file.isEmpty()) {
-            return;
-        }
+
         String uploadPath = getFullPath();
 
         log.info("게시글 이미지 파일 저장 시작! 대상 경로, 이름: {}, {}", uploadPath, savedFileName);
@@ -49,22 +48,19 @@ public class LocalFileHandler {
     }
 
     // 물리적 이미지 파일 삭제
-    public void deleteFile(String savedFileName) {
-        if (savedFileName == null || savedFileName.isEmpty()) {
-            return;
-        }
+    public void deleteFile(String fileName) {
 
         String uploadPath = getFullPath();
-        File file = new File(uploadPath, savedFileName);
+        File file = new File(uploadPath, fileName);
 
         if (file.exists()) {
             if (file.delete()) {
-                log.info("게시글 이미지 파일 삭제 성공: {}", savedFileName);
+                log.info("게시글 이미지 파일 삭제 성공: {}", fileName);
             } else {
-                log.warn("게시글 이미지 파일 삭제 실패: {}", savedFileName);
+                log.warn("게시글 이미지 파일 삭제 실패: {}", fileName);
             }
         } else {
-            log.info("게시글 이미지 파일이 존재하지 않습니다: {}", savedFileName);
+            log.info("게시글 이미지 파일이 존재하지 않습니다: {}", fileName);
         }
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 // LocalFileServiceImpl - 파일 서비스 구현체 (docker 버전)
 @Service
 @RequiredArgsConstructor
-@Profile("dev")
+@Profile("local")
 public class LocalFileServiceImpl implements FileService {
     private final LocalFileHandler localFileHandler;
 
@@ -46,6 +46,9 @@ public class LocalFileServiceImpl implements FileService {
 
     @Override
     public void deleteFile(String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            return;
+        }
 
         localFileHandler.deleteFile(fileName);
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -1,0 +1,85 @@
+package com.finance.finportfolio.infrastructure.file;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("dev")
+public class S3FileHandler {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile file, String savedFileName) {
+
+        // 2. S3 내 저장 경로 설정 (예: post/uuid_filename.jpg)
+        String s3Key = savedFileName;
+
+        // 3. 메타데이터 설정 (파일 타입과 크기)
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try {
+            // 4. S3에 파일 업로드 (ACL 설정 없이 업로드)
+            amazonS3.putObject(new PutObjectRequest(bucket, s3Key, file.getInputStream(), metadata));
+            // 5. 업로드된 파일의 공용 URL 반환
+            String uploadUrl = amazonS3.getUrl(bucket, s3Key).toString();
+
+            log.info("S3 파일 업로드 성공: {}, URL: {}", s3Key, uploadUrl);
+
+            return uploadUrl;
+        } catch (IOException e) {
+            throw new RuntimeException("S3 파일 업로드 중 오류 발생", e);
+        }
+    }
+
+    public void deleteFile(String fileUrl) {
+
+        // URL에서 S3 Key(경로)만 추출 (예: post/uuid_filename.jpg)
+        // URL 형식이 https://버킷명.s3.리전.amazonaws.com/경로 이므로 마지막 '/' 이후가 아니라 버킷명 이후 전체가
+        // key입니다.
+
+        try {
+            // 2. URI 파싱 (JDK 21 권장 방식)
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath();
+
+            if (path == null || path.length() <= 1) {
+                return;
+            }
+
+            // 3. S3 Key 추출 및 디코딩
+            String key = URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
+
+            // 4. S3 삭제 요청
+            amazonS3.deleteObject(bucket, key);
+            log.info("S3 파일 삭제 성공: {}", key);
+
+        } catch (URISyntaxException e) {
+            log.error("잘못된 URL 형식입니다: {}", fileUrl);
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 중 예기치 못한 오류 발생: {}", e.getMessage());
+            // 필요에 따라 예외를 던지거나 로그만 남김
+        }
+    }
+}

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -1,23 +1,46 @@
 package com.finance.finportfolio.infrastructure.file;
 
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-// S3FileServiceImpl - 파일 서비스 구현체 (AWS S3 버전)
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Profile("prod")
+@Profile("dev")
 public class S3FileServiceImpl implements FileService {
+
+    private final S3FileHandler s3FileHandler;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
     @Override
     public String uploadFile(MultipartFile file) {
-        return "";
+        if (file == null || file.isEmpty() || file.getOriginalFilename() == null) {
+            return null;
+        }
+        // 널체크랑 UUID로 이름만 정해주고 핸들러로
+        String savedFileName = createFileName(file.getOriginalFilename());
+        return s3FileHandler.uploadFile(file, savedFileName);
+
     }
 
     @Override
-    public void deleteFile(String fileName) {
+    public void deleteFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return;
+        }
+        s3FileHandler.deleteFile(fileUrl);
+    }
+
+    private String createFileName(String originalFileName) {
+        return UUID.randomUUID() + "-" + originalFileName;
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,8 @@
+# S3 설정
+cloud.aws.credentials.access-key=AKIAVSROV47HFJDJUIG6
+cloud.aws.credentials.secret-key=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
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false
+
+# 버킷 이름
+cloud.aws.s3.bucket=finportfolio-s3-bucket-dev-9806

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ file.upload-dir=upload_images
 # spring.jpa.hibernate.ddl-auto=validate 배포 전 이걸로 변경
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.jpa.open-in-view=false
 
 # POST로 온 요청 중 _method=DELETE가 있으면 DELETE 매핑으로 연결해줌
 spring.mvc.hiddenmethod.filter.enabled=true

--- a/src/test/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDtoTest.java
+++ b/src/test/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDtoTest.java
@@ -1,4 +1,4 @@
-package com.finance.finportfolio.dto;
+package com.finance.finportfolio.domain.post.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.finance.finportfolio.domain.post.domain.Post;
-import com.finance.finportfolio.domain.post.dto.PostSaveRequestDto;
 
 class PostSaveRequestDtoTest {
 


### PR DESCRIPTION
개요
- 게시판 이미지 저장소를 기존의 로컬에서 AWS S3 버킷으로 전환
- **EditorImageController**, **PostService**에서 기존 로컬 저장소인 `/images/`형식으로 주소를 가져와 s3의 http형식 url을 인식하지 못하여 파일의 저장과 삭제가 제대로 이루어지지 않는 문제 발견

변경 사항
- **S3FileServiceImpl**: AmazonS3의존성을 직접 받아와 파일 저장과 삭제를 직접 처리하는 방식에서 **S3FileHandler**를 추가하여 *S3FileServiceImpl**에서는 null체크와 uuid설정만, 물리적인 저장은 **S3FileHandler**에서 담당하도록 설계
- **S3Config**: s3의 자격증명 객체 관리
- **EditorImageController**, **PostService**: 차후 로컬과 s3 둘 모두의 개발 환경을 고려해 `savedFileName.startsWith("http")`와 `pattern` 및 `matcher`를 이용해 각 file경로를 가져오게 refactor하였음

결과
- 로컬`@Profile("local")`과 S3버킷 저장소`@Profile("dev")` 두 환경 모두 저장소에 정상 업로드 및 삭제 확인
