### PR TITLE
[Chore] Sonar 커버리지 조정 및 Finance 파트 테스트 케이스 추가

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -76,8 +76,8 @@ jobs:
       run: |
         npx sonarqube-scanner \
           -Dproject.settings=sonar-project.properties \
-          # -Dsonar.qualitygate.wait=true \
-          # -Dsonar.qualitygate.timeout=300
+          -Dsonar.qualitygate.wait=true \
+          -Dsonar.qualitygate.timeout=300
           
 
     # S3에 빌드 결과물 업로드 (Sync)

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -66,8 +66,11 @@ jobs:
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar    
+        restore-keys: ${{ runner.os }}-sonar
 
+    # 테스트 커버리지 lcov.info파일 생성
+    - name: Run Test Coverage
+      run: npm run test:coverage
     # 소나 분석
     - name: Frontend SonarCloud Scan
       env:

--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/ui": "^4.0.18",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -2187,6 +2188,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2939,6 +2947,28 @@
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
+      "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.18"
       }
     },
     "node_modules/@vitest/utils": {
@@ -4028,6 +4058,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5821,6 +5858,16 @@
         "node": "*"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6444,6 +6491,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6601,6 +6663,16 @@
       "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.0",

--- a/finance-portfolio-frontend/package.json
+++ b/finance-portfolio-frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "sonar": "sonar-scanner"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^11.0.1",
@@ -27,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/ui": "^4.0.18",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/finance-portfolio-frontend/sonar-project.properties
+++ b/finance-portfolio-frontend/sonar-project.properties
@@ -11,12 +11,11 @@ sonar.test.inclusions=**/*.test.js,**/*.spec.js
 
 # 제외 대상
 # 기존 제외 대상에 정적 자원 추가
-sonar.exclusions=**/node_modules/**, dist/**, **/*.test.jsx, **/*.test.js, **/.env, src/assets/**, **/*.png, **/*.jpg, **/*.svg
+sonar.exclusions=**/node_modules/**, dist/**, **/*.test.jsx, **/*.test.js, **/.env, \
+ src/assets/**, **/*.png, **/*.jpg, **/*.svg
 
-# **테스트 제외! 이후 삭제 필요1!!**
-sonar.exclusions=node_modules/**, dist/**, src/assets/**
-sonar.coverage.exclusions=**/main.jsx, **/App.jsx, **/*.test.jsx, **/*.test.js, **/api/axios.js, **/styles/**, **/assets/**
-sonar.javascript.exclusions=**/node_modules/**, **/dist/**, **/test/**, **/*.test.jsx, **/*.test.js, src/main.jsx, src/App.jsx
+sonar.coverage.exclusions=**/main.jsx, **/App.jsx, **/api/axios.js, **/*.css \
+ src/pages/Post*.jsx, src/api/post*.js
 
 # JavaScript 전용 설정
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/finance-portfolio-frontend/src/finances/FinanceFair.test.jsx
+++ b/finance-portfolio-frontend/src/finances/FinanceFair.test.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import FairValueCalculator from './FinanceFair';
+import * as financeApi from '../api/financeApi'; // API 모킹을 위해 임포트
+
+// financeApi의 getFairValue 함수를 가짜(Mock)로 만듭니다.
+vi.mock('../api/financeApi');
+
+describe('FairValueCalculator 컴포넌트 테스트', () => {
+
+    it('사용자가 입력값을 넣으면 해당 값이 input에 반영되어야 한다', () => {
+        render(<FairValueCalculator />);
+
+        const dpsInput = screen.getByLabelText(/주당 배당금/);
+        fireEvent.change(dpsInput, { target: { value: '1000' } });
+
+        expect(dpsInput.value).toBe('1000');
+    });
+
+    it('계산하기 버튼을 누르면 API를 호출하고 결과를 화면에 출력해야 한다', async () => {
+        // 1. API 응답 가짜 데이터 설정 (ResponseDto 구조)
+        const mockResponse = { fairValue: 50000, message: "적정 주가가 계산되었습니다." };
+        financeApi.getFairValue.mockResolvedValue(mockResponse);
+
+        render(<FairValueCalculator />);
+
+        // 2. 값 입력
+        fireEvent.change(screen.getByLabelText(/주당 배당금/), { target: { value: '1000' } });
+        fireEvent.change(screen.getByLabelText(/기대 수익률/), { target: { value: '7.0' } });
+        fireEvent.change(screen.getByLabelText(/지속 성장률/), { target: { value: '5.0' } });
+
+        // 3. 계산 버튼 클릭
+        const submitButton = screen.getByRole('button', { name: /계산하기/ });
+        fireEvent.click(submitButton);
+
+        // 4. 결과 검증
+        // 50,000원이 천 단위 콤마와 함께 표시되는지 확인
+        await waitFor(() => {
+            expect(screen.getByText(/결과: 50,000 원/)).toBeInTheDocument();
+            expect(screen.getByText(/적정 주가가 계산되었습니다/)).toBeInTheDocument();
+        });
+    });
+
+    it('API 호출 도중에는 버튼이 "계산 중..."으로 바뀌고 비활성화되어야 한다', async () => {
+        // API 호출이 끝나지 않도록 지연시키는 가짜 Promise
+        financeApi.getFairValue.mockReturnValue(new Promise(() => { }));
+
+        render(<FairValueCalculator />);
+
+        fireEvent.change(screen.getByLabelText(/주당 배당금/), { target: { value: '1000' } });
+        fireEvent.change(screen.getByLabelText(/기대 수익률/), { target: { value: '7.0' } });
+        fireEvent.change(screen.getByLabelText(/지속 성장률/), { target: { value: '5.0' } });
+
+        const submitButton = screen.getByRole('button', { name: /계산하기/ });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(submitButton).toBeDisabled();
+            expect(submitButton).toHaveTextContent('계산 중...');
+        });
+
+    });
+
+    it('API 호출 실패 시 에러 로그를 찍고 알림창(alert)을 띄워야 한다', async () => {
+        // 1. console.error와 alert가 실행되는지 감시(Spy)하고, 실제 실행은 막기
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+        const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => { });
+
+        // 2. API가 에러를 던지도록 설정 (Reject 시나리오)
+        financeApi.getFairValue.mockRejectedValue(new Error('네트워크 에러'));
+
+        render(<FairValueCalculator />);
+
+        // 3. 필수 입력값 채우기 (그래야 handleCalculate가 실행됨)
+        fireEvent.change(screen.getByLabelText(/주당 배당금/), { target: { value: '1000' } });
+        fireEvent.change(screen.getByLabelText(/기대 수익률/), { target: { value: '7' } });
+        fireEvent.change(screen.getByLabelText(/지속 성장률/), { target: { value: '5' } });
+
+        // 4. 계산 버튼 클릭
+        fireEvent.click(screen.getByRole('button', { name: /계산하기/ }));
+
+        // 5. 검증: console.error와 alert가 호출되었는가?
+        await waitFor(() => {
+            expect(consoleSpy).toHaveBeenCalledWith("계산 에러:", expect.any(Error));
+            expect(alertSpy).toHaveBeenCalledWith("서버 통신 중 오류가 발생했습니다.");
+        });
+
+        // 6. 테스트 종료 후 원래 상태로 복구
+        consoleSpy.mockRestore();
+        alertSpy.mockRestore();
+    });
+});

--- a/finance-portfolio-frontend/src/setupTests.js
+++ b/finance-portfolio-frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/finance-portfolio-frontend/vite.config.js
+++ b/finance-portfolio-frontend/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom', // 브라우저 환경 모사
+    setupFiles: './src/setupTests.js',
     coverage: {
       provider: 'v8', // 커버리지 엔진
       reporter: ['text', 'lcov'], // SonarQube가 읽을 수 있도록 lcov 필수


### PR DESCRIPTION
## 개요
- **방향성 수정**: 기존에 모든 기능에 대해 Coverage를 채우려던 계획에서, 도메인 중요도에 따른 선택과 집중 전략으로 품질 관리 방향을 수정.
  - 무결성이 중요한 금융 계산 로직의 신뢰성을 확보하고, 상대적으로 변경이 잦고 중요도가 낮은 게시판 기능은 검사 대상에서 제외하여 개발 효율성 향상. 
## 변경사항
- **방향성 수정**
  - **sonar-project.properties**: `sonar.coverage.exclusions`에 `pages/Post*.jsx`, `api/post*.js` 제외 추가.
  - **FinanceFair.test.jsx**: 금융 계산기 파트 테스트 케이스 추가.
## 트러블슈팅
- **에러메시지**: `Error: Invalid Chai property: toBeDisabled`
- **원인**: Vitest 기본 매처에 DOM 관련 확장 기능(`jest-dom`)이 포함되지 않음
- **해결방안**
  - **setupTests.js**: `jest-dom`의 확장 매처 import (`toBeDisabled`등 확장 기능 추가).
  - **vite.config.js**: `test.setupFiles`에 `setupTests` 추가.
## 결과
- **개발효율**: 전체 커버리지 목표 대신, FinanceFair 컴포넌트의 핵심 비즈니스 로직(고든 성장 모델)에 대한 100% 커버리지 달성으로 목표 변경.
- **SonarQube 설정 최적화** 
## 관련이슈
- #64 