### PR TITLE
[feature] 게시글 목록, 게시글 상세 페이지 분리 및 hasImage필드 추가

### DIFF
--- a/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
@@ -32,7 +32,7 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public String list(Model model) {
+    public String postList(Model model) {
 
         // 서비스는 Post 엔티티가 아닌 PostResponseDto 리스트를 반환
         List<PostResponseDto> posts = postService.getAllPosts();
@@ -42,37 +42,29 @@ public class PostController {
         return "posts";
     }
 
-    // post-editor 페이지로 (new Posting)
-    @GetMapping("/editor")
-    public String posting(Model model) {
-        model.addAttribute("post", null);
-        return "post-editor";
-    }
+    // post-detail.html return
+    @GetMapping("/detail/{id}")
+    public String toDetailHtml(@PathVariable Long id, Model model) {
+        PostResponseDto dto = postService.getPostById(id);
 
-    // post-editor 페이지로 (Update)
-    @GetMapping("/editor/{id}")
-    public String updateForm(@PathVariable Long id, Model model) {
-        PostResponseDto dto = postService.getPostById(id); // 기존에 만든 상세조회 활용
-
-        log.info("게시글 수정 페이지로 - 제목: {}", dto.getTitle());
+        log.info("게시글 상세 페이지로 - 제목: {}", dto.getTitle());
 
         model.addAttribute("post", dto);
+        return "post-detail";
+    }
+
+    // post-editor.html return (with no ID: new Post)
+    @GetMapping("/editor")
+    public String toEditorHtml(Model model) {
+        model.addAttribute("post", null);
+
+        log.info("게시글 작성 페이지로(with no ID)");
+
         return "post-editor";
     }
 
-    // Update
-    @PostMapping("/editor/{id}")
-    public String update(@PathVariable Long id, @ModelAttribute PostUpdateRequestDto requestDto) {
-
-        log.info("게시글 수정 시도 - 제목: {}", requestDto.title());
-
-        postService.update(id, requestDto);
-        return "redirect:/posts"; // 수정 후 목록으로 리다이렉트
-    }
-
-    // Create
-    @PostMapping("/editor/save")
-    public String save(@ModelAttribute PostSaveRequestDto requestDto) {
+    @PostMapping("/editor/create")
+    public String createPost(@ModelAttribute PostSaveRequestDto requestDto) {
 
         log.info("게시글 저장 시도 - 제목: {}", requestDto.title());
 
@@ -82,8 +74,28 @@ public class PostController {
         return "redirect:/posts";
     }
 
-    @DeleteMapping("/{id}")
-    public String delete(@PathVariable Long id) {
+    // post-editor html return (with ID: update)
+    @GetMapping("/editor/{id}")
+    public String toEditorWithID(@PathVariable Long id, Model model) {
+        PostResponseDto dto = postService.getPostById(id); // 기존에 만든 상세조회 활용
+
+        log.info("게시글 수정 페이지로 - 제목: {}", dto.getTitle());
+
+        model.addAttribute("post", dto);
+        return "post-editor";
+    }
+
+    @PostMapping("/editor/{id}")
+    public String updatePost(@PathVariable Long id, @ModelAttribute PostUpdateRequestDto requestDto) {
+
+        log.info("게시글 수정 시도 - 제목: {}", requestDto.title());
+
+        postService.updatePost(id, requestDto);
+        return "redirect:/posts"; // 수정 후 목록으로 리다이렉트
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public String deletePost(@PathVariable Long id) {
         postService.deletePost(id);
         log.info("게시글 삭제 완료 - ID: {}", id);
         return "redirect:/posts";

--- a/src/main/java/com/finance/finportfolio/domain/post/domain/Post.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/domain/Post.java
@@ -38,12 +38,16 @@ public class Post {
     @Column(columnDefinition = "TEXT") // CKEditor : HTML 문자열로 저장
     private String content;
 
+    @Column(nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    private boolean hasImage = false;
+
     @CreatedDate // 생성 시 자동 저장
     @Column(updatable = false) // 생성 후 수정 불가
     private LocalDateTime createdAt;
 
-    public void update(String title, String content) {
+    public void update(String title, String content, boolean hasImage) {
         this.title = title;
         this.content = content;
+        this.hasImage = hasImage;
     }
 }

--- a/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
@@ -13,6 +13,7 @@ public class PostResponseDto {
     private final String author;
     private final String title;
     private final String content;
+    private final boolean hasImage;
     private final LocalDateTime createdAt;
 
     // Entity -> DTO 변환을 위한 생성자
@@ -21,6 +22,7 @@ public class PostResponseDto {
         this.author = post.getAuthor();
         this.title = post.getTitle();
         this.content = post.getContent();
+        this.hasImage = post.isHasImage();
         this.createdAt = post.getCreatedAt();
     }
 }

--- a/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
@@ -9,14 +9,16 @@ import lombok.Builder;
 public record PostSaveRequestDto(
                 String author,
                 String title,
-                String content) {
+                String content,
+                Boolean hasImage) {
 
         // DTO -> Entity 변환 (DB 저장용)
         public Post toEntity() {
                 return Post.builder()
                                 .author(author)
                                 .title(title)
-                                .content(content) // Jsoup XSS 살균
+                                .content(content)
+                                .hasImage(hasImage)
                                 .build();
         }
 }

--- a/src/main/java/com/finance/finportfolio/domain/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/dto/PostUpdateRequestDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record PostUpdateRequestDto(
-        String title,
-        String content) {
+                String title,
+                String content,
+                Boolean hasImage) {
 }

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,6 +72,15 @@ public class PostService {
         return (text == null) ? "" : Jsoup.clean(text, HTML_SAFE_LIST);
     }
 
+    private boolean checkImage(String htmlContent) {
+        if (htmlContent == null || htmlContent.isEmpty())
+            return false;
+
+        Document doc = Jsoup.parseBodyFragment(htmlContent);
+        // 실제 <img> 태그가 1개 이상 존재하는지 "객체" 단위로 확인
+        return !doc.select("img").isEmpty();
+    }
+
     /**
      * 게시글 저장
      * 
@@ -79,11 +89,14 @@ public class PostService {
      */
     @Transactional
     public Long savePost(PostSaveRequestDto requestDto) {
+        String cleanedContent = cleanHtml(requestDto.content());
+        boolean hasImage = checkImage(cleanedContent);
 
         Post post = Post.builder()
                 .author(cleanText(requestDto.author()))
                 .title(cleanText(requestDto.title()))
-                .content(cleanHtml(requestDto.content()))
+                .content(cleanedContent)
+                .hasImage(hasImage)
                 .build();
 
         // Repository를 통해 DB 저장 후 ID 반환
@@ -91,11 +104,14 @@ public class PostService {
     }
 
     @Transactional
-    public void update(Long id, PostUpdateRequestDto requestDto) {
+    public void updatePost(Long id, PostUpdateRequestDto requestDto) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
 
-        post.update(cleanText(requestDto.title()), cleanHtml(requestDto.content()));
+        String cleanedContent = cleanHtml(requestDto.content());
+        boolean hasImage = checkImage(cleanedContent);
+
+        post.update(cleanText(requestDto.title()), cleanedContent, hasImage);
     }
 
     /**

--- a/src/main/resources/templates/post-detail.html
+++ b/src/main/resources/templates/post-detail.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <title>postDetail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" th:href="@{/css/postsStyle.css}">
+</head>
+
+<body class="container mt-5">
+    <h2>게시글 상세</h2>
+    <table class="table table-striped">
+        <a th:href="@{/posts}" class="btn btn-warning">목록으로</a>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>제목</th>
+                <th>내용</th>
+                <th>시간</th>
+                <th>수정</th>
+                <th>삭제</th>
+            </tr>
+        </thead>
+        <tbody>
+            <td th:text="${post?.id}"></td>
+            <td th:text="${post?.title}"></td>
+            <td th:utext="${post?.content}"></td>
+            <td th:text="${#temporals.format(post?.createdAt, 'yyyy-MM-dd / HH:mm:ss')}"></td>
+            <td th:if="${post?.id != null}">
+                <a th:href="@{/posts/editor/{id}(id=${post.id})}" class="btn btn-warning">수정</a>
+            </td>
+            <td th:if="${post?.id != null}">
+                <form th:action="@{/posts/delete/{id}(id=${post.id})}" th:method="delete">
+                    <button type="submit">삭제</button>
+                </form>
+            </td>
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/src/main/resources/templates/post-editor.html
+++ b/src/main/resources/templates/post-editor.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>editorPage</title>
+    <title>postEditor</title>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" th:href="@{/css/postEditorStyle.css}">
@@ -24,7 +24,7 @@
 
     <div class="card p-3 mb-4">
         <!-- 게시글 업로드 -->
-        <form th:action="${post?.id == null} ? @{/posts/editor/save} : @{/posts/editor/{id}(id=${post.id})}"
+        <form th:action="${post?.id == null} ? @{/posts/editor/create} : @{/posts/editor/{id}(id=${post.id})}"
             method="post" enctype="multipart/form-data">
             <input type="hidden" name="id" th:if="${post?.id != null}" th:value="${post.id}">
             <div>

--- a/src/main/resources/templates/posts.html
+++ b/src/main/resources/templates/posts.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>postsPage</title>
+    <title>posts</title>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" th:href="@{/css/postsStyle.css}">
@@ -19,23 +19,17 @@
             <tr>
                 <th>ID</th>
                 <th>제목</th>
-                <th>내용</th>
                 <th>시간</th>
-                <th>관리</th>
             </tr>
         </thead>
         <tbody>
             <tr th:each="post : ${posts}">
                 <td th:text="${post.id}"></td>
-                <td th:text="${post.title}"></td>
-                <td th:utext="${post.content}"></td>
-                <td th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd / HH:mm:ss')}"></td>
                 <td>
-                    <form th:action="@{/posts/{id}(id=${post.id})}" th:method="delete">
-                        <button type="submit">삭제</button>
-                    </form>
-                    <a th:href="@{/posts/editor/{id}(id=${post.id})}" class="btn btn-warning">수정</a>
-                </td>
+                    <span th:if="${post.hasImage}" class="badge bg-info">📷</span>
+                    <a th:href="@{/posts/detail/{id}(id=${post.id})}" th:text="${post.title}"
+                        style="text-decoration: none; color: black;"></a>
+                <td th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd / HH:mm')}"></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
개요
- 게시글 목록, 게시글 상세 페이지 분리를 통한 편의성 향상
- `Post`엔티티에 `hasImage`필드를 추가하여 게시글 목록에서 게시글이 이미지를 포함하고 있는지 가시화

변경사항
- **posts.html**, **post-detail.html**: 게시글 목록/상세 페이지 분리
- **Post**: ``hasImage` 필드 추가
- **PostResponseDto**, **PostSaveRequestDto**, **PostUpdateRequestDto**: 엔티티 필드 추가로 인한 dto 추가 수정
- **PostController**:  `/detail/{id}` 엔드포인트로 **posts.html** get연결 
- **PostService**: `hasImage`필드 추가로 인한 `savePost`, `updatePost` 수정 및 `checkImage`메서드 추가

결과
- 게시글 목록/상세 분리 확인 및 게시글 목록에서 이미지 포함 여부 확인 완료