### PR TITLE
[Feat] 프론트 네비게이션 및 404 에러페이지 추가

### DIFF
--- a/finance-portfolio-frontend/sonar-project.properties
+++ b/finance-portfolio-frontend/sonar-project.properties
@@ -16,6 +16,3 @@ sonar.exclusions=**/node_modules/**, dist/**, **/.env, \
 
 sonar.coverage.exclusions=**/main.jsx, **/App.jsx, **/*.css, \
  src/**
-
-# JavaScript 전용 설정
-sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -4,13 +4,17 @@ import axiosInstance from './api/axios';
 import authStore from './api/authStore';
 import './App.css';
 
+import Layout from './components/Layout';
+
 import PostList from './pages/posts/PostList';
 import PostDetail from './pages/posts/PostDetail';
 import PostEditor from './pages/posts/PostEditor';
 import FairValuePage from './pages/finances/FinanceFair';
 import LoginPage from './pages/members/LoginPage';
 import JoinPage from './pages/members/JoinPage';
+import ErrorPage from './pages/global/ErrorPage';
 import PrivateRoute from './components/PrivateRoute';
+
 
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
@@ -38,6 +42,7 @@ function App() {
       });
   }, []);
 
+
   if (!authChecked) {
     return (
       <div className="loading-screen">
@@ -48,32 +53,33 @@ function App() {
 
   return (
     <Routes>
-      {/* 공개 라우트 */}
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/join" element={<JoinPage />} />
+      {/* 레이아웃: 네비게이션, */}
+      <Route element={<Layout />}>
 
-      {/* 인증 필요 라우트 */}
-      <Route path="/" element={
-        <PrivateRoute><PostList /></PrivateRoute>
-      } />
-      <Route path="/posts" element={
-        <PrivateRoute><PostList /></PrivateRoute>
-      } />
-      <Route path="/detail/:id" element={
-        <PrivateRoute><PostDetail /></PrivateRoute>
-      } />
-      <Route path="/editor" element={
-        <PrivateRoute><PostEditor /></PrivateRoute>
-      } />
-      <Route path="/editor/:id" element={
-        <PrivateRoute><PostEditor /></PrivateRoute>
-      } />
-      <Route path="/finance/fair" element={
-        <PrivateRoute><FairValuePage /></PrivateRoute>
-      } />
+        {/* 공개 라우트 - 게시판 */}
+        <Route path="/" element={<PostList />} />
+        <Route path="/posts" element={<PostList />} />
+        <Route path="/detail/:id" element={<PostDetail />} />
+        {/* 공개 라우트 - 금융계산기 */}
+        <Route path="/finance/fair" element={<FairValuePage />} />
+        {/* 공개 라우트 - 인증 인가 */}
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/join" element={<JoinPage />} />
 
-      {/* 없는 경로는 로그인 페이지로 */}
-      <Route path="*" element={<Navigate to="/login" replace />} />
+        {/* 인증 필요 라우트 */}
+        <Route path="/editor" element={
+          <PrivateRoute><PostEditor /></PrivateRoute>
+        } />
+        <Route path="/editor/:id" element={
+          <PrivateRoute><PostEditor /></PrivateRoute>
+        } />
+
+        {/* 에러 라우트 */}
+        <Route path="/error" element={<ErrorPage />} />
+
+        {/* 명시한 엔드포인트 이외엔 에러 페이지로 */}
+        <Route path="*" element={<ErrorPage status="404" message="페이지를 찾을 수 없습니다." />} />
+      </Route>
     </Routes>
   );
 }

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -18,7 +18,7 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
     (config) => {
         const token = authStore.getToken();
-        if (token) {
+        if (token && token !== 'null' && token !== 'undefined') {
             config.headers['Authorization'] = `Bearer ${token}`;
         }
         return config;

--- a/finance-portfolio-frontend/src/components/Layout.jsx
+++ b/finance-portfolio-frontend/src/components/Layout.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Navbar from './Navbar';
+
+const Layout = () => {
+    return (
+        <>
+            <Navbar />
+            <main>
+                <Outlet />
+            </main>
+        </>
+    );
+};
+
+export default Layout;

--- a/finance-portfolio-frontend/src/components/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/Navbar.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import authStore from '../api/authStore';
+
+
+const Navbar = () => {
+    const navigate = useNavigate();
+
+    const onLogout = async () => {
+        try {
+            // 백엔드에 로그아웃 요청 (Refresh Token DB 삭제 + 쿠키 만료)
+            await axiosInstance.post('/member/logout');
+        } catch {
+            // 로그아웃은 에러가 나도 클라이언트 상태는 정리합니다
+        } finally {
+            authStore.clearToken();
+            navigate('/login');
+        }
+    };
+
+
+    return (
+        <nav className="navbar navbar-expand-lg navbar-dark bg-dark px-4"
+            style={{}}>
+            <span className="navbar-brand">Finance Portfolio Navigation</span>
+            <div className="d-flex gap-3">
+                <NavLink
+                    to="/post"
+                    className={({ isActive }) =>
+                        'nav-link' + (isActive ? ' text-white fw-bold' : ' text-secondary')
+                    }
+                >
+                    게시판
+                </NavLink>
+                <NavLink
+                    to="/finance/fair"
+                    className={({ isActive }) =>
+                        'nav-link' + (isActive ? ' text-white fw-bold' : ' text-secondary')
+                    }
+                >
+                    금융계산기
+                </NavLink>
+            </div>
+
+            {/* 로그인 관련 */}
+            <div className="ms-auto d-flex align-items-center gap-3">
+                {authStore.isLoggedIn() ? (
+                    <>
+                        <span className="text-light badge bg-secondary px-3 py-2">
+                            `사용자`님 {/* authStore.nickname 교체 예정 */}
+                        </span>
+                        <button onClick={onLogout} className="btn btn-outline-light btn-sm">
+                            로그아웃
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <span className="text-secondary small">로그인이 필요합니다</span>
+                        <button
+                            onClick={() => navigate('/login')}
+                            className="btn btn-primary btn-sm px-3"
+                        >
+                            로그인
+                        </button>
+                    </>
+                )}
+            </div>
+        </nav>
+    );
+};
+
+export default Navbar;

--- a/finance-portfolio-frontend/src/components/PrivateRoute.jsx
+++ b/finance-portfolio-frontend/src/components/PrivateRoute.jsx
@@ -4,7 +4,6 @@ import authStore from '../api/authStore';
 
 // 로그인하지 않은 사용자를 로그인 페이지로 리다이렉트합니다.
 // Access Token이 메모리에 없으면 미인증 상태로 판단합니다.
-// (페이지 새로고침 시 토큰이 초기화되는 문제는 아래 주석 참고)
 const PrivateRoute = ({ children }) => {
     if (!authStore.isLoggedIn()) {
         return <Navigate to="/login" replace />;
@@ -14,22 +13,3 @@ const PrivateRoute = ({ children }) => {
 
 export default PrivateRoute;
 
-/*
- * [새로고침 시 로그인 유지 처리]
- *
- * 메모리 저장 방식 특성상 새로고침하면 Access Token이 사라집니다.
- * 이를 해결하려면 앱 최초 마운트 시(App.jsx) /auth/reissue를 한 번 호출해서
- * Refresh Token 쿠키로 새 Access Token을 받아오는 "silent refresh" 패턴을 쓰면 됩니다.
- *
- * 예시 (App.jsx에서 사용):
- *
- * useEffect(() => {
- *     axiosInstance.post('/auth/reissue')
- *         .then(res => {
- *             const token = res.headers['authorization']?.replace('Bearer ', '');
- *             if (token) authStore.setToken(token);
- *         })
- *         .catch(() => {}) // 비로그인 상태면 무시
- *         .finally(() => setAuthChecked(true));
- * }, []);
- */

--- a/finance-portfolio-frontend/src/pages/global/ErrorPage.jsx
+++ b/finance-portfolio-frontend/src/pages/global/ErrorPage.jsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+
+const ErrorPage = ({ status, message }) => {
+    const navigate = useNavigate();
+
+    return (
+        <div className="container mt-5 text-center">
+            <h2>{status || '오류'}</h2>
+            <p>{message || '알 수 없는 오류가 발생했습니다.'}</p>
+            <button onClick={() => navigate('/')} className="btn btn-secondary">
+                홈으로
+            </button>
+        </div>
+    );
+};
+
+export default ErrorPage;

--- a/finance-portfolio-frontend/src/pages/posts/PostList.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostList.jsx
@@ -35,32 +35,16 @@ const PostList = () => {
         }
     };
 
-    const onLogout = async () => {
-        try {
-            // 백엔드에 로그아웃 요청 (Refresh Token DB 삭제 + 쿠키 만료)
-            await axiosInstance.post('/member/logout');
-        } catch {
-            // 로그아웃은 에러가 나도 클라이언트 상태는 정리합니다
-        } finally {
-            authStore.clearToken();
-            navigate('/login');
-        }
-    };
-
     if (loading) return <div>로딩 중...</div>;
 
     return (
         <div className="container mt-5">
             <div className="d-flex justify-content-between align-items-center mb-3">
                 <h2>금융 포트폴리오 게시판</h2>
-                <button onClick={onLogout} className="btn btn-outline-danger btn-sm">
-                    로그아웃
-                </button>
             </div>
 
             <div className="mb-3 d-flex gap-2">
                 <button onClick={() => navigate('/editor')} className="btn btn-warning">새 글</button>
-                <button onClick={() => navigate('/finance/fair')} className="btn btn-warning">계산하기</button>
                 <button onClick={onCleanUpFiles} className="btn btn-warning">미참조 이미지 삭제</button>
             </div>
 


### PR DESCRIPTION
## 개요
- **문제상황**
  - 페이지 전체가 새로 로드되면서 CSR의 장점을 살리지 못하고 사용자 편의성이 저하.
  - 또한 로그인 상태를 프론트 페이지에서 확인할 수 없어 개발 편의성이 저하.
- **개선방안**: 페이지 상단 네비게이션을 추가하여 필요한 컴포넌트만 교체되도록 개선.
-   #76: 의 사전작업의 일환으로 404 에러페이지 추가.
## 변경사항
- **App.jsx**: 에러페이지, 감싸는 레이아웃 (네비게이션) 추가 및 라우트 인증 조건 재조정.
- **Layout.jsx**: 부모 라우트용 jsx로 각종 `pages` jsx를 네비게이션 jsx가 품는 형태.
- **Navbar.jsx**:  네비게이션 - 게시판, 계산기 navigate와 로그인 여부를 출력.
- **ErrorPage.jsx**: 404 에러시 라우팅 되는 jsx 페이지.
- **PostList.jsx**: 로그아웃 버튼 네비게이션에 이양.
## 결과
- **UI/UX**: 상단 네비게이션을 통한 빠른 페이지 전환 및 로그인 여부 확인 가능.
## 관련이슈
- Closes #77
- #76
- #83