### PR TITLE
[Chore] Github Actions 버전업

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -18,13 +18,13 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
           fetch-depth: 0
 
     # JDK 세팅 [SONAR]
     - name: (Sonar) Set up JDK 21 
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -33,7 +33,7 @@ jobs:
 
     # [SONAR][성능] 실행 엔진 및 플러그인 캐싱 (20초)
     - name: (Sonar) Cache SonarCloud packages 
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
@@ -66,7 +66,7 @@ jobs:
 
     # [DOCKER] Hub 로그인
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -82,11 +82,11 @@ jobs:
 
     # [성능] Buildx: Docker에 type=gha 캐싱 등 확장 기능 추가
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     # [DOCKER] 이미지 빌드 복사 및 푸시
     - name: Build and Push Docker Image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: ./finance-portfolio-backend
         push: true
@@ -102,7 +102,7 @@ jobs:
 
     # [보안] AWS Credentials 설정 (보안 그룹 제어용)
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -102,7 +102,7 @@ jobs:
 
     # [보안] AWS Credentials 설정 (보안 그룹 제어용)
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -38,7 +38,7 @@ jobs:
 
     # Node.js 설정 및 빌드
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -54,7 +54,7 @@ jobs:
 
     # AWS 권한 설정
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: ./finance-portfolio-frontend
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     
@@ -62,7 +62,7 @@ jobs:
 
     # 소나 실행 엔진 캐싱 (빌드 시간 단축)
     - name: Cache SonarCloud packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar


### PR DESCRIPTION
## 개요
- **현황**: 각 deploy에서 사용 중인  Node.js 20 기반 Actions(actions/checkout 등)가 2026년 6월 2일부터 강제 Node.js 24로 전환될 예정인 상황.
- **문제상황**: 고지된 actions의 버전 업데이트를 하지 않으면 해당 날짜 이후 워크플로우가 정상 동작하지 않을 가능성이 있음.

## 변경사항
- **backend-deploy.yml**
  - actions/checkout@v4 -> v6
  - actions/setup-java@v4 -> v5
  - actions/cache@v4 -> v5
  - docker/login-action@v3 -> v4
  - docker/setup-buildx-action@v3 -> v4
  - docker/build-push-action@v5 -> v7
  - aws-actions/configure-aws-credentials@v2 -> v6

- **frontend-deploy.yml**
  - actions/checkout@v4 -> v6
  - actions/cache@v4 -> v5
  - actions/setup-node@v4 -> v5

## 기대효과
- **안정성**: 차후 버전 불일치로 인한 문제 발생 가능성 사전 차단.

## 관련이슈
- Closes #79