### PR TITLE
[Fix] CI/CD 설정 수정 및 S3/CloudFront 이미지 처리 로직 최적화(+Trouble Shooting 과정)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,9 @@ name: Deploy with Docker
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: "main"
+  pull_request:
+    branches: develop
 
 jobs:
   build-and-deploy:

--- a/src/main/java/com/finance/finportfolio/PortfolioServerApplication.java
+++ b/src/main/java/com/finance/finportfolio/PortfolioServerApplication.java
@@ -4,6 +4,7 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 // JPA시간용
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -11,6 +12,7 @@ import jakarta.annotation.PostConstruct;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan("com.finance.finportfolio.infrastructure.file")
 public class PortfolioServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.finance.finportfolio.infrastructure.file.FileService;
+import com.finance.finportfolio.infrastructure.file.S3Properties;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class EditorImageController {
 
     private final FileService fileService;
+    private final S3Properties s3Properties;
 
     @PostMapping("/api/image/upload")
     public Map<String, Object> upload(@RequestParam("upload") MultipartFile file) {
@@ -28,17 +30,20 @@ public class EditorImageController {
             // 1. 파일을 저장하고 저장된 파일명을 받아옴
             String savedFileName = fileService.uploadFile(file);
 
+            String cdnUrl = String.format("https://%s/%s",
+                    s3Properties.cloudfrontDomain(),
+                    savedFileName);
+
             // 2. CKEditor 5 전용 성공 응답 규격
             response.put("uploaded", true);
-            response.put("url", savedFileName);
+            response.put("url", cdnUrl);
 
+            log.info("CKEditor image uploaded successfully: {}", savedFileName);
         } catch (Exception e) {
-            // 3. 에러 발생 시 실패 응답 규격
-            response.put("uploaded", false);
+            log.error("CKEditor image upload failed", e);
 
-            Map<String, String> errorDetail = new HashMap<>();
-            errorDetail.put("message", "이미지 업로드에 실패했습니다: " + e.getMessage());
-            response.put("error", errorDetail);
+            response.put("uploaded", false);
+            response.put("error", Map.of("message", "이미지 업로드 실패: " + e.getMessage()));
         }
 
         return response; // 맵 객체를 최종 반환 (JSON으로 자동 변환됨)

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -16,6 +16,7 @@ import com.finance.finportfolio.domain.post.dto.PostResponseDto;
 import com.finance.finportfolio.domain.post.dto.PostSaveRequestDto;
 import com.finance.finportfolio.domain.post.dto.PostUpdateRequestDto;
 import com.finance.finportfolio.infrastructure.file.FileService;
+import com.finance.finportfolio.infrastructure.file.S3FileServiceImpl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -101,7 +102,8 @@ public class PostService {
      */
     @Transactional
     public Long savePost(PostSaveRequestDto requestDto) {
-        String cleanedContent = cleanHtml(requestDto.content());
+        // jsoup 살균과 Cdn삭제(키 추출) 동시에
+        String cleanedContent = cleanHtml(fileService.removeCdnUrls(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
 
         Post post = Post.builder()
@@ -120,7 +122,8 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
 
-        String cleanedContent = cleanHtml(requestDto.content());
+        // jsoup 살균과 Cdn삭제(키 추출) 동시에
+        String cleanedContent = cleanHtml(fileService.removeCdnUrls(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
 
         post.update(cleanText(requestDto.title()), cleanedContent, hasImage);

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -137,7 +137,7 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("삭제하려는 게시글이 존재하지 않습니다. id=" + id));
 
-        log.info("파일 삭제 요청 id: {}", id);
+        log.info("게시글 삭제 요청 id: {}", id);
         // S3 이미지 삭제
         fileService.deleteFiles(post.getContent());
 

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -103,7 +103,7 @@ public class PostService {
     @Transactional
     public Long savePost(PostSaveRequestDto requestDto) {
         // jsoup 살균과 Cdn삭제(키 추출) 동시에
-        String cleanedContent = cleanHtml(fileService.removeCdnUrls(requestDto.content()));
+        String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
 
         Post post = Post.builder()
@@ -123,7 +123,7 @@ public class PostService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
 
         // jsoup 살균과 Cdn삭제(키 추출) 동시에
-        String cleanedContent = cleanHtml(fileService.removeCdnUrls(requestDto.content()));
+        String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
 
         post.update(cleanText(requestDto.title()), cleanedContent, hasImage);

--- a/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -62,6 +62,7 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
 
+        log.info("게시글 불러오기, content: {}", post.getContent());
         String processedContent = fileService.convertToCdnUrls(post.getContent());
 
         return new PostResponseDto(post, processedContent);

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/FileService.java
@@ -14,4 +14,6 @@ public interface FileService {
     void cleanUpOrphanFiles(List<String> allPostContents);
 
     String convertToCdnUrls(String content);
+
+    String removeCdnUrls(String content);
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/LocalFileServiceImpl.java
@@ -73,6 +73,11 @@ public class LocalFileServiceImpl implements FileService {
         return content;
     }
 
+    @Override
+    public String removeCdnUrls(String content) {
+        return content;
+    }
+
     // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직
     private List<String> extractFileNamesFromContent(String content) {
         List<String> fileNames = new ArrayList<>();

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -30,16 +30,19 @@ public class S3FileHandler {
             // 1. 메타데이터 객체 생성 및 설정 (빌더 패턴 활용)
             ObjectMetadata metadata = ObjectMetadata.builder()
                     .contentType(file.getContentType())
+                    .contentLength(file.getSize())
                     .build();
 
             // 2. 업로드 수행
-            S3Resource resource = s3Template.upload(
+            s3Template.upload(
                     s3Properties.bucketName(),
                     savedFileName,
                     file.getInputStream(),
                     metadata // 람다 대신 객체를 직접 전달
             );
+
             log.info("S3 파일 업로드 성공: {}", savedFileName);
+
             return savedFileName;
 
         } catch (IOException e) {
@@ -52,18 +55,25 @@ public class S3FileHandler {
     }
 
     // 다중 삭제
-    public void deleteFiles(List<String> urlKeys) {
-        if (urlKeys == null || urlKeys.isEmpty()) {
+    public void deleteFiles(List<String> keys) {
+        if (keys == null || keys.isEmpty()) {
             return;
         }
 
         try {
-            // S3Template은 리스트를 받아 일괄 삭제(Batch Delete)를 효율적으로 수행합니다.
-            urlKeys.forEach(key -> s3Template.deleteObject(s3Properties.bucketName(), key));
-            log.info("S3 객체 삭제 완료: {} 건", urlKeys.size());
+            // S3Template은 리스트를 받아 반복 삭제.(S3Client Batch 방식으로 다중 삭제 refactor 가능!)
+            keys.forEach(key -> {
+                try {
+                    s3Template.deleteObject(s3Properties.bucketName(), key);
+                    log.debug("S3 객체 삭제 시도: {}", key);
+                } catch (Exception e) {
+                    log.error("S3 개별 객체 삭제 실패 [key: {}]: {}", key, e.getMessage());
+                }
+            });
 
+            log.info("S3 객체 삭제 완료: {} 건", keys.size());
         } catch (S3Exception e) {
-            log.error("S3 삭제 중 에러 발생: {}", e.awsErrorDetails().errorMessage());
+            log.error("S3 삭제 중 중대한 에러 발생: {}", e.awsErrorDetails().errorMessage());
         }
     }
 
@@ -73,13 +83,9 @@ public class S3FileHandler {
 
     // S3버킷 모든 파일 키만 리스트로 반환
     public List<String> getS3ObjectKeys() {
-        // listObjects가 훨씬 간결해졌으며, 스트림 처리에 최적화되어 있습니다.
         return s3Template.listObjects(s3Properties.bucketName(), "")
                 .stream()
-                // S3Resource::getFilename은 String을 반환하므로 타입 추론이 명확해집니다.
-                .map(resource -> {
-                    return resource.getLocation().getObject();
-                })
+                .map(resource -> resource.getLocation().getObject())
                 .filter(filename -> filename != null && !filename.isEmpty())
                 .toList();
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -77,7 +77,9 @@ public class S3FileHandler {
         return s3Template.listObjects(s3Properties.bucketName(), "")
                 .stream()
                 // S3Resource::getFilename은 String을 반환하므로 타입 추론이 명확해집니다.
-                .map(resource -> resource.getFilename())
+                .map(resource -> {
+                    return resource.getLocation().getObject();
+                })
                 .filter(filename -> filename != null && !filename.isEmpty())
                 .toList();
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -69,7 +69,7 @@ public class S3FileServiceImpl implements FileService {
         if (content == null || content.isBlank()) {
             return "";
         }
-        log.info(content);
+        log.info("작동확인1: {}", content);
 
         // 1. HTML 파싱 (body 태그 내부 내용만 다룸)
         Document doc = Jsoup.parseBodyFragment(content);
@@ -89,7 +89,7 @@ public class S3FileServiceImpl implements FileService {
                 img.attr("src", cdnUrl);
             }
         }
-        log.info(doc.body().html());
+        log.info("작동확인2: {}", doc.body().html());
 
         // 4. 변환된 HTML의 body 내용물만 반환
         return doc.body().html();

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -119,17 +119,15 @@ public class S3FileServiceImpl implements FileService {
                 return fileUrl;
             }
 
-            String path;
+            String key;
             if (fileUrl.startsWith("http")) {
-                // URL 형태인 경우 (https://domain/key)
-                path = fileUrl.substring(fileUrl.indexOf("/", fileUrl.indexOf("//") + 2));
+                key = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+            } else if (fileUrl.startsWith("/")) {
+                key = fileUrl.substring(1);
             } else {
-                // 절대 경로 형태인 경우 (/key)
-                path = fileUrl;
+                key = fileUrl;
             }
 
-            // 첫 슬래시(/) 제거, 디코딩
-            String key = path.startsWith("/") ? path.substring(1) : path;
             return URLDecoder.decode(key, StandardCharsets.UTF_8);
         } catch (Exception e) {
             log.error("Url 추출 실패: {} | error: {}", fileUrl, e.getMessage());

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.safety.Safelist;
 import org.jsoup.select.Elements;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -69,39 +70,74 @@ public class S3FileServiceImpl implements FileService {
         if (content == null || content.isBlank()) {
             return "";
         }
-        log.info("작동확인1: {}", content);
 
-        // 1. HTML 파싱 (body 태그 내부 내용만 다룸)
         Document doc = Jsoup.parseBodyFragment(content);
-
-        // 2. img 태그 중 src 속성이 있는 요소들을 선택
         Elements imgs = doc.select("img[src]");
 
         for (Element img : imgs) {
             String src = img.attr("src");
 
-            // 3. 조건 검사: 이미 전체 경로(http)가 아니거나 로컬 경로가 아닌 경우 (순수 키값인 경우)
-            // DB에 uuid-name.png 형태로 저장되어 있다고 가정합니다.
             if (!src.startsWith("http") && !src.startsWith("/")) {
-                // CloudFront 도메인을 붙여서 새로운 URL 생성
-                // s3Properties.getCloudfrontDomain() 부분은 실제 환경 변수나 설정값을 담은 필드로 대체하세요.
                 String cdnUrl = "https://" + s3FileHandler.getCloudfrontDomain() + "/" + src;
                 img.attr("src", cdnUrl);
             }
         }
-        log.info("작동확인2: {}", doc.body().html());
-
-        // 4. 변환된 HTML의 body 내용물만 반환
         return doc.body().html();
     }
 
+    // content에 섞여있는 img[src]들 CDN url에서 키 값으로 변경
+    @Override
+    public String removeCdnUrls(String content) {
+        if (content == null || content.isBlank()) {
+            return "";
+        }
+
+        Document doc = Jsoup.parseBodyFragment(content);
+        Elements imgs = doc.select("img[src]");
+
+        for (Element img : imgs) {
+            String src = img.attr("src");
+            String pureKey = extractKeyFromUrl(src);
+            if (pureKey != null) {
+                img.attr("src", pureKey);
+            }
+        }
+
+        return doc.body().html();
+    }
+
+    // http:, CDN url 등 경로 쳐내고 키 값 추출
+    private String extractKeyFromUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return null;
+        }
+
+        try {
+            // 이미 키(파일명)만 들어온 경우 처리
+            if (!fileUrl.contains("/")) {
+                return fileUrl;
+            }
+
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath();
+
+            if (path == null || path.length() <= 1) {
+                return null;
+            }
+
+            // 첫 슬래시(/) 제거 및 디코딩
+            return URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.error("Url 추출 실패: {}", fileUrl);
+            return null;
+        }
+    }
+
+    // 미참조 파일 삭제
     @Override
     public void cleanUpOrphanFiles(List<String> allPostContents) {
         Set<String> usedKeys = allPostContents.stream()
-                // (수정) extractKeyFromUrl 대신 정규식 추출 메서드 사용
                 .flatMap(content -> extractFileNamesFromContent(content).stream())
-                .map(this::extractKeyFromUrl)
-                .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
         List<String> s3Keys = s3FileHandler.getS3ObjectKeys();
@@ -111,53 +147,30 @@ public class S3FileServiceImpl implements FileService {
                 .toList();
 
         if (!orphanKeys.isEmpty()) {
+            log.info("미참조 파일 삭제 실행: {} 건", orphanKeys.size());
             s3FileHandler.deleteFiles(orphanKeys);
-        }
-    }
-
-    private String extractKeyFromUrl(String fileUrl) {
-        try {
-            // 이미 키(파일명)만 들어온 경우 처리
-            if (!fileUrl.contains("/"))
-                return fileUrl;
-
-            URI uri = new URI(fileUrl);
-            String path = uri.getPath();
-            if (path == null || path.length() <= 1)
-                return null;
-
-            // 첫 슬래시(/) 제거 및 디코딩
-            return URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            log.error("잘못된 URL 형식: {}", fileUrl);
-            return null;
         }
     }
 
     // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직
     private List<String> extractFileNamesFromContent(String content) {
         List<String> imageKeys = new ArrayList<>();
-        if (content == null || content.isBlank())
+
+        if (content == null || content.isBlank()) {
             return imageKeys;
+        }
 
-        String domain = s3FileHandler.getCloudfrontDomain();
-
-        // 1. CDN URL 형태도 찾고 (이미 변환된 경우 대비)
-        String cdnPattern = "(?:https?://" + Pattern.quote(domain) + "/)([^\"'>\\s]+)";
-        // 2. 순수 파일명 형태도 찾음 (DB 저장 형태) - UUID 특성상 하이픈(-)과 확장자 체크
+        // DB에는 도메인이 제거된 상태로 저장되므로, 순수 키 패턴(UUID 시작)만 찾아냄.
+        // [a-f0-9\\-]{36} -> UUID 형태, 그 뒤에 파일명과 확장자
         String pureKeyPattern = "([a-f0-9\\-]{36}-[^\"'>\\s]+)";
 
-        // 두 패턴을 모두 합쳐서 찾기
-        String combinedRegex = cdnPattern + "|" + pureKeyPattern;
-        Pattern pattern = Pattern.compile(combinedRegex);
+        Pattern pattern = Pattern.compile(pureKeyPattern);
         Matcher matcher = pattern.matcher(content);
 
         while (matcher.find()) {
-            // matcher.group(1)은 CDN 패턴에서 찾은 키, matcher.group(2)는 순수 키 패턴
-            String key = (matcher.group(1) != null) ? matcher.group(1) : matcher.group(2);
-            if (key != null) {
-                imageKeys.add(URLDecoder.decode(key, StandardCharsets.UTF_8));
-            }
+            // 정규식 그룹 1번 자체가 이미 순수 키값입니다.
+            String key = matcher.group(1);
+            imageKeys.add(URLDecoder.decode(key, StandardCharsets.UTF_8));
         }
         return imageKeys;
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -102,6 +102,7 @@ public class S3FileServiceImpl implements FileService {
                 img.attr("src", pureKey);
             }
         }
+        log.info("살균된 content: {}", doc.body().html());
 
         return doc.body().html();
     }
@@ -118,17 +119,20 @@ public class S3FileServiceImpl implements FileService {
                 return fileUrl;
             }
 
-            URI uri = new URI(fileUrl);
-            String path = uri.getPath();
-
-            if (path == null || path.length() <= 1) {
-                return null;
+            String path;
+            if (fileUrl.startsWith("http")) {
+                // URL 형태인 경우 (https://domain/key)
+                path = fileUrl.substring(fileUrl.indexOf("/", fileUrl.indexOf("//") + 2));
+            } else {
+                // 절대 경로 형태인 경우 (/key)
+                path = fileUrl;
             }
 
-            // 첫 슬래시(/) 제거 및 디코딩
-            return URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
+            // 첫 슬래시(/) 제거, 디코딩
+            String key = path.startsWith("/") ? path.substring(1) : path;
+            return URLDecoder.decode(key, StandardCharsets.UTF_8);
         } catch (Exception e) {
-            log.error("Url 추출 실패: {}", fileUrl);
+            log.error("Url 추출 실패: {} | error: {}", fileUrl, e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -136,23 +136,19 @@ public class S3FileServiceImpl implements FileService {
 
     // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직
     private List<String> extractFileNamesFromContent(String content) {
-        List<String> fileNames = new ArrayList<>();
+        List<String> imageKeys = new ArrayList<>();
         if (content == null || content.isBlank())
-            return fileNames;
+            return imageKeys;
 
-        Pattern pattern = Pattern.compile(
-                "/images/([^\"'>\\s]+)|(https://[a-zA-Z0-9.-]+\\.s3\\.[a-zA-Z0-9-]+\\.amazonaws\\.com/[^\"'>\\s]+)");
+        String domain = s3FileHandler.getCloudfrontDomain();
+        String regex = "(?:https?://" + domain + "/)([^\"'>\\s]+)";
+
+        Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(content);
 
         while (matcher.find()) {
-            String localFileName = matcher.group(1);
-            String s3FullUrl = matcher.group(2);
-
-            if (localFileName != null)
-                fileNames.add(localFileName);
-            else if (s3FullUrl != null)
-                fileNames.add(s3FullUrl);
+            imageKeys.add(matcher.group(1));
         }
-        return fileNames;
+        return imageKeys;
     }
 }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -141,13 +141,23 @@ public class S3FileServiceImpl implements FileService {
             return imageKeys;
 
         String domain = s3FileHandler.getCloudfrontDomain();
-        String regex = "(?:https?://" + domain + "/)([^\"'>\\s]+)";
 
-        Pattern pattern = Pattern.compile(regex);
+        // 1. CDN URL 형태도 찾고 (이미 변환된 경우 대비)
+        String cdnPattern = "(?:https?://" + Pattern.quote(domain) + "/)([^\"'>\\s]+)";
+        // 2. 순수 파일명 형태도 찾음 (DB 저장 형태) - UUID 특성상 하이픈(-)과 확장자 체크
+        String pureKeyPattern = "([a-f0-9\\-]{36}-[^\"'>\\s]+)";
+
+        // 두 패턴을 모두 합쳐서 찾기
+        String combinedRegex = cdnPattern + "|" + pureKeyPattern;
+        Pattern pattern = Pattern.compile(combinedRegex);
         Matcher matcher = pattern.matcher(content);
 
         while (matcher.find()) {
-            imageKeys.add(matcher.group(1));
+            // matcher.group(1)은 CDN 패턴에서 찾은 키, matcher.group(2)는 순수 키 패턴
+            String key = (matcher.group(1) != null) ? matcher.group(1) : matcher.group(2);
+            if (key != null) {
+                imageKeys.add(URLDecoder.decode(key, StandardCharsets.UTF_8));
+            }
         }
         return imageKeys;
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -69,6 +69,7 @@ public class S3FileServiceImpl implements FileService {
         if (content == null || content.isBlank()) {
             return "";
         }
+        log.info(content);
 
         // 1. HTML 파싱 (body 태그 내부 내용만 다룸)
         Document doc = Jsoup.parseBodyFragment(content);
@@ -88,6 +89,7 @@ public class S3FileServiceImpl implements FileService {
                 img.attr("src", cdnUrl);
             }
         }
+        log.info(doc.body().html());
 
         // 4. 변환된 HTML의 body 내용물만 반환
         return doc.body().html();

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -44,7 +44,8 @@ public class S3FileServiceImpl implements FileService {
     }
 
     private String createFileName(String originalFileName) {
-        return UUID.randomUUID() + "-" + originalFileName;
+        String safeName = originalFileName.replaceAll("\\s", "_");
+        return UUID.randomUUID() + "-" + safeName;
     }
 
     @Override
@@ -164,7 +165,7 @@ public class S3FileServiceImpl implements FileService {
 
         // DB에는 도메인이 제거된 상태로 저장되므로, 순수 키 패턴(UUID 시작)만 찾아냄.
         // [a-f0-9\\-]{36} -> UUID 형태, 그 뒤에 파일명과 확장자
-        String pureKeyPattern = "([a-f0-9\\-]{36}-[^\"'>\\s]+)";
+        String pureKeyPattern = "([a-f0-9\\-]{36}-[^\"'>]+)";
 
         Pattern pattern = Pattern.compile(pureKeyPattern);
         Matcher matcher = pattern.matcher(content);
@@ -172,7 +173,7 @@ public class S3FileServiceImpl implements FileService {
         while (matcher.find()) {
             // 정규식 그룹 1번 자체가 이미 순수 키값입니다.
             String key = matcher.group(1);
-            imageKeys.add(URLDecoder.decode(key, StandardCharsets.UTF_8));
+            imageKeys.add(URLDecoder.decode(key.trim(), StandardCharsets.UTF_8));
         }
         return imageKeys;
     }

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -1,9 +1,6 @@
 package com.finance.finportfolio.infrastructure.file;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-
 import lombok.NonNull;
 
 @ConfigurationProperties(prefix = "spring.cloud.aws.s3")

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Profile;
 
 import lombok.NonNull;
 
-@ConfigurationProperties(prefix = "cloud.aws.s3")
+@ConfigurationProperties(prefix = "spring.cloud.aws.s3")
 public record S3Properties(
         @NonNull String bucketName,
         @NonNull String cloudfrontDomain) {

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Profile;
 
 import lombok.NonNull;
 
-@Profile("dev")
 @ConfigurationProperties(prefix = "cloud.aws.s3")
 public record S3Properties(
         @NonNull String bucketName,

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 
 import lombok.NonNull;
 
-@Configuration
 @ConfigurationProperties(prefix = "cloud.aws.s3")
 public record S3Properties(
         @NonNull String bucketName,

--- a/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
+++ b/src/main/java/com/finance/finportfolio/infrastructure/file/S3Properties.java
@@ -2,9 +2,11 @@ package com.finance.finportfolio.infrastructure.file;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import lombok.NonNull;
 
+@Profile("dev")
 @ConfigurationProperties(prefix = "cloud.aws.s3")
 public record S3Properties(
         @NonNull String bucketName,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,6 @@ spring:
         instance-profile: false
       s3:
         bucket-name: finportfolio-s3-bucket-dev-9806
-        # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
         cloudfront-domain: d24842uv7pd3qd.cloudfront.net 
 
 file:
@@ -68,8 +67,7 @@ spring:
         instance-profile: false
       s3:
         bucket-name: finportfolio-s3-bucket-dev-9806
-        # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
-        cloudfront-domain: d24842uv7pd3qd.cloudfront.net 
+        cloudfront-domain: d24842uv7pd3qd.cloudfront.net
 ---
 spring:
   config:
@@ -92,5 +90,4 @@ spring:
         instance-profile: false
       s3:
         bucket-name: finportfolio-s3-bucket-prod-9806
-        # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
         cloudfront-domain: d2m4qtzslhorm2.cloudfront.net

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,16 @@ spring:
     username: root
     password: password
 
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+        instance-profile: false
+      s3:
+        bucket-name: finportfolio-s3-bucket-dev-9806
+        # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
+        cloudfront-domain: d24842uv7pd3qd.cloudfront.net 
+
 file:
   upload-dir: upload_images
   domain: http://localhost:8080
@@ -57,7 +67,7 @@ spring:
         static: ap-northeast-2
         instance-profile: false
       s3:
-        bucket: finportfolio-s3-bucket-dev-9806
+        bucket-name: finportfolio-s3-bucket-dev-9806
         # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
         cloudfront-domain: d24842uv7pd3qd.cloudfront.net 
 ---
@@ -81,6 +91,6 @@ spring:
         static: ap-northeast-2
         instance-profile: false
       s3:
-        bucket: finportfolio-s3-bucket-prod-9806
+        bucket-name: finportfolio-s3-bucket-prod-9806
         # 하드코딩, 차후 aws secrets에서 환경변수로 받아오도록 변경
         cloudfront-domain: d2m4qtzslhorm2.cloudfront.net


### PR DESCRIPTION
## 개요
- 최초 Cloudfront 전환에 따른 **deploy.yml** 수정 및 **S3Properties** 빈 등록 이슈 해결을 목표.
- 작업 중 이미지 파일의 호출(CDN 전환) 및 삭제(S3 동기화) 로직이 오작동하는 결함 발견.
- 해당 결함을 해결하기 위하여 인프라 설정부터 비즈니스 로직까지
과도하게 많은 commit이 발생하여 아래와 같이 정리함.

## Trouble Shooting
- **deploy.yml**: main은 직접 푸시 혹은 머지에만, develop 브랜치는 PR시 Github Actions 동작하도록 수정.
- **S3Properties**: 상속하지 못하는 `final` 클래스인 `record`와 `@Configuration` 충돌하는 문제 발생.
- **PortfolioServerApplication**: `@ConfigurationPropertiesScan`을 통해 `com.finance.finportfolio.infrastructure.file` 패키지 내의 `@ConfigurationProperties` 클래스를 빈으로 등록.
- **application.yml**의 `s3.bucket`을 **S3Properties**의 `bucketName` 인식하지 못하는 문제: `s3.bucket-name`으로 수정
- **S3Properties**의 `@ConfigurationProperties(prefix = "cloud.aws.s3")`을 인식하지 못하는 문제: `"spring.cloud.aws.s3"`으로 수정
- Cloudfront의 `domain name` 처리를 제대로 하지 못해 이미지가 보이지 않는 문제: DB와 S3버킷에 저장되기 직전에 `removeCdnUrls` 메서드로 CDN 살균, ckEditor호출과 게시글 호출로 이미지가 호출되기 직전에 convertToCdnUrls로 CDN url화로 오류 수정.
- 게시글 삭제(단일)이 버킷의 오브젝트를 제대로 삭제하지 못하고 미참조 파일 삭제 버튼이 버킷의 모든 오브젝트를 삭제하는 문제: **S3FileServiceImpl**, **S3FileHandler**, **PostService**, **EditorImageController** 로직 전면 수정,
주된 문제는 **문자열의 공백**과 **S3FileServiceImpl**의 `extract` 메서드들.

## 결과
- develop로 브랜치 PR 시 GitHub Actions를 통한 컨테이너 자동 배포 환경 정상화.
- **S3Properties**의 타입 안정성 및 빈 등록 문제 완결.
- 이미지 업로드 시 공백 치환 및 정규식 개선을 통해, 게시글 삭제 및 미참조 파일 삭제 로직이 S3 버킷과 정상적으로 동기화됨을 확인.