### PR TITLE
[retactor] 파일 삭제 로직 다중 처리 방식으로 통합

### DIFF
--- a/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
@@ -105,24 +105,17 @@ public class PostController {
         return "redirect:/posts";
     }
 
+    // 미참조 이미지 파일 삭제 - 버튼 식(차후 정기 실행으로 변경)
     @PostMapping("/cleanup")
-    public String cleanUpOrphanFiles(RedirectAttributes redirectAttributes) {
-
-        List<String> deletedFiles = postService.cleanUpOrphanFiles();
-
-        if (deletedFiles.isEmpty()) {
-            log.info("[CLEANUP] 정리할 고아 파일이 없습니다.");
-        } else {
-            log.info("[CLEANUP] 비참조 파일 정리 완료. 삭제 개수: {}개", deletedFiles.size());
-            log.info("[CLEANUP] 삭제된 파일 목록: {}", deletedFiles);
-        }
+    public String cleanUpOrphanFiles() {
+        postService.cleanUpOrphanFiles();
 
         return "redirect:/posts";
     }
 
     @GetMapping("/showLog")
     public String showLog() {
-        log.info("구분용 로그");
+        log.info("수동 로그");
         return "redirect:/posts";
     }
 }

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -129,25 +129,25 @@ public class PostService {
                 .orElseThrow(() -> new IllegalArgumentException("삭제하려는 게시글이 존재하지 않습니다. id=" + id));
 
         log.info("파일 삭제 요청 id: {}", id);
-        // 이미지 삭제: 해당 게시글 content에서 이미지 파일명들 추출 후 물리적 삭제
-        fileService.deleteFile(post.getContent());
+        // S3 이미지 삭제
+        fileService.deleteFiles(post.getContent());
 
-        // 게시글 삭제
+        // DB 게시글 삭제
         postRepository.delete(post);
     }
 
     // HTML 문자열에서 파일명만 추출하는 메서드
 
-    // 비참조 파일 삭제 요청(Local환경은 버튼, AWS 환경에서는 정시 반복으로 구현 예정)
+    // 미참조 이미지 파일 삭제 - 버튼 식(차후 정기 실행으로 변경)
     @Transactional(readOnly = true)
-    public List<String> cleanUpOrphanFiles() { // 리턴 타입을 List로 변경
+    public void cleanUpOrphanFiles() {
+        // DB에서 post의 모든 content 넘김
         List<String> allPostContents = postRepository.findAll().stream()
                 .map(Post::getContent)
                 .filter(Objects::nonNull)
                 .toList();
 
-        // fileService가 삭제한 목록을 받아서 그대로 컨트롤러에 전달
-        return fileService.cleanUpOrphanFiles(allPostContents);
+        fileService.cleanUpOrphanFiles(allPostContents);
     }
 
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
@@ -9,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface FileService {
     String uploadFile(MultipartFile file);
 
-    void deleteFile(String content);
+    void deleteFiles(String content);
 
-    List<String> cleanUpOrphanFiles(List<String> allPostContents);
+    void cleanUpOrphanFiles(List<String> allPostContents);
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileHandler.java
@@ -3,6 +3,7 @@ package com.finance.finportfolio.infrastructure.file;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -48,19 +49,31 @@ public class LocalFileHandler {
     }
 
     // 물리적 이미지 파일 삭제
-    public void deleteFile(String fileName) {
+    public void deleteFiles(List<String> fileNames) {
+        if (fileNames == null || fileNames.isEmpty())
+            return;
 
-        String uploadPath = getFullPath();
-        File file = new File(uploadPath, fileName);
+        String uploadPath = getFullPath(); // 파일 저장 기본 경로
 
-        if (file.exists()) {
-            if (file.delete()) {
-                log.info("게시글 이미지 파일 삭제 성공: {}", fileName);
-            } else {
-                log.warn("게시글 이미지 파일 삭제 실패: {}", fileName);
+        for (String fileName : fileNames) {
+            try {
+                // 파일 객체 생성
+                File file = new File(uploadPath, fileName);
+
+                if (file.exists()) {
+                    if (file.delete()) {
+                        log.info("[LOCAL] 파일 삭제 성공: {}", fileName);
+                    } else {
+                        log.warn("[LOCAL] 파일 삭제 실패 (권한 문제 등): {}", fileName);
+                    }
+                } else {
+                    log.info("[LOCAL] 삭제할 파일이 존재하지 않습니다: {}", fileName);
+                }
+            } catch (SecurityException e) {
+                log.error("[LOCAL] 파일 삭제 중 보안 예외 발생: {}", e.getMessage());
+            } catch (Exception e) {
+                log.error("[LOCAL] 알 수 없는 삭제 에러: {}", e.getMessage());
             }
-        } else {
-            log.info("게시글 이미지 파일이 존재하지 않습니다: {}", fileName);
         }
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
@@ -6,6 +6,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -47,18 +49,44 @@ public class LocalFileServiceImpl implements FileService {
     }
 
     @Override
-    public void deleteFile(String fileName) {
-        if (fileName == null || fileName.isEmpty()) {
-            return;
-        }
+    public void deleteFiles(String content) {
 
-        localFileHandler.deleteFile(fileName);
+        if (content == null || content.isBlank())
+            return;
+
+        // 1. 본문에서 URL 추출 및 S3 Key로 변환
+        List<String> fileNameToDelete = extractFileNamesFromContent(content);
+
+        // 2. 추출된 키가 있다면 다중 삭제 로직 하나로 처리
+        if (!fileNameToDelete.isEmpty()) {
+            localFileHandler.deleteFiles(fileNameToDelete);
+        }
+    }
+
+    // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직
+    private List<String> extractFileNamesFromContent(String content) {
+        List<String> fileNames = new ArrayList<>();
+        if (content == null || content.isBlank())
+            return fileNames;
+
+        Pattern pattern = Pattern.compile(
+                "/images/([^\"'>\\s]+)|(https://[a-zA-Z0-9.-]+\\.s3\\.[a-zA-Z0-9-]+\\.amazonaws\\.com/[^\"'>\\s]+)");
+        Matcher matcher = pattern.matcher(content);
+
+        while (matcher.find()) {
+            String localFileName = matcher.group(1);
+            String s3FullUrl = matcher.group(2);
+
+            if (localFileName != null)
+                fileNames.add(localFileName);
+            else if (s3FullUrl != null)
+                fileNames.add(s3FullUrl);
+        }
+        return fileNames;
     }
 
     @Override
-    public List<String> cleanUpOrphanFiles(List<String> allPostContents) {
-        List<String> aaa = new ArrayList<>();
-        return aaa;
+    public void cleanUpOrphanFiles(List<String> allPostContents) {
         // fileName을 List화 시키고 LocalFileHandler에 다중삭제 로직 추가 필요
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -12,8 +12,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -56,22 +59,32 @@ public class S3FileHandler {
         }
     }
 
-    public void deleteFile(String urlKey) {
-        try {
-            amazonS3.deleteObject(bucket, urlKey);
-            log.info("S3 파일 삭제 성공: {}", urlKey);
-        } catch (Exception e) {
-            log.error("S3 파일 삭제 중 예기치 못한 오류 발생: {}", e.getMessage());
-            throw new RuntimeException("파일 삭제 실패");
-        }
-    }
-
     // 다중 삭제
     public void deleteFiles(List<String> urlKeys) {
+        if (urlKeys == null || urlKeys.isEmpty()) {
+            return;
+        }
+
         // DeleteObjectsRequest: S3에 요청을 하나씩 주고 받으면 네트워크 비효율이 심해 상자에 담아서 한번에 요청
-        DeleteObjectsRequest request = new DeleteObjectsRequest(bucket)
-                .withKeys(urlKeys.toArray(new String[0]));
-        amazonS3.deleteObjects(request);
+        try {
+            DeleteObjectsRequest request = new DeleteObjectsRequest(bucket)
+                    .withKeys(urlKeys.toArray(new String[0]))
+                    .withQuiet(false); // 성공 내역까지 보고, true: 에러 내역만 보고
+
+            // quiet 모드를 false(기본값)로 두면 상세한 결과 수신 가능
+            DeleteObjectsResult result = amazonS3.deleteObjects(request);
+            log.info("S3 객체 삭제 완료: {} 건", result.getDeletedObjects().size());
+
+        } catch (AmazonServiceException e) {
+            // AWS 서버 측 에러 (권한 부족, 잘못된 버킷명 등)
+            log.error("AWS S3 서비스 에러 발생: {}", e.getErrorMessage());
+            // 서비스 로직에 따라 Custom Exception을 던지거나 로그만 남김
+        } catch (SdkClientException e) {
+            // 클라이언트 측 에러 (네트워크 연결 끊김 등)
+            log.error("S3 연결 실패: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("S3 삭제 중 예상치 못한 에러: {}", e.getMessage());
+        }
     }
 
     // S3버킷 모든 파일 키만 리스트로 반환

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -47,54 +47,25 @@ public class S3FileServiceImpl implements FileService {
         return UUID.randomUUID() + "-" + originalFileName;
     }
 
-    // @Override 원래 Url받아서 지우던 애
-    // public void deleteFile(String fileUrl) {
-    // if (fileUrl == null || fileUrl.isEmpty()) {
-    // return;
-    // }
-    // String urlKey = extractKeyFromUrl(fileUrl);
-    // if (urlKey != null) {
-    // s3FileHandler.deleteFile(urlKey);
-    // }
-    // }
-
-    // @Override 콘텐츠 전체 받아오던애
-    // public void deleteFile(String content) {
-    // if (content == null || content.isBlank())
-    // return;
-
-    // // 아까 만든 전문 메서드들 호출 (재사용!)
-    // List<String> urls = extractUrlsFromHtml(content);
-
-    // for (String url : urls) {
-    // this.deleteFile(url); // 내부에서 extractKeyFromUrl 호출 후 S3 삭제
-    // }
-    // }
     @Override
-    public void deleteFile(String content) {
+    public void deleteFiles(String content) {
         if (content == null || content.isBlank())
             return;
 
-        // 정규식 메서드 재사용
-        List<String> urls = extractFileNamesFromContent(content);
+        // 1. 본문에서 URL 추출 및 S3 Key로 변환
+        List<String> keysToDelete = extractFileNamesFromContent(content).stream()
+                .map(this::extractKeyFromUrl)
+                .filter(Objects::nonNull)
+                .toList();
 
-        for (String url : urls) {
-            // (수정) this.deleteFile(url) 대신 전용 단일 삭제 메서드 호출
-            deleteSingleFileByUrl(url);
-        }
-    }
-
-    private void deleteSingleFileByUrl(String fileUrl) {
-        if (fileUrl == null || fileUrl.isEmpty())
-            return;
-        String urlKey = extractKeyFromUrl(fileUrl);
-        if (urlKey != null) {
-            s3FileHandler.deleteFile(urlKey);
+        // 2. 추출된 키가 있다면 다중 삭제 로직 하나로 처리
+        if (!keysToDelete.isEmpty()) {
+            s3FileHandler.deleteFiles(keysToDelete);
         }
     }
 
     @Override
-    public List<String> cleanUpOrphanFiles(List<String> allPostContents) {
+    public void cleanUpOrphanFiles(List<String> allPostContents) {
         Set<String> usedKeys = allPostContents.stream()
                 // (수정) extractKeyFromUrl 대신 정규식 추출 메서드 사용
                 .flatMap(content -> extractFileNamesFromContent(content).stream())
@@ -111,8 +82,6 @@ public class S3FileServiceImpl implements FileService {
         if (!orphanKeys.isEmpty()) {
             s3FileHandler.deleteFiles(orphanKeys);
         }
-
-        return orphanKeys;
     }
 
     private String extractKeyFromUrl(String fileUrl) {


### PR DESCRIPTION
## 개요
- S3 및 Local 단일 파일 삭제 메서드 제거
- List 기반의 다중 삭제(deleteFiles)로 인터페이스 통일
- LocalFileHandler의 리스트 인자 수용을 위한 로직 수정
## 변경사항
- **PostController**: `cleanUpOrphanFiles`메서드의 파일 삭제 로그 파트 **S3FileHandler**로 이전
- **FileService**:  로그 파트 이전으로 인해 불필요해진 `List<String>` 반환 타입 `void`로 변경
- **S3FileServiceImpl**, **S3FileHandler**: `deleteFile`메서드 삭제 후 `deleteFiles`메서드로 통합

- **LocalFileServiceImpl**, **LocalFileHandler**: 인터페이스의 `deleteFiles` 전달 인자가 이미지 이름을 전달하는 방식에서 `content`를 통째로 전달하는 방식으로 변하여 이에 따른 로직 수정
## 결과
- 불필요한 단일 삭제 메서드 삭제로 코드 경량화
- **LocalFileServiceImpl**, **LocalFileHandler** 로직 수정으로 인해 인터페이스 구조 일관성 복구
## 관련이슈
- closed #10 