### PR TITLE
[Refactor] Spring Security 인증 세션 -> JWT방식으로 전환

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -146,6 +146,7 @@ jobs:
           AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CF_SECRET_KEY=${{ secrets.CF_SECRET_KEY }}
+          JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           EOF
           
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 	// 스프링 시큐리티 추가 + 테스트 환경도
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+	// JWT 생성 및 검증
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public ResponseEntity<String> join(@RequestBody MemberJoinRequest request) {
+    public ResponseEntity<String> join(@Valid @RequestBody MemberJoinRequest request) {
         memberService.join(request);
         return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
     }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
@@ -1,59 +1,68 @@
 package com.finance.finportfolio.domain.member.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequest;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequest;
 import com.finance.finportfolio.domain.member.service.MemberService;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
 public class MemberController {
+
     private final MemberService memberService;
-    private final AuthenticationManager authenticationManager;
 
     @PostMapping("/join")
     public ResponseEntity<String> join(@RequestBody MemberJoinRequest request) {
         memberService.join(request);
-
         return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
     }
 
     @PostMapping("/login")
     public ResponseEntity<String> login(@Valid @RequestBody MemberLoginRequest loginRequest,
-            HttpServletRequest request) {
+            HttpServletResponse response) {
 
-        // 1. 아이디와 비밀번호로 인증 토큰 생성
-        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                loginRequest.loginId(), loginRequest.password());
+        // 1. 로그인 처리 → Access Token + Refresh Token 발급
+        String[] tokens = memberService.login(loginRequest);
+        String accessToken = tokens[0];
+        String refreshToken = tokens[1];
 
-        // 2. 실제 인증 수행 (CustomUserDetailsService가 여기서 호출됨)
-        Authentication authentication = authenticationManager.authenticate(token);
+        // 2. Refresh Token → HttpOnly 쿠키로 전달 (JS 접근 불가 → XSS 방어)
+        Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+        refreshCookie.setHttpOnly(true); // JS에서 접근 불가
+        refreshCookie.setSecure(true); // HTTPS 환경에서만 전송
+        refreshCookie.setPath("/"); // 모든 경로에서 쿠키 전송
+        refreshCookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+        response.addCookie(refreshCookie);
 
-        // 3. 인증 성공 시 SecurityContext에 저장
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        // 4. 세션에 인증 정보 저장 (React에서 쿠키를 통해 로그인 유지 가능)
-        HttpSession session = request.getSession(true);
-        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
-                SecurityContextHolder.getContext());
+        // 3. Access Token → 응답 헤더로 전달 (프론트에서 메모리에 저장)
+        response.setHeader("Authorization", "Bearer " + accessToken);
 
         return ResponseEntity.ok("로그인이 완료되었습니다.");
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@Valid @RequestBody MemberLoginRequest loginRequest,
+            HttpServletResponse response) {
+
+        memberService.logout(loginRequest.loginId());
+
+        // Refresh Token 쿠키 만료 처리
+        Cookie refreshCookie = new Cookie("refreshToken", null);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(refreshCookie);
+
+        return ResponseEntity.ok("로그아웃이 완료되었습니다.");
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -23,30 +23,32 @@ public class TokenReissueController {
     public ResponseEntity<String> reissue(HttpServletRequest request,
             HttpServletResponse response) {
 
-        // 1. 쿠키에서 Refresh Token 추출
         String refreshToken = extractRefreshTokenFromCookie(request);
 
         if (refreshToken == null) {
             return ResponseEntity.badRequest().body("Refresh Token이 없습니다.");
         }
 
-        // 2. 새 Access Token + Refresh Token 발급 (Rotation)
-        String[] tokens = memberService.reissue(refreshToken);
-        String newAccessToken = tokens[0];
-        String newRefreshToken = tokens[1];
+        try {
+            String[] tokens = memberService.reissue(refreshToken);
+            String newAccessToken = tokens[0];
+            String newRefreshToken = tokens[1];
 
-        // 3. 새 Refresh Token → 쿠키 갱신
-        Cookie refreshCookie = new Cookie("refreshToken", newRefreshToken);
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setSecure(true);
-        refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(7 * 24 * 60 * 60);
-        response.addCookie(refreshCookie);
+            Cookie refreshCookie = new Cookie("refreshToken", newRefreshToken);
+            refreshCookie.setHttpOnly(true);
+            refreshCookie.setSecure(true);
+            refreshCookie.setPath("/");
+            refreshCookie.setMaxAge(7 * 24 * 60 * 60);
+            response.addCookie(refreshCookie);
 
-        // 4. 새 Access Token → 헤더로 전달
-        response.setHeader("Authorization", "Bearer " + newAccessToken);
+            response.setHeader("Authorization", "Bearer " + newAccessToken);
 
-        return ResponseEntity.ok("토큰이 재발급되었습니다.");
+            return ResponseEntity.ok("토큰이 재발급되었습니다.");
+
+        } catch (IllegalStateException e) {
+            // 탈취 감지, 유효하지 않은 토큰 등 → 400 반환
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 
     private String extractRefreshTokenFromCookie(HttpServletRequest request) {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -1,0 +1,62 @@
+package com.finance.finportfolio.domain.member.controller;
+
+import com.finance.finportfolio.domain.member.service.MemberService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class TokenReissueController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<String> reissue(HttpServletRequest request,
+            HttpServletResponse response) {
+
+        // 1. 쿠키에서 Refresh Token 추출
+        String refreshToken = extractRefreshTokenFromCookie(request);
+
+        if (refreshToken == null) {
+            return ResponseEntity.badRequest().body("Refresh Token이 없습니다.");
+        }
+
+        // 2. 새 Access Token + Refresh Token 발급 (Rotation)
+        String[] tokens = memberService.reissue(refreshToken);
+        String newAccessToken = tokens[0];
+        String newRefreshToken = tokens[1];
+
+        // 3. 새 Refresh Token → 쿠키 갱신
+        Cookie refreshCookie = new Cookie("refreshToken", newRefreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(7 * 24 * 60 * 60);
+        response.addCookie(refreshCookie);
+
+        // 4. 새 Access Token → 헤더로 전달
+        response.setHeader("Authorization", "Bearer " + newAccessToken);
+
+        return ResponseEntity.ok("토큰이 재발급되었습니다.");
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null)
+            return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/domain/RefreshToken.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/domain/RefreshToken.java
@@ -1,0 +1,42 @@
+package com.finance.finportfolio.domain.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false, length = 512)
+    private String token;
+
+    @Builder
+    public RefreshToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    // ── Refresh Token Rotation: 재발급 시 기존 토큰 교체 ──────
+    public void rotate(String newToken) {
+        this.token = newToken;
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/domain/RefreshTokenRepository.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/domain/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.finance.finportfolio.domain.member.domain;
+
+import com.finance.finportfolio.domain.member.domain.Member;
+import com.finance.finportfolio.domain.member.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByMember(Member member);
+
+    // 로그아웃 시 토큰값으로 삭제
+    void deleteByMember(Member member);
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
@@ -1,23 +1,33 @@
 package com.finance.finportfolio.domain.member.service;
 
+import com.finance.finportfolio.domain.member.dto.MemberJoinRequest;
+import com.finance.finportfolio.domain.member.dto.MemberLoginRequest;
+import com.finance.finportfolio.domain.member.domain.Member;
+import com.finance.finportfolio.domain.member.domain.RefreshToken;
+import com.finance.finportfolio.domain.member.domain.MemberRepository;
+import com.finance.finportfolio.domain.member.domain.RefreshTokenRepository;
+import com.finance.finportfolio.domain.member.domain.Role;
+import com.finance.finportfolio.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.finance.finportfolio.domain.member.domain.Member;
-import com.finance.finportfolio.domain.member.domain.MemberRepository;
-import com.finance.finportfolio.domain.member.domain.Role;
-import com.finance.finportfolio.domain.member.dto.MemberJoinRequest;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
 
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // ── 회원가입 ───────────────────────────────────────────────
     @Transactional
     public Long join(MemberJoinRequest request) {
         memberRepository.findByLoginId(request.loginId())
@@ -25,7 +35,6 @@ public class MemberService {
                     throw new IllegalStateException("이미 존재하는 아이디입니다.");
                 });
 
-        // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(request.password());
 
         Member member = Member.builder()
@@ -36,5 +45,80 @@ public class MemberService {
                 .build();
 
         return memberRepository.save(member).getId();
+    }
+
+    // ── 로그인 → [accessToken, refreshToken] 반환 ─────────────
+    @Transactional
+    public String[] login(MemberLoginRequest request) {
+
+        // 1. 아이디/비밀번호 인증
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        request.loginId(), request.password()));
+
+        String loginId = authentication.getName();
+        String role = authentication.getAuthorities().iterator().next().getAuthority();
+
+        // 2. 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(loginId, role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(loginId);
+
+        // 3. Refresh Token DB 저장 (없으면 insert, 있으면 rotate)
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+
+        refreshTokenRepository.findByMember(member)
+                .ifPresentOrElse(
+                        existing -> existing.rotate(refreshToken), // 재로그인: 토큰 교체
+                        () -> refreshTokenRepository.save( // 최초 로그인: 신규 저장
+                                RefreshToken.builder()
+                                        .member(member)
+                                        .token(refreshToken)
+                                        .build()));
+
+        return new String[] { accessToken, refreshToken };
+    }
+
+    // ── 로그아웃 → Refresh Token DB에서 삭제 ──────────────────
+    @Transactional
+    public void logout(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+
+        refreshTokenRepository.deleteByMember(member);
+    }
+
+    // ── 토큰 재발급 (Refresh Token Rotation) ──────────────────
+    @Transactional
+    public String[] reissue(String refreshToken) {
+
+        // 1. Refresh Token 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalStateException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        String loginId = jwtTokenProvider.getLoginId(refreshToken);
+
+        // 2. DB에 저장된 토큰과 일치 여부 확인 (탈취 감지)
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+
+        RefreshToken savedToken = refreshTokenRepository.findByMember(member)
+                .orElseThrow(() -> new IllegalStateException("로그인 상태가 아닙니다."));
+
+        if (!savedToken.getToken().equals(refreshToken)) {
+            // 저장된 토큰과 다르면 탈취 가능성 → 강제 로그아웃
+            refreshTokenRepository.deleteByMember(member);
+            throw new IllegalStateException("Refresh Token이 일치하지 않습니다. 재로그인이 필요합니다.");
+        }
+
+        // 3. 새 토큰 발급 + Rotation
+        String role = member.getRole().getKey();
+        String newAccessToken = jwtTokenProvider.createAccessToken(loginId, role);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(loginId);
+
+        savedToken.rotate(newRefreshToken);
+
+        return new String[] { newAccessToken, newRefreshToken };
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@SuppressWarnings("java:S4502")
 public class SecurityConfig {
 
         private final JwtTokenProvider jwtTokenProvider;

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.finance.finportfolio.global.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -11,50 +12,97 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.finance.finportfolio.global.security.JwtAuthenticationFilter;
+import com.finance.finportfolio.global.security.JwtTokenProvider;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    // 비밀번호 암호화 (BCrypt 사용)
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+        private final JwtTokenProvider jwtTokenProvider;
 
-    // 컨트롤러에 주입해주기 위해 Bean 등록
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
-        return authConfig.getAuthenticationManager();
-    }
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+                return new BCryptPasswordEncoder();
+        }
 
-    @SuppressWarnings("java:S3330")
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                // CSRF 방지
-                // NOSONAR: React에서 CSRF 토큰을 읽기 위해 HttpOnly(false)가 필수적임
-                .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // React가 쿠키를 읽을 수 있게 설정
-                )
-                // 추가적인 보안 헤더 설정 - XSS 방어
-                .headers(headers -> headers
-                        .contentSecurityPolicy(csp -> csp
-                                .policyDirectives("default-src 'self'; " + // 모든 리소스는 동일 출처(자기 자신)만 허용
-                                        "script-src 'self'; " + // 스크립트 실행도 자기 자신만 허용 (인라인 스크립트 차단)
-                                        "style-src 'self' 'unsafe-inline'; " + // CSS는 인라인 스타일 허용 (React 스타일링 대응)
-                                        "img-src 'self' data: https://*.s3.amazonaws.com; " + // S3 이미지 로딩 허용
-                                        "connect-src 'self';") // API 통신은 자기 자신과만 가능
-                        )) // 세션 설정 (`IF_REQUIRED`: 요청 시)
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
-                // 인가 설정
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll() // posts관련 Get 메서드는 전부 허용
-                        .requestMatchers("/api/member/join", "/api/member/login").permitAll() // 가입, 로그인은 모두 허용
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()); // 그 외 모든 요청 인증 필요
-        return http.build();
-    }
+        @Bean
+        public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig)
+                        throws Exception {
+                return authConfig.getAuthenticationManager();
+        }
+
+        @Bean
+        public JwtAuthenticationFilter jwtAuthenticationFilter() {
+                return new JwtAuthenticationFilter(jwtTokenProvider);
+        }
+
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                http
+                                // ── CSRF: JWT 방식은 세션 미사용 → CSRF 불필요 ──────────
+                                .csrf(csrf -> csrf.disable())
+
+                                // ── CORS: S3/CloudFront 도메인 허용 ─────────────────────
+                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                                // ── 보안 헤더 (기존 CSP 유지) ────────────────────────────
+                                .headers(headers -> headers
+                                                .contentSecurityPolicy(csp -> csp
+                                                                .policyDirectives("default-src 'self'; " +
+                                                                                "script-src 'self'; " +
+                                                                                "style-src 'self' 'unsafe-inline'; " +
+                                                                                "img-src 'self' data: https://*.s3.amazonaws.com; "
+                                                                                +
+                                                                                "connect-src 'self';")))
+
+                                // ── 세션 STATELESS: JWT 방식은 서버에 세션 저장 안 함 ────
+                                .sessionManagement(session -> session
+                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                                // ── 인가 설정 ────────────────────────────────────────────
+                                .authorizeHttpRequests(auth -> auth
+                                                .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                                                .requestMatchers("/api/member/join", "/api/member/login").permitAll()
+                                                .requestMatchers("/api/auth/reissue").permitAll()
+                                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                                .anyRequest().authenticated())
+
+                                // ── JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록 ──
+                                .addFilterBefore(jwtAuthenticationFilter(),
+                                                UsernamePasswordAuthenticationFilter.class);
+
+                return http.build();
+        }
+
+        // ── CORS 설정: React(S3/CloudFront) 도메인 허용 ───────────────
+        @Bean
+        public CorsConfigurationSource corsConfigurationSource() {
+                CorsConfiguration config = new CorsConfiguration();
+
+                // 실제 배포 도메인으로 교체 필요
+                config.setAllowedOrigins(List.of(
+                                "http://localhost:5173", // 로컬 개발 (Vite 기본 포트)
+                                "https://your-cloudfront-domain" // 실제 CloudFront 도메인
+                ));
+                config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+                config.setAllowedHeaders(List.of("*"));
+
+                // Authorization 헤더를 프론트에서 읽을 수 있도록 허용
+                config.setExposedHeaders(List.of("Authorization"));
+                config.setAllowCredentials(true); // Refresh Token 쿠키 전달 허용
+                config.setMaxAge(3600L);
+
+                UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+                source.registerCorsConfiguration("/**", config);
+                return source;
+        }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.finance.finportfolio.global.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -37,5 +38,21 @@ public class GlobalExceptionHandler {
                 .build();
 
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // @Valid 검증 실패 → 400
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getDefaultMessage())
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다.");
+        return ResponseEntity.badRequest().body(message);
+    }
+
+    // 중복 아이디 등 비즈니스 예외 → 400
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalStateException(IllegalStateException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/JwtAuthenticationFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,76 @@
+package com.finance.finportfolio.global.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        // 토큰 없으면 다음 필터로 (인증 불필요한 엔드포인트는 SecurityConfig에서 처리)
+        if (!StringUtils.hasText(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            if (jwtTokenProvider.validateToken(token)) {
+                setAuthentication(token);
+            }
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰 → 401 반환 (프론트에서 /reissue 요청하도록 유도)
+            log.warn("만료된 Access Token: {}", request.getRequestURI());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"error\": \"ACCESS_TOKEN_EXPIRED\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // ── Authorization 헤더에서 Bearer 토큰 추출 ────────────────
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // ── SecurityContext에 인증 정보 저장 ───────────────────────
+    private void setAuthentication(String token) {
+        String loginId = jwtTokenProvider.getLoginId(token);
+        String role = jwtTokenProvider.getRole(token);
+
+        // DB 조회 없이 토큰 클레임만으로 인증 객체 생성 → 성능 최적화
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                loginId,
+                null,
+                List.of(new SimpleGrantedAuthority(role)));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/JwtTokenProvider.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/JwtTokenProvider.java
@@ -1,0 +1,96 @@
+package com.finance.finportfolio.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // ── Access Token 생성 ──────────────────────────────────────
+    public String createAccessToken(String loginId, String role) {
+        return Jwts.builder()
+                .subject(loginId)
+                .claim("role", role)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // ── Refresh Token 생성 (페이로드 최소화) ───────────────────
+    public String createRefreshToken(String loginId) {
+        return Jwts.builder()
+                .subject(loginId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // ── 토큰에서 loginId 추출 ──────────────────────────────────
+    public String getLoginId(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    // ── 토큰에서 role 추출 ─────────────────────────────────────
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    // ── 토큰 유효성 검증 ───────────────────────────────────────
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw e; // 만료는 별도 처리 (재발급 흐름)
+        } catch (JwtException | IllegalArgumentException e) {
+            return false; // 위변조, 형식 오류 등
+        }
+    }
+
+    // ── Access Token 만료 여부만 확인 (재발급 시 사용) ─────────
+    public boolean isTokenExpired(String token) {
+        try {
+            getClaims(token);
+            return false;
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -29,6 +29,11 @@ cloudfront:
     header:
       name: X-Custom-Access-Key
       value: ${CF_SECRET_KEY}
+
+jwt:
+  secret: ${JWT_SECRET_KEY}  # 32자 이상
+  access-token-expiration: 900000       # 15분 (ms)
+  refresh-token-expiration: 604800000   # 7일 (ms)      
 ---
 spring:
   config:

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -5,6 +5,7 @@ import com.finance.finportfolio.domain.member.dto.MemberJoinRequest;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequest;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
+import com.finance.finportfolio.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -21,7 +21,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,25 +38,18 @@ class MemberControllerTest {
     @MockBean
     private MemberService memberService;
 
-    // SecurityConfig에 정의된 빈들을 주입받아 커버리지를 채웁니다.
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-
     @MockBean
     private AuthenticationManager authenticationManager;
 
     @MockBean
-    private Authentication authentication;
+    private JwtTokenProvider jwtTokenProvider; // ← SecurityConfig 주입용, 추가 필수
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Test
-    void coverageCheck() {
-        System.out.println("주입된 빈: " + passwordEncoder.getClass().getName());
-    }
-
-    @Test
-    @DisplayName("SecurityConfig의 빈들이 정상적으로 로드되었는지 확인")
+    @DisplayName("SecurityConfig 빈 정상 로드 확인")
     void securityConfigBeansLoad() {
-        // 이 검증을 통해 SecurityConfig의 메서드들이 실행됨을 보장 (커버리지 확보)
         assertThat(passwordEncoder).isNotNull();
         assertThat(authenticationManager).isNotNull();
     }
@@ -67,12 +59,11 @@ class MemberControllerTest {
     @DisplayName("회원가입 API 호출 시 성공 메시지를 반환한다")
     void join_Success() throws Exception {
         MemberJoinRequest request = new MemberJoinRequest("testId", "password123", "nickname");
-        String json = objectMapper.writeValueAsString(request);
 
         mockMvc.perform(post("/api/member/join")
-                .with(csrf())
+                // csrf() 제거 — JWT 방식은 CSRF 비활성화
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("회원가입이 성공적으로 완료되었습니다."));
     }
@@ -81,36 +72,29 @@ class MemberControllerTest {
     @WithMockUser
     @DisplayName("로그인 API 호출 시 성공 메시지를 반환한다")
     void login_Success() throws Exception {
-        // 1. 데이터 준비
         MemberLoginRequest loginRequest = new MemberLoginRequest("testId", "password123");
-        String json = objectMapper.writeValueAsString(loginRequest);
 
-        // 2. 컨트롤러가 사용하는 모든 의존성을 확실히 모킹 (가장 중요)
-        // 컨트롤러에서 authenticationManager.authenticate()를 호출한다면:
-        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+        // memberService.login()이 토큰 배열 반환하도록 모킹
+        when(memberService.login(any())).thenReturn(new String[] { "accessToken", "refreshToken" });
 
-        // 만약 서비스의 특정 메서드도 호출한다면 그것도 작성:
-        // when(memberService.someMethod(any())).thenReturn(someValue);
-
-        // 3. 실행 및 검증
         mockMvc.perform(post("/api/member/login")
-                .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
+                .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("로그인이 완료되었습니다."));
     }
 
     @Test
     @WithMockUser
-    @DisplayName("CSRF 토큰 없이 POST 요청 시 403 Forbidden 에러가 발생해야 한다")
-    void login_Fail_Without_Csrf() throws Exception {
+    @DisplayName("JWT 방식에서는 CSRF 없이도 POST 요청이 성공해야 한다")
+    void login_Success_Without_Csrf() throws Exception {
+        // JWT로 전환 후 CSRF 비활성화 → csrf() 없어도 200 반환되어야 함
         MemberLoginRequest loginRequest = new MemberLoginRequest("testId", "password123");
-        String json = objectMapper.writeValueAsString(loginRequest);
+        when(memberService.login(any())).thenReturn(new String[] { "accessToken", "refreshToken" });
 
         mockMvc.perform(post("/api/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
-                .andExpect(status().isForbidden());
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk());
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -6,6 +6,7 @@ import com.finance.finportfolio.domain.member.dto.MemberLoginRequest;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
 import com.finance.finportfolio.global.security.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,9 +21,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
@@ -42,7 +47,7 @@ class MemberControllerTest {
     private AuthenticationManager authenticationManager;
 
     @MockBean
-    private JwtTokenProvider jwtTokenProvider; // ← SecurityConfig 주입용, 추가 필수
+    private JwtTokenProvider jwtTokenProvider;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -54,14 +59,15 @@ class MemberControllerTest {
         assertThat(authenticationManager).isNotNull();
     }
 
+    // ── 회원가입 ───────────────────────────────────────────────
+
     @Test
     @WithMockUser
-    @DisplayName("회원가입 API 호출 시 성공 메시지를 반환한다")
+    @DisplayName("회원가입 성공 시 200과 성공 메시지를 반환한다")
     void join_Success() throws Exception {
         MemberJoinRequest request = new MemberJoinRequest("testId", "password123", "nickname");
 
         mockMvc.perform(post("/api/member/join")
-                // csrf() 제거 — JWT 방식은 CSRF 비활성화
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -70,31 +76,90 @@ class MemberControllerTest {
 
     @Test
     @WithMockUser
-    @DisplayName("로그인 API 호출 시 성공 메시지를 반환한다")
+    @DisplayName("아이디가 공백이면 회원가입 요청이 400을 반환한다")
+    void join_Fail_BlankLoginId() throws Exception {
+        MemberJoinRequest request = new MemberJoinRequest("", "password123", "nickname");
+
+        mockMvc.perform(post("/api/member/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("비밀번호가 4자 미만이면 회원가입 요청이 400을 반환한다")
+    void join_Fail_ShortPassword() throws Exception {
+        MemberJoinRequest request = new MemberJoinRequest("testId", "123", "nickname");
+
+        mockMvc.perform(post("/api/member/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── 로그인 ─────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그인 성공 시 Authorization 헤더와 refreshToken 쿠키가 반환된다")
     void login_Success() throws Exception {
         MemberLoginRequest loginRequest = new MemberLoginRequest("testId", "password123");
-
-        // memberService.login()이 토큰 배열 반환하도록 모킹
-        when(memberService.login(any())).thenReturn(new String[] { "accessToken", "refreshToken" });
+        given(memberService.login(any())).willReturn(new String[] { "accessToken", "refreshToken" });
 
         mockMvc.perform(post("/api/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(content().string("로그인이 완료되었습니다."));
+                .andExpect(content().string("로그인이 완료되었습니다."))
+                // Access Token → Authorization 헤더 확인
+                .andExpect(header().string("Authorization", "Bearer accessToken"))
+                // Refresh Token → HttpOnly 쿠키 확인
+                .andExpect(cookie().value("refreshToken", "refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true));
     }
 
     @Test
     @WithMockUser
-    @DisplayName("JWT 방식에서는 CSRF 없이도 POST 요청이 성공해야 한다")
-    void login_Success_Without_Csrf() throws Exception {
-        // JWT로 전환 후 CSRF 비활성화 → csrf() 없어도 200 반환되어야 함
+    @DisplayName("JWT 방식에서는 CSRF 없이도 로그인 요청이 성공한다")
+    void login_Success_WithoutCsrf() throws Exception {
         MemberLoginRequest loginRequest = new MemberLoginRequest("testId", "password123");
-        when(memberService.login(any())).thenReturn(new String[] { "accessToken", "refreshToken" });
+        given(memberService.login(any())).willReturn(new String[] { "accessToken", "refreshToken" });
 
         mockMvc.perform(post("/api/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("아이디가 공백이면 로그인 요청이 400을 반환한다")
+    void login_Fail_BlankLoginId() throws Exception {
+        MemberLoginRequest loginRequest = new MemberLoginRequest("", "password123");
+
+        mockMvc.perform(post("/api/member/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest());
+
+        verify(memberService, never()).login(any());
+    }
+
+    // ── 로그아웃 ───────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그아웃 성공 시 refreshToken 쿠키가 즉시 만료된다")
+    void logout_Success() throws Exception {
+        MemberLoginRequest loginRequest = new MemberLoginRequest("testId", "password123");
+
+        mockMvc.perform(post("/api/member/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("로그아웃이 완료되었습니다."))
+                // 쿠키 maxAge = 0 → 즉시 만료 확인
+                .andExpect(cookie().maxAge("refreshToken", 0));
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -1,0 +1,104 @@
+package com.finance.finportfolio.domain.member.controller;
+
+import com.finance.finportfolio.domain.member.service.MemberService;
+import com.finance.finportfolio.global.config.SecurityConfig;
+import com.finance.finportfolio.global.security.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TokenReissueController.class)
+@Import(SecurityConfig.class)
+class TokenReissueControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    // ── 정상 재발급 ────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    @DisplayName("유효한 Refresh Token 쿠키로 요청 시 새 토큰이 발급된다")
+    void reissue_Success() throws Exception {
+        given(memberService.reissue(any()))
+                .willReturn(new String[] { "newAccessToken", "newRefreshToken" });
+
+        mockMvc.perform(post("/api/auth/reissue")
+                .cookie(new Cookie("refreshToken", "validRefreshToken")))
+                .andExpect(status().isOk())
+                .andExpect(content().string("토큰이 재발급되었습니다."))
+                // 새 Access Token이 Authorization 헤더에 담겨야 함
+                .andExpect(header().string("Authorization", "Bearer newAccessToken"))
+                // 새 Refresh Token이 HttpOnly 쿠키로 내려와야 함
+                .andExpect(cookie().value("refreshToken", "newRefreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true));
+    }
+
+    // ── Refresh Token 없는 경우 ────────────────────────────────
+
+    @Test
+    @WithMockUser
+    @DisplayName("Refresh Token 쿠키가 없으면 400 Bad Request를 반환한다")
+    void reissue_Fail_NoCookie() throws Exception {
+        mockMvc.perform(post("/api/auth/reissue"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Refresh Token이 없습니다."));
+
+        // 쿠키 없으면 서비스 호출 안 해야 함
+        verify(memberService, never()).reissue(any());
+    }
+
+    // ── 유효하지 않은 Refresh Token ────────────────────────────
+
+    @Test
+    @WithMockUser
+    @DisplayName("유효하지 않은 Refresh Token이면 400 Bad Request를 반환한다")
+    void reissue_Fail_InvalidToken() throws Exception {
+        given(memberService.reissue(any()))
+                .willThrow(new IllegalStateException("유효하지 않은 Refresh Token입니다."));
+
+        mockMvc.perform(post("/api/auth/reissue")
+                .cookie(new Cookie("refreshToken", "invalidToken")))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── 탈취 감지 ──────────────────────────────────────────────
+
+    @Test
+    @WithMockUser
+    @DisplayName("탈취 감지 시 (토큰 불일치) 400 Bad Request를 반환한다")
+    void reissue_Fail_TokenMismatch() throws Exception {
+        given(memberService.reissue(any()))
+                .willThrow(new IllegalStateException("Refresh Token이 일치하지 않습니다. 재로그인이 필요합니다."));
+
+        mockMvc.perform(post("/api/auth/reissue")
+                .cookie(new Cookie("refreshToken", "stolenToken")))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/domain/RefreshTokenTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/domain/RefreshTokenTest.java
@@ -1,0 +1,78 @@
+package com.finance.finportfolio.domain.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RefreshTokenTest {
+
+    private Member createMember() {
+        return Member.builder()
+                .loginId("testUser")
+                .password("encodedPassword")
+                .nickname("tester")
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("RefreshToken 생성 시 member와 token이 정상적으로 저장된다")
+    void create_Success() {
+        Member member = createMember();
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .member(member)
+                .token("originalToken")
+                .build();
+
+        assertThat(refreshToken.getMember()).isEqualTo(member);
+        assertThat(refreshToken.getToken()).isEqualTo("originalToken");
+    }
+
+    @Test
+    @DisplayName("rotate() 호출 시 토큰이 새 값으로 교체된다")
+    void rotate_Success() {
+        Member member = createMember();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .member(member)
+                .token("originalToken")
+                .build();
+
+        refreshToken.rotate("newToken");
+
+        assertThat(refreshToken.getToken()).isEqualTo("newToken");
+    }
+
+    @Test
+    @DisplayName("rotate()를 여러 번 호출해도 항상 최신 토큰으로 교체된다")
+    void rotate_Multiple_Success() {
+        Member member = createMember();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .member(member)
+                .token("token1")
+                .build();
+
+        refreshToken.rotate("token2");
+        refreshToken.rotate("token3");
+
+        // 최종적으로 마지막 토큰만 남아야 함
+        assertThat(refreshToken.getToken()).isEqualTo("token3");
+    }
+
+    @Test
+    @DisplayName("id는 기본적으로 null이고 ReflectionTestUtils로 설정 가능하다")
+    void id_DefaultNull() {
+        Member member = createMember();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .member(member)
+                .token("token")
+                .build();
+
+        assertThat(refreshToken.getId()).isNull();
+
+        ReflectionTestUtils.setField(refreshToken, "id", 1L);
+        assertThat(refreshToken.getId()).isEqualTo(1L);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
@@ -1,17 +1,27 @@
 package com.finance.finportfolio.domain.member.service;
 
 import com.finance.finportfolio.domain.member.domain.Member;
+import com.finance.finportfolio.domain.member.domain.RefreshToken;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequest;
+import com.finance.finportfolio.domain.member.dto.MemberLoginRequest;
 import com.finance.finportfolio.domain.member.domain.MemberRepository;
+import com.finance.finportfolio.domain.member.domain.RefreshTokenRepository;
+import com.finance.finportfolio.domain.member.domain.Role;
+import com.finance.finportfolio.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,53 +40,122 @@ class MemberServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
+    private RefreshTokenRepository refreshTokenRepository; // ← 추가
+
+    @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private AuthenticationManager authenticationManager; // ← 추가
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider; // ← 추가
+
+    // ── join 테스트 (기존 유지) ────────────────────────────────
     @Test
     @DisplayName("회원가입 성공 - 비밀번호가 암호화되어 저장되어야 한다")
     void join_Success() {
-        // given
         MemberJoinRequest request = new MemberJoinRequest("testId", "rawPassword", "tester");
         String encodedPassword = "encodedPassword123";
 
         given(memberRepository.findByLoginId(request.loginId())).willReturn(Optional.empty());
         given(passwordEncoder.encode(request.password())).willReturn(encodedPassword);
 
-        // 가짜 멤버 엔티티 생성 (ID 포함)
         Member savedMember = Member.builder()
                 .loginId(request.loginId())
                 .password(encodedPassword)
                 .nickname(request.nickname())
                 .build();
-
         ReflectionTestUtils.setField(savedMember, "id", 1L);
 
         given(memberRepository.save(any(Member.class))).willReturn(savedMember);
 
-        // when
         Long savedId = memberService.join(request);
 
-        // then
         assertThat(savedId).isEqualTo(1L);
-        verify(passwordEncoder, times(1)).encode("rawPassword"); // 암호화가 실행되었는지 확인
-        verify(memberRepository, times(1)).save(any(Member.class)); // 저장이 실행되었는지 확인
+        verify(passwordEncoder, times(1)).encode("rawPassword");
+        verify(memberRepository, times(1)).save(any(Member.class));
     }
 
     @Test
     @DisplayName("회원가입 실패 - 이미 존재하는 아이디인 경우 예외 발생")
     void join_Fail_DuplicateId() {
-        // given
         MemberJoinRequest request = new MemberJoinRequest("duplicateId", "password", "tester");
         Member existingMember = Member.builder().loginId("duplicateId").build();
 
         given(memberRepository.findByLoginId("duplicateId")).willReturn(Optional.of(existingMember));
 
-        // when & then
         assertThatThrownBy(() -> memberService.join(request))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("이미 존재하는 아이디입니다.");
 
-        // 중복인 경우 저장 로직이 호출되지 않아야 함
         verify(memberRepository, never()).save(any(Member.class));
+    }
+
+    // ── login 테스트 (신규) ────────────────────────────────────
+    @Test
+    @DisplayName("로그인 성공 - Access Token과 Refresh Token이 반환된다")
+    void login_Success() {
+        MemberLoginRequest request = new MemberLoginRequest("testId", "rawPassword");
+
+        // Authentication 모킹
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                "testId", null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        given(authenticationManager.authenticate(any())).willReturn(authentication);
+
+        // Member 조회 모킹
+        Member member = Member.builder()
+                .loginId("testId")
+                .password("encodedPassword")
+                .nickname("tester")
+                .role(Role.USER)
+                .build();
+        given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
+
+        // 토큰 생성 모킹
+        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("accessToken");
+        given(jwtTokenProvider.createRefreshToken(any())).willReturn("refreshToken");
+
+        // RefreshToken 없는 경우 (최초 로그인)
+        given(refreshTokenRepository.findByMember(member)).willReturn(Optional.empty());
+
+        String[] tokens = memberService.login(request);
+
+        assertThat(tokens[0]).isEqualTo("accessToken");
+        assertThat(tokens[1]).isEqualTo("refreshToken");
+        verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+    }
+
+    // ── reissue 테스트 (신규) ──────────────────────────────────
+    @Test
+    @DisplayName("토큰 재발급 실패 - DB 토큰과 불일치 시 예외 발생 (탈취 감지)")
+    void reissue_Fail_TokenMismatch() {
+        String requestToken = "stolenToken";
+
+        given(jwtTokenProvider.validateToken(requestToken)).willReturn(true);
+        given(jwtTokenProvider.getLoginId(requestToken)).willReturn("testId");
+
+        Member member = Member.builder()
+                .loginId("testId")
+                .password("encodedPassword")
+                .nickname("tester")
+                .role(Role.USER)
+                .build();
+        given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
+
+        // DB에는 다른 토큰이 저장되어 있음
+        RefreshToken savedToken = RefreshToken.builder()
+                .member(member)
+                .token("originalToken") // 요청 토큰과 다름
+                .build();
+        given(refreshTokenRepository.findByMember(member)).willReturn(Optional.of(savedToken));
+
+        assertThatThrownBy(() -> memberService.reissue(requestToken))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Refresh Token이 일치하지 않습니다.");
+
+        // 탈취 감지 시 DB 토큰 삭제 확인
+        verify(refreshTokenRepository, times(1)).deleteByMember(member);
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
@@ -2,11 +2,11 @@ package com.finance.finportfolio.domain.member.service;
 
 import com.finance.finportfolio.domain.member.domain.Member;
 import com.finance.finportfolio.domain.member.domain.RefreshToken;
+import com.finance.finportfolio.domain.member.domain.Role;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequest;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequest;
 import com.finance.finportfolio.domain.member.domain.MemberRepository;
 import com.finance.finportfolio.domain.member.domain.RefreshTokenRepository;
-import com.finance.finportfolio.domain.member.domain.Role;
 import com.finance.finportfolio.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -40,34 +41,39 @@ class MemberServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private RefreshTokenRepository refreshTokenRepository; // ← 추가
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Mock
     private PasswordEncoder passwordEncoder;
 
     @Mock
-    private AuthenticationManager authenticationManager; // ← 추가
+    private AuthenticationManager authenticationManager;
 
     @Mock
-    private JwtTokenProvider jwtTokenProvider; // ← 추가
+    private JwtTokenProvider jwtTokenProvider;
 
-    // ── join 테스트 (기존 유지) ────────────────────────────────
+    // 테스트용 Member 생성 헬퍼
+    private Member createMember(String loginId) {
+        Member member = Member.builder()
+                .loginId(loginId)
+                .password("encodedPassword")
+                .nickname("tester")
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        return member;
+    }
+
+    // ── join ───────────────────────────────────────────────────
+
     @Test
-    @DisplayName("회원가입 성공 - 비밀번호가 암호화되어 저장되어야 한다")
+    @DisplayName("회원가입 성공 - 비밀번호가 암호화되어 저장된다")
     void join_Success() {
         MemberJoinRequest request = new MemberJoinRequest("testId", "rawPassword", "tester");
-        String encodedPassword = "encodedPassword123";
+        Member savedMember = createMember("testId");
 
         given(memberRepository.findByLoginId(request.loginId())).willReturn(Optional.empty());
-        given(passwordEncoder.encode(request.password())).willReturn(encodedPassword);
-
-        Member savedMember = Member.builder()
-                .loginId(request.loginId())
-                .password(encodedPassword)
-                .nickname(request.nickname())
-                .build();
-        ReflectionTestUtils.setField(savedMember, "id", 1L);
-
+        given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
         given(memberRepository.save(any(Member.class))).willReturn(savedMember);
 
         Long savedId = memberService.join(request);
@@ -78,12 +84,11 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원가입 실패 - 이미 존재하는 아이디인 경우 예외 발생")
+    @DisplayName("회원가입 실패 - 중복 아이디면 예외가 발생하고 저장이 호출되지 않는다")
     void join_Fail_DuplicateId() {
         MemberJoinRequest request = new MemberJoinRequest("duplicateId", "password", "tester");
-        Member existingMember = Member.builder().loginId("duplicateId").build();
-
-        given(memberRepository.findByLoginId("duplicateId")).willReturn(Optional.of(existingMember));
+        given(memberRepository.findByLoginId("duplicateId"))
+                .willReturn(Optional.of(createMember("duplicateId")));
 
         assertThatThrownBy(() -> memberService.join(request))
                 .isInstanceOf(IllegalStateException.class)
@@ -92,70 +97,167 @@ class MemberServiceTest {
         verify(memberRepository, never()).save(any(Member.class));
     }
 
-    // ── login 테스트 (신규) ────────────────────────────────────
+    // ── login ──────────────────────────────────────────────────
+
     @Test
     @DisplayName("로그인 성공 - Access Token과 Refresh Token이 반환된다")
     void login_Success() {
         MemberLoginRequest request = new MemberLoginRequest("testId", "rawPassword");
+        Member member = createMember("testId");
 
-        // Authentication 모킹
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 "testId", null,
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         given(authenticationManager.authenticate(any())).willReturn(authentication);
-
-        // Member 조회 모킹
-        Member member = Member.builder()
-                .loginId("testId")
-                .password("encodedPassword")
-                .nickname("tester")
-                .role(Role.USER)
-                .build();
         given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
-
-        // 토큰 생성 모킹
         given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("accessToken");
         given(jwtTokenProvider.createRefreshToken(any())).willReturn("refreshToken");
-
-        // RefreshToken 없는 경우 (최초 로그인)
         given(refreshTokenRepository.findByMember(member)).willReturn(Optional.empty());
 
         String[] tokens = memberService.login(request);
 
         assertThat(tokens[0]).isEqualTo("accessToken");
         assertThat(tokens[1]).isEqualTo("refreshToken");
+        // 최초 로그인 → save 호출 확인
         verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
     }
 
-    // ── reissue 테스트 (신규) ──────────────────────────────────
     @Test
-    @DisplayName("토큰 재발급 실패 - DB 토큰과 불일치 시 예외 발생 (탈취 감지)")
-    void reissue_Fail_TokenMismatch() {
-        String requestToken = "stolenToken";
-
-        given(jwtTokenProvider.validateToken(requestToken)).willReturn(true);
-        given(jwtTokenProvider.getLoginId(requestToken)).willReturn("testId");
-
-        Member member = Member.builder()
-                .loginId("testId")
-                .password("encodedPassword")
-                .nickname("tester")
-                .role(Role.USER)
+    @DisplayName("재로그인 성공 - 기존 Refresh Token이 rotate()로 교체된다")
+    void login_Success_Relogin_RotatesToken() {
+        MemberLoginRequest request = new MemberLoginRequest("testId", "rawPassword");
+        Member member = createMember("testId");
+        RefreshToken existingToken = RefreshToken.builder()
+                .member(member)
+                .token("oldRefreshToken")
                 .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                "testId", null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        given(authenticationManager.authenticate(any())).willReturn(authentication);
+        given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
+        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("newAccessToken");
+        given(jwtTokenProvider.createRefreshToken(any())).willReturn("newRefreshToken");
+        // 기존 토큰 존재 → rotate() 경로
+        given(refreshTokenRepository.findByMember(member)).willReturn(Optional.of(existingToken));
+
+        memberService.login(request);
+
+        // save가 아닌 rotate()로 교체됐는지 확인
+        assertThat(existingToken.getToken()).isEqualTo("newRefreshToken");
+        verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 비밀번호면 예외가 발생한다")
+    void login_Fail_WrongPassword() {
+        MemberLoginRequest request = new MemberLoginRequest("testId", "wrongPassword");
+        given(authenticationManager.authenticate(any()))
+                .willThrow(new BadCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다."));
+
+        assertThatThrownBy(() -> memberService.login(request))
+                .isInstanceOf(BadCredentialsException.class);
+
+        verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+    }
+
+    // ── logout ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("로그아웃 성공 - Refresh Token이 DB에서 삭제된다")
+    void logout_Success() {
+        Member member = createMember("testId");
         given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
 
-        // DB에는 다른 토큰이 저장되어 있음
+        memberService.logout("testId");
+
+        verify(refreshTokenRepository, times(1)).deleteByMember(member);
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패 - 존재하지 않는 회원이면 예외가 발생한다")
+    void logout_Fail_MemberNotFound() {
+        given(memberRepository.findByLoginId("unknown")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.logout("unknown"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("존재하지 않는 회원입니다.");
+
+        verify(refreshTokenRepository, never()).deleteByMember(any());
+    }
+
+    // ── reissue ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("토큰 재발급 성공 - 새 토큰 2개가 반환되고 DB 토큰이 교체된다")
+    void reissue_Success() {
+        Member member = createMember("testId");
         RefreshToken savedToken = RefreshToken.builder()
                 .member(member)
-                .token("originalToken") // 요청 토큰과 다름
+                .token("validRefreshToken")
                 .build();
+
+        given(jwtTokenProvider.validateToken("validRefreshToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("validRefreshToken")).willReturn("testId");
+        given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
+        given(refreshTokenRepository.findByMember(member)).willReturn(Optional.of(savedToken));
+        given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("newAccessToken");
+        given(jwtTokenProvider.createRefreshToken(any())).willReturn("newRefreshToken");
+
+        String[] tokens = memberService.reissue("validRefreshToken");
+
+        assertThat(tokens[0]).isEqualTo("newAccessToken");
+        assertThat(tokens[1]).isEqualTo("newRefreshToken");
+        // DB 토큰이 rotate()로 교체됐는지 확인
+        assertThat(savedToken.getToken()).isEqualTo("newRefreshToken");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 유효하지 않은 토큰이면 예외가 발생한다")
+    void reissue_Fail_InvalidToken() {
+        given(jwtTokenProvider.validateToken("invalidToken")).willReturn(false);
+
+        assertThatThrownBy(() -> memberService.reissue("invalidToken"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - DB 토큰과 불일치 시 강제 로그아웃된다 (탈취 감지)")
+    void reissue_Fail_TokenMismatch_ForcesLogout() {
+        Member member = createMember("testId");
+        RefreshToken savedToken = RefreshToken.builder()
+                .member(member)
+                .token("originalToken")
+                .build();
+
+        given(jwtTokenProvider.validateToken("stolenToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("stolenToken")).willReturn("testId");
+        given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
         given(refreshTokenRepository.findByMember(member)).willReturn(Optional.of(savedToken));
 
-        assertThatThrownBy(() -> memberService.reissue(requestToken))
+        assertThatThrownBy(() -> memberService.reissue("stolenToken"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Refresh Token이 일치하지 않습니다.");
 
-        // 탈취 감지 시 DB 토큰 삭제 확인
+        // 탈취 감지 → 강제 로그아웃 (DB 토큰 삭제) 확인
         verify(refreshTokenRepository, times(1)).deleteByMember(member);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 로그인 상태가 아니면 예외가 발생한다")
+    void reissue_Fail_NotLoggedIn() {
+        Member member = createMember("testId");
+
+        given(jwtTokenProvider.validateToken("refreshToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("refreshToken")).willReturn("testId");
+        given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
+        // DB에 토큰 없음 → 로그인 상태 아님
+        given(refreshTokenRepository.findByMember(member)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.reissue("refreshToken"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("로그인 상태가 아닙니다.");
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/JwtAuthenticationFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,153 @@
+package com.finance.finportfolio.global.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        // 각 테스트 전 SecurityContext 초기화
+        SecurityContextHolder.clearContext();
+    }
+
+    // ── 정상 인증 ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("유효한 토큰이면 SecurityContext에 인증 정보가 저장된다")
+    void doFilter_ValidToken_SetsAuthentication() throws ServletException, IOException {
+        request.addHeader("Authorization", "Bearer validToken");
+
+        given(jwtTokenProvider.validateToken("validToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("validToken")).willReturn("testUser");
+        given(jwtTokenProvider.getRole("validToken")).willReturn("ROLE_USER");
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // SecurityContext에 인증 정보 저장 확인
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+                .isEqualTo("testUser");
+
+        // 다음 필터로 정상 진행 확인
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    // ── 토큰 없는 경우 ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 SecurityContext에 인증 정보가 없고 다음 필터로 진행한다")
+    void doFilter_NoToken_PassesThrough() throws ServletException, IOException {
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // 인증 정보 없음 확인
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+
+        // 다음 필터로 정상 진행 확인
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Bearer 접두사가 없는 토큰은 무시하고 다음 필터로 진행한다")
+    void doFilter_NoBearerPrefix_PassesThrough() throws ServletException, IOException {
+        request.addHeader("Authorization", "InvalidTokenFormat");
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain, times(1)).doFilter(request, response);
+
+        // 헤더 형식이 잘못되면 토큰 검증 자체를 호출하지 않아야 함
+        verify(jwtTokenProvider, never()).validateToken(any());
+    }
+
+    // ── 만료된 토큰 ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("만료된 토큰이면 401과 ACCESS_TOKEN_EXPIRED 에러를 반환한다")
+    void doFilter_ExpiredToken_Returns401() throws ServletException, IOException {
+        request.addHeader("Authorization", "Bearer expiredToken");
+
+        given(jwtTokenProvider.validateToken("expiredToken"))
+                .willThrow(new ExpiredJwtException(null, null, "Token expired"));
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // 401 반환 확인
+        assertThat(response.getStatus()).isEqualTo(401);
+
+        // 응답 바디에 ACCESS_TOKEN_EXPIRED 포함 확인
+        assertThat(response.getContentAsString()).contains("ACCESS_TOKEN_EXPIRED");
+
+        // 만료된 경우 다음 필터로 진행하면 안 됨
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    // ── 위변조된 토큰 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("위변조된 토큰이면 SecurityContext에 인증 정보가 없고 다음 필터로 진행한다")
+    void doFilter_InvalidToken_NoAuthentication() throws ServletException, IOException {
+        request.addHeader("Authorization", "Bearer tamperedToken");
+
+        given(jwtTokenProvider.validateToken("tamperedToken")).willReturn(false);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // 인증 정보 없음 확인
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+
+        // 위변조 토큰은 그냥 통과 (이후 인증 필요한 엔드포인트에서 403 처리)
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    // ── role 검증 ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("ADMIN 토큰이면 SecurityContext에 ROLE_ADMIN 권한이 저장된다")
+    void doFilter_AdminToken_SetsAdminRole() throws ServletException, IOException {
+        request.addHeader("Authorization", "Bearer adminToken");
+
+        given(jwtTokenProvider.validateToken("adminToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("adminToken")).willReturn("adminUser");
+        given(jwtTokenProvider.getRole("adminToken")).willReturn("ROLE_ADMIN");
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()
+                .getAuthorities().iterator().next().getAuthority())
+                .isEqualTo("ROLE_ADMIN");
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/JwtTokenProviderTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/JwtTokenProviderTest.java
@@ -1,0 +1,106 @@
+package com.finance.finportfolio.global.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    // HS256 최소 32바이트 → Base64 인코딩 필요
+    private static final String SECRET = "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItY2hhcmFjdGVycw==";
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider();
+        ReflectionTestUtils.setField(jwtTokenProvider, "secretKey", SECRET);
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenExpiration", 900000L); // 15분
+        ReflectionTestUtils.setField(jwtTokenProvider, "refreshTokenExpiration", 604800000L); // 7일
+    }
+
+    // ── Access Token ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("Access Token 생성 후 loginId와 role을 정상적으로 추출할 수 있다")
+    void createAccessToken_Success() {
+        String token = jwtTokenProvider.createAccessToken("testUser", "ROLE_USER");
+
+        assertThat(jwtTokenProvider.getLoginId(token)).isEqualTo("testUser");
+        assertThat(jwtTokenProvider.getRole(token)).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("유효한 Access Token은 validateToken이 true를 반환한다")
+    void validateToken_ValidToken_ReturnsTrue() {
+        String token = jwtTokenProvider.createAccessToken("testUser", "ROLE_USER");
+
+        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("위변조된 토큰은 validateToken이 false를 반환한다")
+    void validateToken_TamperedToken_ReturnsFalse() {
+        String token = jwtTokenProvider.createAccessToken("testUser", "ROLE_USER");
+        String tamperedToken = token + "tampered";
+
+        assertThat(jwtTokenProvider.validateToken(tamperedToken)).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 Access Token은 validateToken에서 ExpiredJwtException을 던진다")
+    void validateToken_ExpiredToken_ThrowsExpiredJwtException() {
+        // 만료 시간을 -1초로 설정 → 즉시 만료
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenExpiration", -1000L);
+        String expiredToken = jwtTokenProvider.createAccessToken("testUser", "ROLE_USER");
+
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(expiredToken))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    // ── Refresh Token ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("Refresh Token 생성 후 loginId를 정상적으로 추출할 수 있다")
+    void createRefreshToken_Success() {
+        String token = jwtTokenProvider.createRefreshToken("testUser");
+
+        assertThat(jwtTokenProvider.getLoginId(token)).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("유효한 Refresh Token은 isTokenExpired가 false를 반환한다")
+    void isTokenExpired_ValidToken_ReturnsFalse() {
+        String token = jwtTokenProvider.createRefreshToken("testUser");
+
+        assertThat(jwtTokenProvider.isTokenExpired(token)).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 Refresh Token은 isTokenExpired가 true를 반환한다")
+    void isTokenExpired_ExpiredToken_ReturnsTrue() {
+        ReflectionTestUtils.setField(jwtTokenProvider, "refreshTokenExpiration", -1000L);
+        String expiredToken = jwtTokenProvider.createRefreshToken("testUser");
+
+        assertThat(jwtTokenProvider.isTokenExpired(expiredToken)).isTrue();
+    }
+
+    // ── 기타 ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("getRefreshTokenExpiration은 설정값을 반환한다")
+    void getRefreshTokenExpiration_ReturnsConfiguredValue() {
+        assertThat(jwtTokenProvider.getRefreshTokenExpiration()).isEqualTo(604800000L);
+    }
+
+    @Test
+    @DisplayName("완전히 잘못된 형식의 토큰은 validateToken이 false를 반환한다")
+    void validateToken_InvalidFormat_ReturnsFalse() {
+        assertThat(jwtTokenProvider.validateToken("this.is.not.a.jwt")).isFalse();
+    }
+}


### PR DESCRIPTION
## 개요
- 세션 기반 인증을 JWT 방식으로 전환
## 변경사항
- controller
  - **MemberController**: 로그인 응답에 Access Token(헤더) + Refresh Token(HttpOnly 쿠키) 발급으로 수정, 로그아웃 엔드포인트 추가.
  - **TokenReissueController**: `/api/auth/reissue` - Refresh Token 검증 후 토큰 재발급 추가.
- domain
  - **RefreshToken*: Refresh Token DB 저장 엔티티 추가 (Member와 1:1 관계).
  - **RefreshTokenRepositoty**: RefreshToken CRUD 레포지토리 추가.
- service
  - **MemberService**: login (토큰 발급 + DB 저장), logout (토큰 삭제), reissue (Rotation + 탈취 감지) 메서드 추가.
- config
  - **SecurityConfig**: CSRF 비활성화, 세션 STATELESS, CORS 설정, JwtAuthenticationFilter 등록으로 수정.
- security
  - **JwtAuthenticationFilter**: 매 요청마다 Access Token 검증 후 SecurityContext 저장 필터 추가.
  - **JwtTokenProvider**: Access/Refresh Token 생성 및 검증 컴포넌트 추가.
## 결과
- 서버 세션 의존 제거 → Stateless 구조로 수평 확장 대응
- Refresh Token Rotation 및 탈취 감지로 보안 강화
- HttpOnly 쿠키 + 메모리 저장 전략으로 XSS/CSRF 대응
## 관련PR
- #70
