### PR TITLE
[Infra] Route53 도메인 등록, ACM 인증서 등록, Cloudfront 프론트/백 통합 관리 및 헤더 로직 추가

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -89,6 +89,7 @@ jobs:
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
           echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .env
           echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
+          echo "CF_SECRET_KEY=${{ secrets.CF_SECRET_KEY }}" >> .env
           
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
           docker-compose pull

--- a/finance-portfolio-backend/nginx/conf.d/default.conf
+++ b/finance-portfolio-backend/nginx/conf.d/default.conf
@@ -1,0 +1,25 @@
+# nginx/conf.d/default.conf
+
+# server {
+#     listen 80;
+#     server_name your-domain.com; # 실제 도메인이 없다면 공인 IP 작성
+
+#     # 1. HTTP 요청을 HTTPS로 강제 리다이렉트 (SSL 적용 후 활성화)
+#     # return 301 https://$host$request_uri;
+
+#     # 2. 백엔드 API 프록시 설정
+#     location /api/ {
+#         proxy_pass http://finance-portfolio-backend:8080; # Docker 서비스 이름 사용
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+
+#     # 3. 프론트엔드 정적 파일 서빙 (React 빌드 파일)
+#     location / {
+#         root /usr/share/nginx/html;
+#         index index.html index.htm;
+#         try_files $uri $uri/ /index.html; # React Router 지원
+#     }
+# }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/FilterConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/FilterConfig.java
@@ -1,0 +1,32 @@
+package com.finance.finportfolio.global.config;
+
+import com.finance.finportfolio.global.filter.CloudFrontHeaderFilter;
+import org.springframework.beans.factory.annotation.Value; // import 추가
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class FilterConfig {
+
+    @Value("${cloudfront.custom.header.name}")
+    private String cfHeaderName;
+
+    @Value("${cloudfront.custom.header.value}")
+    private String cfHeaderValue;
+
+    @Bean
+    @Profile({ "dev", "prod" })
+    public FilterRegistrationBean<CloudFrontHeaderFilter> cloudFrontHeaderFilterRegistration() {
+        // 필터를 여기서 직접 생성 (빈 주입을 기다리지 않음)
+        CloudFrontHeaderFilter filter = new CloudFrontHeaderFilter(cfHeaderName, cfHeaderValue);
+
+        FilterRegistrationBean<CloudFrontHeaderFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(filter);
+        registrationBean.addUrlPatterns("/api/*");
+        registrationBean.setOrder(1);
+
+        return registrationBean;
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
@@ -15,8 +15,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**") // API 경로에 대해 CORS 적용
                 .allowedOrigins("http://localhost:3000",
+                        "https://www.ljh-finance.com",
+                        "https://dev.ljh-finance.com",
                         "https://dh90dx2d0udap.cloudfront.net",
-                        "https://d1wcpvhjz8ef5p.cloudfront.net") // React 개발 서버 허용
+                        "https://d1wcpvhjz8ef5p.cloudfront.net") // React
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
                 .allowedHeaders("*") // 모든 헤더 허용
                 .allowCredentials(true) // 쿠키/인증 정보 포함 허용

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/filter/CloudFrontHeaderFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/filter/CloudFrontHeaderFilter.java
@@ -1,0 +1,52 @@
+package com.finance.finportfolio.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+
+// Component에 등록하면 호출과 무관하게 헤더 검증 로직이 작동하는 문제가 있음!: @Value 사용 불가
+public class CloudFrontHeaderFilter extends OncePerRequestFilter {
+
+    private final String cfHeaderName;
+    private final String cfHeaderValue;
+
+    // 생성자를 통해 값을 직접 주입받음
+    public CloudFrontHeaderFilter(String name, String value) {
+        this.cfHeaderName = name;
+        this.cfHeaderValue = value;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. OPTIONS 요청(CORS) 무조건 통과
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2. Health Check 예외 처리
+        if ("/api/health".equals(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 3. 헤더 검증
+        String headerValue = request.getHeader(cfHeaderName);
+
+        if (headerValue == null || !headerValue.equals(cfHeaderValue)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(
+                    "{\"status\": 403, \"message\": \"Direct access is not allowed. Please access through CloudFront.\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -23,6 +23,12 @@ spring:
       region:
         static: ap-northeast-2
         instance-profile: false
+
+cloudfront:
+  custom:
+    header:
+      name: X-Custom-Access-Key
+      value: ${CF_SECRET_KEY:default-local-key}
 ---
 spring:
   config:


### PR DESCRIPTION
## 개요
- **현황**: Mixed Content 에러를 해결하기 위해 1차 적으로 SSL 인증서를 서버 내부에 직접 설치하는 방식을 선택했으나. #46
- 다음과 같은 사유로 인해 해결방안을 변경하였습니다. 
  - **보안**: 서버 내부에 인증서를 보관하는 방식 - 탈취 위험.
  - **성능**: 서버에서 인증서 암,복호화 연산 처리 - CPU 리소스 증가.
  - **관리**:  90일 주기 자동 갱신 스크립트 관리 필요 - 운영 환경 불안정.
- **최종 해결방안**:  프론트엔드, 백엔드 CloudFront 통합 관리 + 헤더 추가.
  - **CORS 에러 처리**: 통합 관리로 인해 동일한 도메인을 사용하여 CORS 에러 처리.
  - **Mixed Content 에러 처리**: 프론트(https)는 백엔드의 Cloudfront(https)와 통신.
  - **HTTP 노출 방지**:  Cloudfront에 커스텀 헤더를 추가하고 서버 측에서 이를 인증하는 로직 추가.
## 작업내용
- **AWS**
  - **Route 53 도메인 구매 및 등록**: Cloudfront SSL 인증서 처리를 위해 도메인 등록이 반드시 선행. #49
  - **ACM 인증서 발급**: 인증서 발급 및 DNS 레코드 생성.
  - **CloudFront - 인증서 연결**
    - **S3 프론트**: `CNAME`, 인증서 등록, `Route 53.Hosted zones.Records` 레코드 추가.
    - **EC2 서버**: Origin 추가 및 커스텀 헤더 추가, Behavior를 통한 경로 분기 설정.
- **finance-portfolio-backend**
  - **FilterConfig**: dev, prod 환경일 경우 접속 필터.
  - **CloudFrontHeaderFilter**: 헤더 검증.
  - **application.yml**: 커스텀 헤더 이름 및 값 추가.
- **Github Secrets**: 커스텀 키 `X-Custom-Access-Key` 값 등록.
## 결과
- **사용자 경험**: CDN domin이 아닌 일반 도메인을 통해 접속.   
- **에러 Fix**: `Mixed Content`, `CORS`에러 방지.
- **보안 강화**: 프론트 - 서버 간 데이터 노출 헤더로 방어.
## 관련이슈
- Closes #46
- Closes #49

## 데이터 흐름
User -> Route 53 (Domain) -> CloudFront (SSL Termination & Header) -> EC2 (Header Filter) -> Response

## 추가  Trouble Shootring
- Component에 등록하면 호출과 무관하게 헤더 검증 로직이 작동하는 문제 경험: 로컬 환경에서도 헤더 검증이 강제로 발생.
  - @Component를 사용하지 못해 @Value 또한 사용 불가: Config 측에서 값을 넘겨받는 형식으로 변경.