### PR TITLE
[Refactor] 백엔드 파트 CSR 전환 #34

### DIFF
--- a/src/main/java/com/finance/finportfolio/domain/post/controller/PostControllerCSR.java
+++ b/src/main/java/com/finance/finportfolio/domain/post/controller/PostControllerCSR.java
@@ -1,0 +1,79 @@
+package com.finance.finportfolio.domain.post.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.finance.finportfolio.domain.post.dto.PostResponseDto;
+import com.finance.finportfolio.domain.post.dto.PostSaveRequestDto;
+import com.finance.finportfolio.domain.post.dto.PostUpdateRequestDto;
+import com.finance.finportfolio.domain.post.service.PostService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class PostControllerCSR {
+
+    private final PostService postService;
+
+    @GetMapping // posts 엔드포인트 접근 시 기본 GET
+    public ResponseEntity<List<PostResponseDto>> getAllPosts() {
+        List<PostResponseDto> posts = postService.getAllPosts();
+        log.info("게시글 목록 조회 - 개수: {}", posts.size());
+        return ResponseEntity.ok(posts); // JSON으로 반환
+    }
+
+    @GetMapping("/{id}") // post detail, editor 페이지에서 조회
+    public ResponseEntity<PostResponseDto> getPostById(@PathVariable("id") Long id) {
+        PostResponseDto post = postService.getPostById(id);
+        log.info("게시글 상세 조회 - ID: {}, 제목: {}", id, post.getTitle());
+        return ResponseEntity.ok(post);
+    }
+
+    @PostMapping // 새 post - portfolio_db에 저장
+    public ResponseEntity<Long> createPost(@RequestBody PostSaveRequestDto requestDto) {
+        log.info("게시글 저장 시도 - 제목: {}", requestDto.title());
+        Long postId = postService.savePost(requestDto);
+        return ResponseEntity.status(201).body(postId);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Long> updatePost(@PathVariable("id") Long id, @RequestBody PostUpdateRequestDto requestDto) {
+        log.info("게시글 수정 시도 - ID: {}, 제목: {}", id, requestDto.title());
+        postService.updatePost(id, requestDto);
+        return ResponseEntity.ok(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Long> deletePost(@PathVariable("id") Long id) {
+        log.info("게시글 삭제 시도 - ID: {}", id);
+        postService.deletePost(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/cleanup")
+    public ResponseEntity<Void> cleanUpOrphanFiles() {
+        log.info("미참조 이미지 정리 시작");
+        postService.cleanUpOrphanFiles();
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/showLog")
+    public ResponseEntity<Void> showLog() {
+        log.info("서버에서 응답!");
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
+++ b/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.finance.finportfolio.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.HiddenHttpMethodFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -10,9 +11,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**") // API 경로에 대해 CORS 적용
+                .allowedOrigins("http://localhost:3000") // React 개발 서버 허용
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+                .allowedHeaders("*") // 모든 헤더 허용
+                .allowCredentials(true) // 쿠키/인증 정보 포함 허용
+                .maxAge(3600); // 프리플라이트(Preflight) 요청 캐싱 시간 (초)
+    }
 
-    // http에서 보내는 delete, put, patch 메서드를 쓸 수 있게(원래 post, get만 사용 가능)
-    @Bean
+    @Bean // http에서 delete, put, patch 메서드를 사용 가능
     public HiddenHttpMethodFilter hiddenHttpMethodFilter() {
         return new HiddenHttpMethodFilter();
     }


### PR DESCRIPTION
## 개요
백엔드 파트 SSR 방식에서 CSR 구조로 재설계.

## 작업내용
- **PostController**: @Controller를 @RestController로 전환하여 뷰(View) 이름 대신 `ResponseEntity`에 담긴 JSON 반환으로 리팩토링.
  - 모델 기반에서 DTO 기반으로 리팩토링
  - CSR에서 불필요한 화면 전환 GET 요청 삭제
- **WebConfig**: react와 통신하기 위한 CORS 매핑 `http://localhost:3000`.

## 결과
- 프론트(React)와 Controller 간 데이터 통신 방식 재설계.
- 프론트 접근을 허가하기 위한 CORS 설정 완료.

## 관련이슈
- #34 