### PR TITLE
[Refactor] 중복된 CORS 설정 삭제 및 CloudFront도메인 직접 접근 차단

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -89,11 +89,10 @@ public class SecurityConfig {
         public CorsConfigurationSource corsConfigurationSource() {
                 CorsConfiguration config = new CorsConfiguration();
 
-                // 실제 배포 도메인으로 교체 필요
                 config.setAllowedOrigins(List.of(
-                                "http://localhost:5173", // 로컬 개발 (Vite 기본 포트)
-                                "https://your-cloudfront-domain" // 실제 CloudFront 도메인
-                ));
+                                "http://localhost:3000", // 로컬 개발 (Vite 기본 포트)
+                                "https://www.ljh-finance.com", // 실제 CloudFront 도메인
+                                "https://dev.ljh-finance.com"));
                 config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
                 config.setAllowedHeaders(List.of("*"));
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -53,7 +54,7 @@ public class SecurityConfig {
                                 .csrf(csrf -> csrf.disable())
 
                                 // ── CORS: S3/CloudFront 도메인 허용 ─────────────────────
-                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                                .cors(Customizer.withDefaults())
 
                                 // ── 보안 헤더 (기존 CSP 유지) ────────────────────────────
                                 .headers(headers -> headers
@@ -82,27 +83,5 @@ public class SecurityConfig {
                                                 UsernamePasswordAuthenticationFilter.class);
 
                 return http.build();
-        }
-
-        // ── CORS 설정: React(S3/CloudFront) 도메인 허용 ───────────────
-        @Bean
-        public CorsConfigurationSource corsConfigurationSource() {
-                CorsConfiguration config = new CorsConfiguration();
-
-                config.setAllowedOrigins(List.of(
-                                "http://localhost:3000", // 로컬 개발 (Vite 기본 포트)
-                                "https://www.ljh-finance.com", // 실제 CloudFront 도메인
-                                "https://dev.ljh-finance.com"));
-                config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-                config.setAllowedHeaders(List.of("*"));
-
-                // Authorization 헤더를 프론트에서 읽을 수 있도록 허용
-                config.setExposedHeaders(List.of("Authorization"));
-                config.setAllowCredentials(true); // Refresh Token 쿠키 전달 허용
-                config.setMaxAge(3600L);
-
-                UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-                source.registerCorsConfiguration("/**", config);
-                return source;
         }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
@@ -16,9 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**") // API 경로에 대해 CORS 적용
                 .allowedOrigins("http://localhost:3000",
                         "https://www.ljh-finance.com",
-                        "https://dev.ljh-finance.com",
-                        "https://dh90dx2d0udap.cloudfront.net",
-                        "https://d1wcpvhjz8ef5p.cloudfront.net") // React
+                        "https://dev.ljh-finance.com") // React
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
                 .allowedHeaders("*") // 모든 헤더 허용
                 .allowCredentials(true) // 쿠키/인증 정보 포함 허용


### PR DESCRIPTION
## 개요
- **중복제거**: CORS 허가 설정이 기존의 **WebConfig**와 새로 Spring Security 도입 과정에서 추가된 **SecurityConfig**에서 중복.
- **레거시 코드 삭제**: CORS의 허가 Origin에 `ljh-finance` 도메인 도입 전 사용했던 Cloudfront 도메인이 잔재.
## 변경사항
- **WebConfig**: `dh90dx2d0udap.cloudfront.net` 등 Cloudfront 도메인 삭제로 직접 접근 제한.
- **SecurityConfig**: 중복되어 불필요한 `corsConfigurationSource` 빈 삭제 및 `Customizer.withDefaults()`을 통해 **WebConfig**에서 CORS 설정을 받아오게 변경.
## 결과
- **보안**: 불필요한 allowOrigin 삭제를 통해 접근 경로 제한.
- **효율**: 중복된 CORS 설정을 단일화하여 설정의 충돌이나 차후 설정 변경 시 불필요한 중복 수정 방지.
## 관련PR
- #70
