### PR TITLE
[Security] S3 prod 버킷 추가 및 CloudFront OAC 도입을 통한 인프라 격리 #36 # 37

### DIFF
--- a/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
@@ -30,14 +30,7 @@ public class EditorImageController {
 
             // 2. CKEditor 5 전용 성공 응답 규격
             response.put("uploaded", true);
-
-            if (savedFileName.startsWith("http")) {
-                // S3방식
-                response.put("url", savedFileName);
-            } else {
-                // local방식, WebConfig 리소스 매핑 주소
-                response.put("url", "/images/" + savedFileName);
-            }
+            response.put("url", savedFileName);
 
         } catch (Exception e) {
             // 3. 에러 발생 시 실패 응답 규격

--- a/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
@@ -30,7 +30,7 @@ public class PostResponseDto {
         this.id = post.getId();
         this.author = post.getAuthor();
         this.title = post.getTitle();
-        this.content = post.getContent();
+        this.content = processedContent;
         this.hasImage = post.isHasImage();
         this.createdAt = post.getCreatedAt();
     }

--- a/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
@@ -21,6 +21,15 @@ public class PostResponseDto {
         this.id = post.getId();
         this.author = post.getAuthor();
         this.title = post.getTitle();
+        this.content = null;
+        this.hasImage = post.isHasImage();
+        this.createdAt = post.getCreatedAt();
+    }
+
+    public PostResponseDto(Post post, String processedContent) {
+        this.id = post.getId();
+        this.author = post.getAuthor();
+        this.title = post.getTitle();
         this.content = post.getContent();
         this.hasImage = post.isHasImage();
         this.createdAt = post.getCreatedAt();

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -62,16 +62,18 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
 
-        return new PostResponseDto(post);
+        String processedContent = fileService.convertToCdnUrls(post.getContent());
+
+        return new PostResponseDto(post, processedContent);
     }
 
     // Jsoup 소독 메서드
     private String cleanText(String text) {
-        return (text == null) ? "" : Jsoup.clean(text, Safelist.none());
+        return (text == null || text.isEmpty()) ? "" : Jsoup.clean(text, Safelist.none());
     }
 
     private String cleanHtml(String text) {
-        if (text == null)
+        if (text == null || text.isEmpty())
             return "";
 
         if ("local".equals(activeProfile)) {

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
@@ -13,4 +13,5 @@ public interface FileService {
 
     void cleanUpOrphanFiles(List<String> allPostContents);
 
+    String convertToCdnUrls(String content);
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
@@ -50,7 +50,7 @@ public class LocalFileServiceImpl implements FileService {
 
         localFileHandler.uploadFile(file, savedFileName);
 
-        return savedFileName;
+        return "/images/" + savedFileName;
     }
 
     @Override
@@ -66,6 +66,11 @@ public class LocalFileServiceImpl implements FileService {
         if (!fileNameToDelete.isEmpty()) {
             localFileHandler.deleteFiles(fileNameToDelete);
         }
+    }
+
+    @Override
+    public String convertToCdnUrls(String content) {
+        return content;
     }
 
     // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -23,9 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class S3FileHandler {
 
     private final S3Template s3Template;
-
-    @Value("${spring.cloud.aws.s3.bucket}")
-    private String bucket;
+    private final S3Properties s3Properties;
 
     public String uploadFile(MultipartFile file, String savedFileName) {
         try {
@@ -36,15 +34,13 @@ public class S3FileHandler {
 
             // 2. 업로드 수행
             S3Resource resource = s3Template.upload(
-                    bucket,
+                    s3Properties.bucketName(),
                     savedFileName,
                     file.getInputStream(),
                     metadata // 람다 대신 객체를 직접 전달
             );
-
-            String uploadUrl = resource.getURL().toString();
-            log.info("S3 파일 업로드 성공: {}, URL: {}", savedFileName, uploadUrl);
-            return uploadUrl;
+            log.info("S3 파일 업로드 성공: {}", savedFileName);
+            return savedFileName;
 
         } catch (IOException e) {
             log.error("S3 파일 읽기 에러: {}", e.getMessage());
@@ -63,7 +59,7 @@ public class S3FileHandler {
 
         try {
             // S3Template은 리스트를 받아 일괄 삭제(Batch Delete)를 효율적으로 수행합니다.
-            urlKeys.forEach(key -> s3Template.deleteObject(bucket, key));
+            urlKeys.forEach(key -> s3Template.deleteObject(s3Properties.bucketName(), key));
             log.info("S3 객체 삭제 완료: {} 건", urlKeys.size());
 
         } catch (S3Exception e) {
@@ -71,10 +67,14 @@ public class S3FileHandler {
         }
     }
 
+    public String getCloudfrontDomain() {
+        return s3Properties.cloudfrontDomain();
+    }
+
     // S3버킷 모든 파일 키만 리스트로 반환
     public List<String> getS3ObjectKeys() {
         // listObjects가 훨씬 간결해졌으며, 스트림 처리에 최적화되어 있습니다.
-        return s3Template.listObjects(bucket, "")
+        return s3Template.listObjects(s3Properties.bucketName(), "")
                 .stream()
                 // S3Resource::getFilename은 String을 반환하므로 타입 추론이 명확해집니다.
                 .map(resource -> resource.getFilename())

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -12,6 +12,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,8 +48,9 @@ public class S3FileServiceImpl implements FileService {
 
     @Override
     public void deleteFiles(String content) {
-        if (content == null || content.isBlank())
+        if (content == null || content.isBlank()) {
             return;
+        }
 
         // 1. 본문에서 URL 추출 및 S3 Key로 변환
         List<String> keysToDelete = extractFileNamesFromContent(content).stream()
@@ -57,6 +62,35 @@ public class S3FileServiceImpl implements FileService {
         if (!keysToDelete.isEmpty()) {
             s3FileHandler.deleteFiles(keysToDelete);
         }
+    }
+
+    @Override
+    public String convertToCdnUrls(String content) {
+        if (content == null || content.isBlank()) {
+            return "";
+        }
+
+        // 1. HTML 파싱 (body 태그 내부 내용만 다룸)
+        Document doc = Jsoup.parseBodyFragment(content);
+
+        // 2. img 태그 중 src 속성이 있는 요소들을 선택
+        Elements imgs = doc.select("img[src]");
+
+        for (Element img : imgs) {
+            String src = img.attr("src");
+
+            // 3. 조건 검사: 이미 전체 경로(http)가 아니거나 로컬 경로가 아닌 경우 (순수 키값인 경우)
+            // DB에 uuid-name.png 형태로 저장되어 있다고 가정합니다.
+            if (!src.startsWith("http") && !src.startsWith("/")) {
+                // CloudFront 도메인을 붙여서 새로운 URL 생성
+                // s3Properties.getCloudfrontDomain() 부분은 실제 환경 변수나 설정값을 담은 필드로 대체하세요.
+                String cdnUrl = "https://" + s3FileHandler.getCloudfrontDomain() + "/" + src;
+                img.attr("src", cdnUrl);
+            }
+        }
+
+        // 4. 변환된 HTML의 body 내용물만 반환
+        return doc.body().html();
     }
 
     @Override

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -1,0 +1,11 @@
+package com.finance.finportfolio.infrastructure.file;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.NonNull;
+
+@ConfigurationProperties
+public record S3Properties(
+        @NonNull String bucketName,
+        @NonNull String cloudfrontDomain) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ spring:
         instance-profile: false
       s3:
         bucket: finportfolio-s3-bucket-dev-9806
+        # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
+        cloudfront-domain: d24842uv7pd3qd.cloudfront.net 
 ---
 spring:
   config:
@@ -80,3 +82,5 @@ spring:
         instance-profile: false
       s3:
         bucket: finportfolio-s3-bucket-prod-9806
+        # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
+        cloudfront-domain: d2m4qtzslhorm2.cloudfront.net


### PR DESCRIPTION
## 개요
- Block public access에서 url 직접 접근을 허용하는 보안 위협을 개선.
- Presigned URL을 이용한 1차 대응을 선행하려 했으나 **매번 서명을 생성해야 하는 오버헤드**와 **캐싱 효율 저하** 우려, 개발 효율성 등을 고려해본 결과 본 프로젝트에 다소 부적합하다고 판단하여 생략 후 곧바로 Cloudfront + OAC 방식을 도입.
- 산업 표준 **CloudFront + OAC**을 통해 S3 버킷을 완전 비공개로 전환하고, 인증된 CloudFront Edge를 통해서만 데이터에 접근할 수 있도록 물리적/논리적 격리를 수행.

## 작업 내용
#AWS
- **finportfolio-s3-bucket-dev-9806** Block all public access ON
- **finportfolio-cdn-dev** 생성 및 OAC 설정
- **finportfolio-s3-bucket-dev-9806** Bucket policy OAC 허용
- **finportfolio-s3-bucket-prod-9806** 버킷 추가
- **finportfolio-cdn-prod** 생성 및 OAC 설정
- **finportfolio-s3-bucket-prod-9806** Bucket policy OAC 허용
#Spring
- **application.yml**: `prod`와 `dev` profile에 각각 `cloudfront-domain` 추가
- **S3Properties**: `@NonNull`등의 강점을 활용하기 위하여 `@Value` 대신 `@ConfigurationProperties`을 통하여 s3 버킷 이름과 cloudfront 도메인 이름을 dto 형태로 수신.
- **PostResponseDto**: `processedContent`을 수신하는 생성자 오버로딩 추가(게시판/게시글 분리).
- **PostService**, **S3FileServiceImpl**: content 조회 시 CDN + 키 형태로 변환하는 로직 추가.
- **S3FileHandler**: `@Value` 대신 **S3Properties**을 통하여 환경변수 주입.

## 결과
- **비용 공격 방지**: CloudFront 엔드포인트만 허용하여 크롤링 등의 위험 방지.
- **비용 최적화**: CloudFront 엣지 캐싱을 통해 S3 직접 요청을 줄여 데이터 전송 비용 절감 및 성능 향상.
- **보안**: S3 원본 서버를 외부 인터넷으로부터 물리적으로 격리하여 보안 위협 차단.

## 관련 이슈
- Closed #36 
- Closed #37

<img width="165" height="48" alt="image" src="https://github.com/user-attachments/assets/df919fd0-bf0b-41d8-837e-3e45d39d2843" />
