### PR TITLE
[feature] s3 버킷과 DB post 엔티티 비교 후 비참조 이미지 파일 삭제 로직 추가

### DIFF
--- a/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
@@ -1,7 +1,10 @@
 package com.finance.finportfolio.domain.post.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 // 스프링 어노테이션
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.finance.finportfolio.domain.post.dto.PostResponseDto;
 import com.finance.finportfolio.domain.post.dto.PostSaveRequestDto;
@@ -101,4 +105,24 @@ public class PostController {
         return "redirect:/posts";
     }
 
+    @PostMapping("/cleanup")
+    public String cleanUpOrphanFiles(RedirectAttributes redirectAttributes) {
+
+        List<String> deletedFiles = postService.cleanUpOrphanFiles();
+
+        if (deletedFiles.isEmpty()) {
+            log.info("[CLEANUP] 정리할 고아 파일이 없습니다.");
+        } else {
+            log.info("[CLEANUP] 비참조 파일 정리 완료. 삭제 개수: {}개", deletedFiles.size());
+            log.info("[CLEANUP] 삭제된 파일 목록: {}", deletedFiles);
+        }
+
+        return "redirect:/posts";
+    }
+
+    @GetMapping("/showLog")
+    public String showLog() {
+        log.info("구분용 로그");
+        return "redirect:/posts";
+    }
 }

--- a/src/main/java/com/finance/finportfolio/domain/post/domain/Post.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/domain/Post.java
@@ -24,8 +24,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 빌더를 쓰려면 기본 생성자 필수, 외부호출 금지
-@AllArgsConstructor // 빌더를 쓰려면 전체 생성자도 필수
-@Builder // 빌더
 @EntityListeners(AuditingEntityListener.class) // 시간 감시자
 public class Post {
 
@@ -44,6 +42,14 @@ public class Post {
     @CreatedDate // 생성 시 자동 저장
     @Column(updatable = false) // 생성 후 수정 불가
     private LocalDateTime createdAt;
+
+    @Builder
+    private Post(String author, String title, String content, boolean hasImage) {
+        this.author = author;
+        this.title = title;
+        this.content = content;
+        this.hasImage = hasImage;
+    }
 
     public void update(String title, String content, boolean hasImage) {
         this.title = title;

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -1,7 +1,10 @@
 package com.finance.finportfolio.domain.post.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -122,46 +125,29 @@ public class PostService {
     @Transactional
     public void deletePost(Long id) {
         // 게시글 조회
-
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("삭제하려는 게시글이 존재하지 않습니다. id=" + id));
 
         log.info("파일 삭제 요청 id: {}", id);
         // 이미지 삭제: 해당 게시글 content에서 이미지 파일명들 추출 후 물리적 삭제
-        List<String> fileNames = extractFileNamesFromContent(post.getContent());
-
-        for (String fileName : fileNames) {
-            log.info("파일 삭제 요청 fileName: {}", fileName);
-            fileService.deleteFile(fileName);
-        }
+        fileService.deleteFile(post.getContent());
 
         // 게시글 삭제
         postRepository.delete(post);
     }
 
     // HTML 문자열에서 파일명만 추출하는 메서드
-    private List<String> extractFileNamesFromContent(String content) {
-        List<String> fileNames = new ArrayList<>();
-        if (content == null || content.isBlank())
-            return fileNames;
 
-        // /images/ 뒤에 오는 파일명 패턴 혹은 http:로 시작하는 S3경로 찾음 (정규표현식)
-        Pattern pattern = Pattern.compile(
-                "/images/([^\"'>\\s]+)|(https://[a-zA-Z0-9.-]+\\.s3\\.[a-zA-Z0-9-]+\\.amazonaws\\.com/[^\"'>\\s]+)");
-        Matcher matcher = pattern.matcher(content);
+    // 비참조 파일 삭제 요청(Local환경은 버튼, AWS 환경에서는 정시 반복으로 구현 예정)
+    @Transactional(readOnly = true)
+    public List<String> cleanUpOrphanFiles() { // 리턴 타입을 List로 변경
+        List<String> allPostContents = postRepository.findAll().stream()
+                .map(Post::getContent)
+                .filter(Objects::nonNull)
+                .toList();
 
-        while (matcher.find()) {
-            String localFileName = matcher.group(1); // 로컬 파일명 (uuid-test.jpg)
-            String s3FullUrl = matcher.group(2); // S3 전체 URL
-
-            if (localFileName != null) {
-                // 로컬 환경일 때: "uuid-test.jpg"만 추가
-                fileNames.add(localFileName);
-            } else if (s3FullUrl != null) {
-                // S3 환경일 때: 전체 URL 추가 (이미 만들어둔 URI 파싱 로직 활용)
-                fileNames.add(s3FullUrl);
-            }
-        }
-        return fileNames;
+        // fileService가 삭제한 목록을 받아서 그대로 컨트롤러에 전달
+        return fileService.cleanUpOrphanFiles(allPostContents);
     }
+
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
@@ -1,11 +1,15 @@
 package com.finance.finportfolio.infrastructure.file;
 //package com.example.portfolio.infrastructure.file;
 
+import java.util.List;
+
 import org.springframework.web.multipart.MultipartFile;
 
 // FileService - 파일 서비스 인터페이스
 public interface FileService {
     String uploadFile(MultipartFile file);
 
-    void deleteFile(String fileName);
+    void deleteFile(String content);
+
+    List<String> cleanUpOrphanFiles(List<String> allPostContents);
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
@@ -3,6 +3,8 @@ package com.finance.finportfolio.infrastructure.file;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.context.annotation.Profile;
@@ -51,5 +53,12 @@ public class LocalFileServiceImpl implements FileService {
         }
 
         localFileHandler.deleteFile(fileName);
+    }
+
+    @Override
+    public List<String> cleanUpOrphanFiles(List<String> allPostContents) {
+        List<String> aaa = new ArrayList<>();
+        return aaa;
+        // fileName을 List화 시키고 LocalFileHandler에 다중삭제 로직 추가 필요
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -12,8 +13,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,33 +56,28 @@ public class S3FileHandler {
         }
     }
 
-    public void deleteFile(String fileUrl) {
-
-        // URL에서 S3 Key(경로)만 추출 (예: post/uuid_filename.jpg)
-        // URL 형식이 https://버킷명.s3.리전.amazonaws.com/경로 이므로 마지막 '/' 이후가 아니라 버킷명 이후 전체가
-        // key입니다.
-
+    public void deleteFile(String urlKey) {
         try {
-            // 2. URI 파싱 (JDK 21 권장 방식)
-            URI uri = new URI(fileUrl);
-            String path = uri.getPath();
-
-            if (path == null || path.length() <= 1) {
-                return;
-            }
-
-            // 3. S3 Key 추출 및 디코딩
-            String key = URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
-
-            // 4. S3 삭제 요청
-            amazonS3.deleteObject(bucket, key);
-            log.info("S3 파일 삭제 성공: {}", key);
-
-        } catch (URISyntaxException e) {
-            log.error("잘못된 URL 형식입니다: {}", fileUrl);
+            amazonS3.deleteObject(bucket, urlKey);
+            log.info("S3 파일 삭제 성공: {}", urlKey);
         } catch (Exception e) {
             log.error("S3 파일 삭제 중 예기치 못한 오류 발생: {}", e.getMessage());
-            // 필요에 따라 예외를 던지거나 로그만 남김
+            throw new RuntimeException("파일 삭제 실패");
         }
+    }
+
+    // 다중 삭제
+    public void deleteFiles(List<String> urlKeys) {
+        // DeleteObjectsRequest: S3에 요청을 하나씩 주고 받으면 네트워크 비효율이 심해 상자에 담아서 한번에 요청
+        DeleteObjectsRequest request = new DeleteObjectsRequest(bucket)
+                .withKeys(urlKeys.toArray(new String[0]));
+        amazonS3.deleteObjects(request);
+    }
+
+    // S3버킷 모든 파일 키만 리스트로 반환
+    public List<String> getS3ObjectKeys() {
+        return amazonS3.listObjects(bucket).getObjectSummaries().stream()
+                .map(S3ObjectSummary::getKey)
+                .toList();
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -1,6 +1,17 @@
 package com.finance.finportfolio.infrastructure.file;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -32,15 +43,116 @@ public class S3FileServiceImpl implements FileService {
 
     }
 
-    @Override
-    public void deleteFile(String fileUrl) {
-        if (fileUrl == null || fileUrl.isEmpty()) {
-            return;
-        }
-        s3FileHandler.deleteFile(fileUrl);
-    }
-
     private String createFileName(String originalFileName) {
         return UUID.randomUUID() + "-" + originalFileName;
+    }
+
+    // @Override 원래 Url받아서 지우던 애
+    // public void deleteFile(String fileUrl) {
+    // if (fileUrl == null || fileUrl.isEmpty()) {
+    // return;
+    // }
+    // String urlKey = extractKeyFromUrl(fileUrl);
+    // if (urlKey != null) {
+    // s3FileHandler.deleteFile(urlKey);
+    // }
+    // }
+
+    // @Override 콘텐츠 전체 받아오던애
+    // public void deleteFile(String content) {
+    // if (content == null || content.isBlank())
+    // return;
+
+    // // 아까 만든 전문 메서드들 호출 (재사용!)
+    // List<String> urls = extractUrlsFromHtml(content);
+
+    // for (String url : urls) {
+    // this.deleteFile(url); // 내부에서 extractKeyFromUrl 호출 후 S3 삭제
+    // }
+    // }
+    @Override
+    public void deleteFile(String content) {
+        if (content == null || content.isBlank())
+            return;
+
+        // 정규식 메서드 재사용
+        List<String> urls = extractFileNamesFromContent(content);
+
+        for (String url : urls) {
+            // (수정) this.deleteFile(url) 대신 전용 단일 삭제 메서드 호출
+            deleteSingleFileByUrl(url);
+        }
+    }
+
+    private void deleteSingleFileByUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty())
+            return;
+        String urlKey = extractKeyFromUrl(fileUrl);
+        if (urlKey != null) {
+            s3FileHandler.deleteFile(urlKey);
+        }
+    }
+
+    @Override
+    public List<String> cleanUpOrphanFiles(List<String> allPostContents) {
+        Set<String> usedKeys = allPostContents.stream()
+                // (수정) extractKeyFromUrl 대신 정규식 추출 메서드 사용
+                .flatMap(content -> extractFileNamesFromContent(content).stream())
+                .map(this::extractKeyFromUrl)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        List<String> s3Keys = s3FileHandler.getS3ObjectKeys();
+
+        List<String> orphanKeys = s3Keys.stream()
+                .filter(key -> !usedKeys.contains(key))
+                .toList();
+
+        if (!orphanKeys.isEmpty()) {
+            s3FileHandler.deleteFiles(orphanKeys);
+        }
+
+        return orphanKeys;
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        try {
+            // 이미 키(파일명)만 들어온 경우 처리
+            if (!fileUrl.contains("/"))
+                return fileUrl;
+
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath();
+            if (path == null || path.length() <= 1)
+                return null;
+
+            // 첫 슬래시(/) 제거 및 디코딩
+            return URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.error("잘못된 URL 형식: {}", fileUrl);
+            return null;
+        }
+    }
+
+    // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직
+    private List<String> extractFileNamesFromContent(String content) {
+        List<String> fileNames = new ArrayList<>();
+        if (content == null || content.isBlank())
+            return fileNames;
+
+        Pattern pattern = Pattern.compile(
+                "/images/([^\"'>\\s]+)|(https://[a-zA-Z0-9.-]+\\.s3\\.[a-zA-Z0-9-]+\\.amazonaws\\.com/[^\"'>\\s]+)");
+        Matcher matcher = pattern.matcher(content);
+
+        while (matcher.find()) {
+            String localFileName = matcher.group(1);
+            String s3FullUrl = matcher.group(2);
+
+            if (localFileName != null)
+                fileNames.add(localFileName);
+            else if (s3FullUrl != null)
+                fileNames.add(s3FullUrl);
+        }
+        return fileNames;
     }
 }

--- a/src/main/resources/templates/post-detail.html
+++ b/src/main/resources/templates/post-detail.html
@@ -10,33 +10,38 @@
 
 <body class="container mt-5">
     <h2>게시글 상세</h2>
-    <table class="table table-striped">
-        <a th:href="@{/posts}" class="btn btn-warning">목록으로</a>
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>제목</th>
-                <th>내용</th>
-                <th>시간</th>
-                <th>수정</th>
-                <th>삭제</th>
-            </tr>
-        </thead>
+    <table class="table table-bordered">
         <tbody>
-            <td th:text="${post?.id}"></td>
-            <td th:text="${post?.title}"></td>
-            <td th:utext="${post?.content}"></td>
-            <td th:text="${#temporals.format(post?.createdAt, 'yyyy-MM-dd / HH:mm:ss')}"></td>
-            <td th:if="${post?.id != null}">
-                <a th:href="@{/posts/editor/{id}(id=${post.id})}" class="btn btn-warning">수정</a>
-            </td>
-            <td th:if="${post?.id != null}">
-                <form th:action="@{/posts/delete/{id}(id=${post.id})}" th:method="delete">
-                    <button type="submit">삭제</button>
-                </form>
-            </td>
+            <tr>
+                <th class="table-light" style="width: 20%;">ID</th>
+                <td th:text="${post?.id}"></td>
+            </tr>
+            <tr>
+                <th class="table-light">제목</th>
+                <td th:text="${post?.title}"></td>
+            </tr>
+            <tr>
+                <th class="table-light">내용</th>
+                <td th:utext="${post?.content}"></td>
+            </tr>
+            <tr>
+                <th class="table-light">시간</th>
+                <td th:text="${#temporals.format(post?.createdAt, 'yyyy-MM-dd / HH:mm:ss')}"></td>
+            </tr>
         </tbody>
     </table>
+
+    <div class="mt-3">
+        <a th:href="@{/posts}" class="btn btn-secondary">목록으로</a>
+
+        <th:block th:if="${post?.id != null}">
+            <a th:href="@{/posts/editor/{id}(id=${post.id})}" class="btn btn-warning">수정</a>
+
+            <form th:action="@{/posts/delete/{id}(id=${post.id})}" th:method="delete" style="display: inline-block;">
+                <button type="submit" class="btn btn-danger" onclick="return confirm('정말 삭제하시겠습니까?')">삭제</button>
+            </form>
+        </th:block>
+    </div>
 </body>
 
 </html>

--- a/src/main/resources/templates/posts.html
+++ b/src/main/resources/templates/posts.html
@@ -14,7 +14,11 @@
     <h2>게시글 목록</h2>
 
     <table class="table table-striped">
+        <a th:href="@{/posts/showLog}" class="btn btn-primary">로그 호출</a>
         <a th:href="@{/posts/editor}" class="btn btn-primary">글 쓰기</a>
+        <form th:action="@{/posts/cleanup}" method="post" style="display:inline;">
+            <button type="submit" class="btn btn-primary">비참조 파일 삭제</button>
+        </form>
         <thead>
             <tr>
                 <th>ID</th>


### PR DESCRIPTION
개요
- ckEditor를 통한 게시글 업로드 방식으로 인해 글 작성 중단 시 S3 버킷에는 저장 되었지만 DB post 엔티티의 content에는 이미지 경로가 저장되지 않는 비참조 파일이 발생
- 정기적 비참조 파일 삭제 로직이 필요하지만 로컬환경이므로 버튼 작동식으로 작업 후 변경 예정
- **PostService**에서 이미지 처리 로직을 맡는 것이 부적합 하다고 판단 **S3FileServiceImpl**로 이전

변경사항
- **PostController**: `cleanUpOrphanFiles`를 포스트 매핑으로 수동 작동
- **PostService**: `cleanUpOrphanFiles` 로직 작성 및 `content`에서 url을 추출하는 로직을**S3FileServiceImpl**로 이전
- **FileService**: 인터페이스에 `cleanUpOrphanFiles` 추가
- **S3FileServiceImpl**: `cleanUpOrphanFiles`로직 구현 및 `extractKeyFromUrl`과 `extractFileNamesFromContent`을 이 구현체로 이전, 따라서 delete로직 수정
- **S3FileHandler**: `deleteFiles` - 다중 삭제 로직 구현

결과
- S3 버킷에서의 비참조 파일 정상 삭제 확인