### PR TITLE
[feature] 로컬 미참조 이미지 파일 삭제 로직 추가

### DIFF
--- a/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
@@ -11,7 +11,9 @@ import org.springframework.web.multipart.MultipartFile;
 import com.finance.finportfolio.infrastructure.file.FileService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class EditorImageController {

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +36,16 @@ public class PostService {
     private static final Safelist HTML_SAFE_LIST = Safelist.relaxed()
             .addAttributes("img", "style", "alt", "width", "height") // 이미지 관련 속성 허용
             .addTags("hr", "br"); // 가로줄, 줄바꿈 명시적 허용
+
+    // local에서 /images/ 감지 시 jsoup가 img srs를 살균해버리는 것 방지
+    private static final Safelist LOCAL_SAFE_LIST = Safelist.relaxed()
+            .addAttributes("img", "style", "alt", "width", "height")
+            .addTags("hr", "br")
+            .preserveRelativeLinks(true)
+            .addProtocols("img", "src", "http", "https", "/");
+
+    @Value("${spring.profiles.active:local}") // 기본값 local
+    private String activeProfile;
 
     // 의존성 주입
     private final PostRepository postRepository;
@@ -72,7 +83,14 @@ public class PostService {
     }
 
     private String cleanHtml(String text) {
-        return (text == null) ? "" : Jsoup.clean(text, HTML_SAFE_LIST);
+        if (text == null)
+            return "";
+
+        if ("local".equals(activeProfile)) {
+            return text;
+        }
+
+        return Jsoup.clean(text, HTML_SAFE_LIST);
     }
 
     private boolean checkImage(String htmlContent) {
@@ -135,8 +153,6 @@ public class PostService {
         // DB 게시글 삭제
         postRepository.delete(post);
     }
-
-    // HTML 문자열에서 파일명만 추출하는 메서드
 
     // 미참조 이미지 파일 삭제 - 버튼 식(차후 정기 실행으로 변경)
     @Transactional(readOnly = true)

--- a/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
+++ b/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
-@Profile("local")
 public class WebConfig implements WebMvcConfigurer {
 
     // 이미지 업로드 경로 주소 환경변수로 받아옴

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
@@ -12,4 +12,5 @@ public interface FileService {
     void deleteFiles(String content);
 
     void cleanUpOrphanFiles(List<String> allPostContents);
+
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileHandler.java
@@ -2,8 +2,12 @@ package com.finance.finportfolio.infrastructure.file;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -74,6 +78,28 @@ public class LocalFileHandler {
             } catch (Exception e) {
                 log.error("[LOCAL] 알 수 없는 삭제 에러: {}", e.getMessage());
             }
+        }
+    }
+
+    public List<String> getLocalFileNames() {
+        try {
+            Path uploadPath = Paths.get(getFullPath());
+
+            // 디렉토리가 없으면 빈 리스트 반환 (방어 코드)
+            if (!Files.exists(uploadPath)) {
+                return Collections.emptyList();
+            }
+
+            // Files.list는 Stream을 반환하며, 사용 후 닫아주는게 좋으므로 try-with-resources 사용
+            try (Stream<Path> stream = Files.list(uploadPath)) {
+                return stream
+                        .filter(Files::isRegularFile) // 디렉토리가 아닌 '파일'만 추출
+                        .map(path -> path.getFileName().toString()) // 파일명만 추출 (uuid.png)
+                        .toList();
+            }
+        } catch (IOException e) {
+            log.error("로컬 파일 목록 조회 중 오류 발생: {}", e.getMessage());
+            return Collections.emptyList();
         }
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
@@ -5,17 +5,22 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 // LocalFileServiceImpl - 파일 서비스 구현체 (docker 버전)
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Profile("local")
@@ -87,6 +92,26 @@ public class LocalFileServiceImpl implements FileService {
 
     @Override
     public void cleanUpOrphanFiles(List<String> allPostContents) {
-        // fileName을 List화 시키고 LocalFileHandler에 다중삭제 로직 추가 필요
+        Set<String> usedKeys = allPostContents.stream()
+                // (수정) extractKeyFromUrl 대신 정규식 추출 메서드 사용
+                .flatMap(content -> extractFileNamesFromContent(content).stream())
+                .map(path -> {
+                    if (path.startsWith("http")) {
+                        return path.substring(path.lastIndexOf("/") + 1);
+                    }
+                    return path; // 로컬은 이미 파일명임
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        List<String> s3Keys = localFileHandler.getLocalFileNames();
+
+        List<String> orphanKeys = s3Keys.stream()
+                .filter(key -> !usedKeys.contains(key))
+                .toList();
+
+        if (!orphanKeys.isEmpty()) {
+            localFileHandler.deleteFiles(orphanKeys);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # 파일 업로드 경로 설정(나중에 한번에 변경 가능)
 file.upload-dir=upload_images
+file.domain=http://localhost:8080
 
 # JPA 설정
 # spring.jpa.hibernate.ddl-auto=validate 배포 전 이걸로 변경

--- a/src/main/resources/templates/posts.html
+++ b/src/main/resources/templates/posts.html
@@ -17,7 +17,7 @@
         <a th:href="@{/posts/showLog}" class="btn btn-primary">로그 호출</a>
         <a th:href="@{/posts/editor}" class="btn btn-primary">글 쓰기</a>
         <form th:action="@{/posts/cleanup}" method="post" style="display:inline;">
-            <button type="submit" class="btn btn-primary">비참조 파일 삭제</button>
+            <button type="submit" class="btn btn-primary">미참조 파일 삭제</button>
         </form>
         <thead>
             <tr>


### PR DESCRIPTION
## 개요
- local환경에서 미참조 파일 삭제 로직 추가로 일관성 유지
- local환경에서 img src 저장 경로가 jsoup에 살균 당하는 문제 발견

## 변경사항
- **PostService**: `profile`이 "local"일 경우 `content`의  `Jsoup.clean()`을 생략
- **LocalFileServiceImpl**: 미참조 파일 삭제용  `cleanUpOrphanFiles` 메서드 로직 작성 
- **LocalFileHandler**: 로컬 디렉토리의 파일 리스트를 반환하는 `getLocalFileNames` 메서드 추가

## 결과
- local 환경에서의 미참조 파일 삭제 정상 작동 확인 및 img src 살균으로 인해 이미지가 보이지 않던 문제 해결

## 관련이슈
- #12