### PR TITLE
[CI] 이중 빌드 비효율 개선

### DIFF
--- a/finance-portfolio-backend/Dockerfile
+++ b/finance-portfolio-backend/Dockerfile
@@ -1,15 +1,11 @@
 # 1단계: 빌드 스테이지
-FROM gradle:8.5-jdk21 AS build
-WORKDIR /home/gradle/src
-COPY --chown=gradle:gradle . .
-# 빌드 시점에 필요한 환경변수가 있다면 여기서 처리하거나, 테스트 제외 빌드
-RUN ./gradlew clean bootJar -x test --no-daemon
+# deploy 워크플로우의 (Sonar) Code Quality Analysis 단계에서 빌드하게 변경
 
 # 2단계: 실행 스테이지
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
-# 빌드 스테이지에서 생성된 jar를 복사 (이름을 app.jar로 고정)
-COPY --from=build /home/gradle/src/build/libs/*.jar app.jar
+# 소나 워크플로우에서 생성된 jar를 복사 (이름을 app.jar로 고정)
+COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 # Graceful Shutdown 설정 추가


### PR DESCRIPTION
## 개요
- **현황**: deploy 워크플로우의 Sonar 테스트 단계와 Dockerfile 내부 빌드 스테이지에서 빌드가 두 번 발생하여 CI/CD 배포 시간이 최대 약 6분 까지 소요되는 상황.
- **문제상황**: 동일한 빌드가 중복 실행되어 배포 시간이 불필요하게 길어짐.

## 변경사항
- **Dockerfile**: 빌드 스테이지를 제거, 실행 스테이지에서 deploy sonar 과정에서 빌드된 jar를 복사하는 방식으로 전환.

## 결과
- **빌드 시간 단축**: 빌드 중복 제거로 CI/CD 배포 시간 단축 및 효율 향상.
  - 캐시 히트 여부에 따라 약 98~142초 개선 - [빌드시간단축](##빌드시간단축)

## 관련이슈
- Closes #78

## 빌드시간단축
### 기존 
  - 6m 7s - 캐시 히트 X 
<img width="567" height="143" alt="Image" src="https://github.com/user-attachments/assets/9d491deb-fde2-456c-99ee-d8e9ef457b5f" />

  - 3m 48s - 캐시 히트 O
<img width="567" height="134" alt="image" src="https://github.com/user-attachments/assets/c9bee157-022b-4c7b-8e2c-9d9ef1a536cc" />

### 변경 후
  - 3m 45s - 캐시 히트 X
<img width="567" height="133" alt="image" src="https://github.com/user-attachments/assets/4b6bf96f-d325-412d-a988-9893d4946907" />

  - 2m 10s - 캐시 히트 O
<img width="567" height="134" alt="image" src="https://github.com/user-attachments/assets/b486ea22-605d-40bd-adc3-b719ec3181af" />


