### PR TITLE
[Fix] CKEditor update간 이미지 upload 문제 수정

### DIFF
--- a/finance-portfolio-frontend/src/api/postApi.js
+++ b/finance-portfolio-frontend/src/api/postApi.js
@@ -34,3 +34,33 @@ export const deletePost = async (id) => {
 export const cleanUpFiles = async () => {
     await axiosInstance.delete('/posts/cleanup');
 };
+
+// 7. CKeditor 전용 업로드 어댑터
+export const imageUploadAdapter = (loader) => {
+    return {
+        upload: () => {
+            return new Promise((resolve, reject) => {
+                const formData = new FormData();
+
+                loader.file.then((file) => {
+                    formData.append('upload', file); // Spring 백엔드의 @RequestParam("upload")와 일치해야 함
+
+                    axiosInstance.post('/image/upload', formData, {
+                        headers: {
+                            'Content-Type': 'multipart/form-data',
+                        },
+                    })
+                        .then((res) => {
+                            // 성공 시 S3 URL 반환
+                            resolve({
+                                default: res.data.url
+                            });
+                        })
+                        .catch((err) => {
+                            reject(err.response?.data?.message || '업로드 실패');
+                        });
+                });
+            });
+        }
+    };
+};

--- a/finance-portfolio-frontend/src/pages/PostEditor.jsx
+++ b/finance-portfolio-frontend/src/pages/PostEditor.jsx
@@ -12,11 +12,10 @@ import {
     List,
     Image,
     ImageUpload,
-    CKFinderUploadAdapter
 } from 'ckeditor5';
 import 'ckeditor5/ckeditor5.css';
 
-import { getPostById, createPost, updatePost } from '../api/postApi';
+import { getPostById, createPost, updatePost, imageUploadAdapter } from '../api/postApi';
 
 const PostEditor = () => {
     const { id } = useParams();
@@ -80,13 +79,15 @@ const PostEditor = () => {
                     <CKEditor
                         editor={ClassicEditor}
                         data={content}
+                        onReady={(editor) => {
+                            editor.plugins.get('FileRepository').createUploadAdapter = (loader) => {
+                                return imageUploadAdapter(loader);
+                            };
+                        }}
                         config={{
                             licenseKey: 'GPL',
-                            plugins: [Essentials, Bold, Italic, Paragraph, Link, List, Image, ImageUpload, CKFinderUploadAdapter],
+                            plugins: [Essentials, Bold, Italic, Paragraph, Link, List, Image, ImageUpload],
                             toolbar: ['undo', 'redo', '|', 'bold', 'italic', '|', 'link', 'bulletedList', 'numberedList', '|', 'imageUpload'],
-                            ckfinder: {
-                                uploadUrl: `api/image/upload`
-                            },
                             placeholder: "내용을 입력하세요..."
                         }}
                         onChange={(event, editor) => {


### PR DESCRIPTION
## 개요
- **문제상황**: CKEditor 자체 Upload기능을 변경된 Axios에서 사용 시 `/api/image/upload`가 update시에는 제대로 동작하지 않는 문제 발생.
- **해결방안**: 이미지 업로드 어댑터 Api 전달 로직을 따로 작성하여 CKEditor 자체 업로드 기능을 대체.
## 작업내용
- **postApi.js**: `imageUploadAdapter` api 전달 메서드 작성.
- **PostEditor.jsx**: `CKFinderUploadAdapter` 삭제 및 `imageUploadAdapter`로 대체.
## 결과
### **Sonar: 보안 취약점으로 인해 PR 취소**
- 통합 관리: #64 