### PR TITLE
[fix] S3Properties 빈 등록 누락

### DIFF
--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -1,9 +1,12 @@
 package com.finance.finportfolio.infrastructure.file;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
 import lombok.NonNull;
 
-@ConfigurationProperties
+@Configuration
+@ConfigurationProperties(prefix = "cloud.aws.s3")
 public record S3Properties(
         @NonNull String bucketName,
         @NonNull String cloudfrontDomain) {


### PR DESCRIPTION
- @Configuration을 누락하여 S3Properties가 빈으로 등록되지 않는 문제 해결.
- `(prefix = "cloud.aws.s3")`로 경로 지정.