### PR TITLE
[Feat] 프론트 글로벌 예외처리 추가 및 전체 예외처리 고도화

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/CustomUserDetailsService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 아이디를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("아이디를 찾을 수 없습니다."));
         return User.builder()
                 .username(member.getLoginId())
                 .password(member.getPassword())

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                                 .csrf(csrf -> csrf.disable())
 
                                 // ── CORS: S3/CloudFront 도메인 허용 ─────────────────────
-                                .cors(Customizer.withDefaults())
+                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
                                 // ── 보안 헤더 (기존 CSP 유지) ────────────────────────────
                                 .headers(headers -> headers
@@ -72,6 +72,15 @@ public class SecurityConfig {
                                 .sessionManagement(session -> session
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
+                                // ── 인가 설정 ────────────────────────────────────────────
+                                .authorizeHttpRequests(auth -> auth
+                                                .requestMatchers("/error").permitAll()
+                                                .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                                                .requestMatchers("/api/member/join", "/api/member/login").permitAll()
+                                                .requestMatchers("/api/auth/reissue").permitAll()
+                                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                                .anyRequest().authenticated())
+
                                 // 인증되지 않은 사용자가 보호된 리소스에 접근 시 응답 설정
                                 .exceptionHandling(ex -> ex
                                                 .authenticationEntryPoint((request, response, authException) -> {
@@ -79,18 +88,31 @@ public class SecurityConfig {
                                                         response.setContentType("application/json;charset=UTF-8");
                                                         response.getWriter().write("{\"error\": \"UNAUTHORIZED\"}");
                                                 }))
-                                // ── 인가 설정 ────────────────────────────────────────────
-                                .authorizeHttpRequests(auth -> auth
-                                                .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
-                                                .requestMatchers("/api/member/join", "/api/member/login").permitAll()
-                                                .requestMatchers("/api/auth/reissue").permitAll()
-                                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                                                .anyRequest().authenticated())
 
                                 // ── JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록 ──
                                 .addFilterBefore(jwtAuthenticationFilter(),
                                                 UsernamePasswordAuthenticationFilter.class);
 
                 return http.build();
+        }
+
+        @Bean
+        public CorsConfigurationSource corsConfigurationSource() {
+                CorsConfiguration configuration = new CorsConfiguration();
+
+                // CloudFront 통합 관리로 자기 경로 참조하기 때문에 Origin 허용 필수는 아님
+                configuration.setAllowedOrigins(List.of(
+                                "http://localhost:3000",
+                                "https://www.ljh-finance.com",
+                                "https://dev.ljh-finance.com"));
+                configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+                configuration.setAllowedHeaders(List.of("*"));
+                configuration.setAllowCredentials(true);
+                configuration.setExposedHeaders(List.of("Authorization"));
+                configuration.setMaxAge(3600L);
+
+                UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+                source.registerCorsConfiguration("/**", configuration); // 모든 경로에 적용
+                return source;
         }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -21,6 +21,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import com.finance.finportfolio.global.security.filter.JwtAuthenticationFilter;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.util.List;
 
 @Configuration
@@ -70,6 +72,13 @@ public class SecurityConfig {
                                 .sessionManagement(session -> session
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
+                                // 인증되지 않은 사용자가 보호된 리소스에 접근 시 응답 설정
+                                .exceptionHandling(ex -> ex
+                                                .authenticationEntryPoint((request, response, authException) -> {
+                                                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                                                        response.setContentType("application/json;charset=UTF-8");
+                                                        response.getWriter().write("{\"error\": \"UNAUTHORIZED\"}");
+                                                }))
                                 // ── 인가 설정 ────────────────────────────────────────────
                                 .authorizeHttpRequests(auth -> auth
                                                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/WebConfig.java
@@ -11,19 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**") // API 경로에 대해 CORS 적용
-                .allowedOrigins("http://localhost:3000",
-                        "https://www.ljh-finance.com",
-                        "https://dev.ljh-finance.com") // React
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
-                .allowedHeaders("*") // 모든 헤더 허용
-                .allowCredentials(true) // 쿠키/인증 정보 포함 허용
-                .exposedHeaders("Authorization") // Authorization 헤더 허용(Login)
-                .maxAge(3600); // 프리플라이트(Preflight) 요청 캐싱 시간 (초)
-    }
-
     @Bean // http에서 delete, put, patch 메서드를 사용 가능
     public HiddenHttpMethodFilter hiddenHttpMethodFilter() {
         return new HiddenHttpMethodFilter();

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/ErrorResponse.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/ErrorResponse.java
@@ -1,11 +1,15 @@
 package com.finance.finportfolio.global.error;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 // ErrorResponse - 예외 처리용 DTO
 @Getter
 @Builder
+@NoArgsConstructor // 기본 생성자 추가
+@AllArgsConstructor // 모든 필드 생성자 추가
 public class ErrorResponse {
     private int status;
     private String code;

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.finance.finportfolio.global.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -64,6 +66,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleUsernameNotFoundException(UsernameNotFoundException e) {
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    // 1. 로그인 실패 (사용자 입력 오류)
+    // 401 Unauthorized
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<String> handleBadCredentials(BadCredentialsException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("아이디 또는 비밀번호가 일치하지 않습니다.");
+    }
+
+    // 2. 그 외 모든 인증 실패 (토큰 문제 등)
+    // 401 Unauthorized
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<String> handleAuthException(AuthenticationException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 세션이 만료되었거나 유효하지 않습니다.");
     }
 
     // 그 외 예상치 못한 모든 에러(500) 처리

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.finance.finportfolio.global.error;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -17,84 +19,98 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice // 모든 컨트롤러의 예외를 여기서 캐치
 public class GlobalExceptionHandler {
 
-    // 인자 예외
+    // -- 공통 메서드 --
+
+    // 공통 응답 생성 메서드
+    private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus status, String code, String message) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(status.value())
+                .code(code)
+                .message(message)
+                .build();
+        return new ResponseEntity<>(response, status);
+    }
+
+    // 메시지 빈 값 대비
+    // e.getMessage()로 에러 메시지 전달 받았으면 exceptionMessage, 아니면 defaultMessage 반환
+    private String resolveMessage(String exceptionMessage, String defaultMessage) {
+        return Optional.ofNullable(exceptionMessage)
+                .filter(msg -> !msg.isBlank())
+                .orElse(defaultMessage);
+    }
+
+    // -- 예외 핸들러 --
+
     // 400 BAD_REQUEST
+    // INVALID_INPUT: 잘못된 인자
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-        log.error("잘못된 인자 유입: {}", e.getMessage());
-
-        ErrorResponse response = ErrorResponse.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
-                .code("BAD_REQUEST")
-                .message(e.getMessage())
-                .build();
-
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        String message = resolveMessage(e.getMessage(), "🛠입력 데이터가 올바르지 않습니다.");
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "INVALID_INPUT", message);
     }
 
-    // 상태 예외
-    // 400 badRequest
+    // 400 BAD_REQUEST
+    // ILLEGAL_STATE: 잘못된 상태
     @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<String> handleIllegalStateException(IllegalStateException e) {
-
-        return ResponseEntity.badRequest().body(e.getMessage());
+    public ResponseEntity<ErrorResponse> handleBadRequestException(IllegalStateException e) {
+        String message = resolveMessage(e.getMessage(), "🛠현재 요청을 처리할 수 없는 상태입니다.");
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "ILLEGAL_STATE", message);
     }
 
-    // @Valid 검증 실패
-    // 400 badRequest
+    // 400 BAD_REQUEST
+    // VALIDATION_ERROR: @Valid 검증 실패
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        // @Valid 조건에 적어놓은 message 가져옴(명시하지 않은 경우 Hibernate Validator에 내장된 기본 메시지)
         String message = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> error.getDefaultMessage())
+                .map(error -> String.format("[%s] %s", error.getField(), error.getDefaultMessage()))
                 .findFirst()
-                .orElse("입력값이 올바르지 않습니다.");
+                .orElse("🛠입력값이 올바르지 않습니다.");
 
-        return ResponseEntity.badRequest().body(message);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
     }
 
-    // 중복 아이디 커스텀 예외
-    // 409 Conflict
+    // 401 UNAUTHORIZED
+    // 401: 인증 실패 통합 관리(아이디 조회 실패, 비밀번호 오입력 등 각종 로그인 실패)
+    @ExceptionHandler({
+            UsernameNotFoundException.class,
+            BadCredentialsException.class,
+            AuthenticationException.class })
+    public ResponseEntity<ErrorResponse> handleAuthException(Exception e) {
+        String defaultMsg = "🛠인증에 실패하였습니다.";
+        String code = "UNAUTHORIZED";
+
+        // 1순위: 가장 구체적인 '사용자 없음'
+        if (e instanceof UsernameNotFoundException) {
+            defaultMsg = "🛠존재하지 않는 사용자입니다.";
+            code = "USER_NOT_FOUND";
+        }
+        // 2순위: '비밀번호 틀림'
+        else if (e instanceof BadCredentialsException) {
+            defaultMsg = "🛠아이디 또는 비밀번호가 일치하지 않습니다.";
+            code = "BAD_CREDENTIALS";
+        }
+        // 3순위: 그 외 기타 인증 에러 (토큰 만료, 접근 거부 등)
+        // 여기서는 기본 설정된 defaultMsg와 code가 사용됩니다.
+
+        String message = resolveMessage(e.getMessage(), defaultMsg);
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, code, message);
+    }
+
+    // 409 CONFLICT
+    // DUPLICATE_RESOURCE: 중복 아이디 커스텀 예외
     @ExceptionHandler(DuplicateResourceException.class)
-    public ResponseEntity<String> handleDuplicateException(DuplicateResourceException e) {
-
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    public ResponseEntity<ErrorResponse> handleDuplicateException(DuplicateResourceException e) {
+        String message = resolveMessage(e.getMessage(), "🛠이미 존재하는 리소스입니다.");
+        return buildErrorResponse(HttpStatus.CONFLICT, "DUPLICATE_RESOURCE", message);
     }
 
-    // 아이디 못찾음 예외
-    // 401 Unauthorized
-    @ExceptionHandler(UsernameNotFoundException.class)
-    public ResponseEntity<String> handleUsernameNotFoundException(UsernameNotFoundException e) {
-
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-    }
-
-    // 1. 로그인 실패 (사용자 입력 오류)
-    // 401 Unauthorized
-    @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<String> handleBadCredentials(BadCredentialsException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("아이디 또는 비밀번호가 일치하지 않습니다.");
-    }
-
-    // 2. 그 외 모든 인증 실패 (토큰 문제 등)
-    // 401 Unauthorized
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<String> handleAuthException(AuthenticationException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 세션이 만료되었거나 유효하지 않습니다.");
-    }
-
-    // 그 외 예상치 못한 모든 에러(500) 처리
     // 500 INTERNAL_SERVER_ERROR
+    // INTERNAL_SERVER_ERROR: 그 외 예상치 못한 모든 에러(500) 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleAllException(Exception e) {
-        log.error("서버 내부 에러 발생!", e); // 스택 트레이스 전체 로그 기록
-
-        ErrorResponse response = ErrorResponse.builder()
-                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                .code("INTERNAL_SERVER_ERROR")
-                .message("서버 이용에 불편을 드려 죄송합니다. 관리자에게 문의하세요.")
-                .build();
-
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        log.error("서버 내부 에러 발생!", e);
+        String message = resolveMessage(e.getMessage(), "예상치 못한 문제가 발생했습니다. 이용에 불편을 드려 죄송합니다.");
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", message);
     }
-
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/JwtAuthenticationFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/JwtAuthenticationFilter.java
@@ -31,25 +31,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        // 토큰 없으면 다음 필터로 (인증 불필요한 엔드포인트는 SecurityConfig에서 처리)
-        if (!StringUtils.hasText(token)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        try {
-            if (jwtTokenProvider.validateToken(token)) {
-                setAuthentication(token);
+        if (StringUtils.hasText(token)) {
+            try {
+                if (jwtTokenProvider.validateToken(token)) {
+                    // 1. 인증 정보 설정 시 발생할 수 있는 예외 방지
+                    setAuthentication(token);
+                }
+            } catch (ExpiredJwtException e) {
+                log.warn("만료된 Access Token: {}", request.getRequestURI());
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"error\": \"ACCESS_TOKEN_EXPIRED\"}");
+                return; // 만료 시 여기서 종료
+            } catch (Exception e) {
+                // 2. 그 외 모든 예외는 로그를 남기고 인증되지 않은 상태로 진행 (500 에러 방어)
+                log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
+                SecurityContextHolder.clearContext();
             }
-        } catch (ExpiredJwtException e) {
-            // 만료된 토큰 → 401 반환 (프론트에서 /reissue 요청하도록 유도)
-            log.warn("만료된 Access Token: {}", request.getRequestURI());
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json;charset=UTF-8");
-            response.getWriter().write("{\"error\": \"ACCESS_TOKEN_EXPIRED\"}");
-            return;
         }
 
+        // 3. 토큰이 없거나, 유효하지 않거나, 에러가 나더라도 다음 필터로 넘겨야 permitAll이 작동함
         filterChain.doFilter(request, response);
     }
 
@@ -67,12 +68,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String loginId = jwtTokenProvider.getLoginId(token);
         String role = jwtTokenProvider.getRole(token);
 
-        // DB 조회 없이 토큰 클레임만으로 인증 객체 생성 → 성능 최적화
-        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                loginId,
-                null,
-                List.of(new SimpleGrantedAuthority(role)));
+        if (loginId != null && role != null) {
+            // Spring Security의 hasRole()은 기본적으로 "ROLE_" 접두사를 기대합니다.
+            String grantedRole = role.startsWith("ROLE_") ? role : "ROLE_" + role;
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    loginId,
+                    null,
+                    List.of(new SimpleGrantedAuthority(grantedRole)));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
     }
 }

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
         static: ap-northeast-2
         instance-profile: false
 
+server:
+  error:
+    include-stacktrace: never      # 스택트레이스 노출 차단 (필수)
+    include-message: never         # 에러 메시지 노출 차단
+    include-exception: false       # 예외 클래스명 노출 차단
+    include-binding-errors: never  # 파라미터 바인딩 에러 노출 차단
+
 cloudfront:
   custom:
     header:

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/CustomUserDetailsServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/CustomUserDetailsServiceTest.java
@@ -61,6 +61,6 @@ class CustomUserDetailsServiceTest {
         // when & then
         assertThatThrownBy(() -> userDetailsService.loadUserByUsername("unknownUser"))
                 .isInstanceOf(UsernameNotFoundException.class)
-                .hasMessageContaining("해당 아이디를 찾을 수 없습니다.");
+                .hasMessageContaining("아이디를 찾을 수 없습니다.");
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
@@ -1,0 +1,158 @@
+package com.finance.finportfolio.global.config;
+
+import com.finance.finportfolio.domain.member.controller.MemberController;
+import com.finance.finportfolio.domain.member.service.MemberService;
+import com.finance.finportfolio.domain.post.controller.PostController;
+import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*; // 이 줄이 print()를 가능하게 합니다.
+
+/**
+ * SecurityConfig의 authenticationEntryPoint 동작 검증 테스트
+ *
+ * 검증 대상:
+ * 1. 인증 없이 보호된 리소스 접근 시 401 + UNAUTHORIZED JSON 반환
+ * 2. 공개 허용 경로(GET /api/posts/**)는 인증 없이 통과
+ * 3. 인증 후 보호된 리소스 접근 가능
+ */
+@WebMvcTest({ PostController.class, MemberController.class })
+@Import(SecurityConfig.class)
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // PostController 의존성 Mock
+    @MockBean
+    private com.finance.finportfolio.domain.post.service.PostService postService;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @Test
+    @DisplayName("CORS Preflight 요청(OPTIONS)은 인증 없이 200 OK를 반환해야 한다")
+    void corsPreflightTest() throws Exception {
+        mockMvc.perform(options("/api/posts")
+                .header("Origin", "http://localhost:3000")
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Access-Control-Allow-Origin"))
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"));
+    }
+
+    @Test
+    @DisplayName("로그인 경로는 permitAll이므로 접근 시 401이 발생하지 않는다")
+    void loginPath_ShouldNotReturn401() throws Exception {
+        mockMvc.perform(post("/api/member/login") // POST로 변경
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"test@test.com\", \"password\":\"1234\"}")) // 가짜 바디
+                .andDo(print())
+                .andExpect(result -> org.assertj.core.api.Assertions
+                        .assertThat(result.getResponse().getStatus())
+                        .isNotEqualTo(401));
+    }
+
+    @Test
+    @DisplayName("인증이 필요한 경로에 토큰 없이 접근하면 401 에러가 발생해야 한다")
+    void authenticatedPathFailTest() throws Exception {
+        mockMvc.perform(get("/api/admin/some-resource")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized()); // Custom EntryPoint 작동 확인
+    }
+
+    // ── authenticationEntryPoint 핵심 검증 ────────────────────
+
+    @Test
+    @DisplayName("인증 없이 보호된 엔드포인트에 접근하면 401과 UNAUTHORIZED JSON을 반환한다")
+    void accessProtectedResource_WithoutAuth_Returns401WithJson() throws Exception {
+        // POST /api/posts 는 anyRequest().authenticated() 대상
+        mockMvc.perform(post("/api/posts")
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 DELETE 요청을 하면 401과 UNAUTHORIZED JSON을 반환한다")
+    void deletePost_WithoutAuth_Returns401WithJson() throws Exception {
+        mockMvc.perform(delete("/api/posts/1"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 PATCH 요청을 하면 401과 UNAUTHORIZED JSON을 반환한다")
+    void patchPost_WithoutAuth_Returns401WithJson() throws Exception {
+        mockMvc.perform(patch("/api/posts/1")
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+    }
+
+    // ── 공개 허용 경로 검증 ────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /api/posts 는 인증 없이도 200을 반환한다 (permitAll)")
+    void getAllPosts_WithoutAuth_Returns200() throws Exception {
+        // postService.getAllPosts()는 기본 Mock → 빈 리스트 반환
+        org.mockito.BDDMockito.given(postService.getAllPosts())
+                .willReturn(java.util.List.of());
+
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GET /api/posts/{id} 는 인증 없이도 접근 가능하다 (permitAll)")
+    void getPostById_WithoutAuth_IsPermitted() throws Exception {
+        // 존재하지 않는 ID → 서비스에서 예외 발생하더라도 인증 문제는 아님
+        // 여기서는 401이 아닌 것만 확인 (404 or 400은 서비스 레이어 동작)
+        mockMvc.perform(get("/api/posts/999"))
+                .andExpect(result -> org.assertj.core.api.Assertions
+                        .assertThat(result.getResponse().getStatus())
+                        .isNotEqualTo(401));
+    }
+
+    // ── 응답 형식 검증 ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("401 응답의 Content-Type은 application/json;charset=UTF-8이어야 한다")
+    void unauthorizedResponse_ContentType_IsJson() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
+    }
+
+    @Test
+    @DisplayName("401 응답 바디에 error 필드가 UNAUTHORIZED 값으로 포함되어야 한다")
+    void unauthorizedResponse_Body_ContainsErrorField() throws Exception {
+        mockMvc.perform(delete("/api/posts/1"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,74 @@
+package com.finance.finportfolio.global.error;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebMvcTest(controllers = TestExceptionController.class, excludeAutoConfiguration = { SecurityAutoConfiguration.class })
+@Import(GlobalExceptionHandler.class) // 핸들러를 테스트 환경에 주입
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("IllegalArgumentException 발생 시 400 에러와 커스텀 메시지를 반환한다")
+    void handleIllegalArgumentExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/illegal-argument"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value("특정 값이 잘못되었습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("메시지 없이 IllegalStateException 발생 시 🛠 기본 메시지를 반환한다")
+    void handleIllegalStateExceptionDefaultTest() throws Exception {
+        mockMvc.perform(get("/test/illegal-state-default"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("ILLEGAL_STATE"))
+                .andExpect(jsonPath("$.message").value("🛠현재 요청을 처리할 수 없는 상태입니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("BadCredentialsException 발생 시 401 에러와 전용 코드를 반환한다")
+    void handleBadCredentialsTest() throws Exception {
+        mockMvc.perform(get("/test/bad-credentials"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("BAD_CREDENTIALS"))
+                .andExpect(jsonPath("$.message").value("비밀번호 불일치"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("DuplicateResourceException 발생 시 409 에러를 반환한다")
+    void handleDuplicateExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/duplicate"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_RESOURCE"))
+                .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("예상치 못한 RuntimeException 발생 시 500 에러를 반환한다")
+    void handleAllExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/runtime"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value("DB 연결 오류"))
+                .andDo(print());
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
@@ -1,0 +1,35 @@
+package com.finance.finportfolio.global.error;
+
+import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.authentication.BadCredentialsException;
+
+@RestController
+public class TestExceptionController {
+
+    @GetMapping("/test/illegal-argument")
+    public void throwIllegalArgument() {
+        throw new IllegalArgumentException("특정 값이 잘못되었습니다.");
+    }
+
+    @GetMapping("/test/illegal-state-default")
+    public void throwIllegalStateDefault() {
+        throw new IllegalStateException(""); // 메시지 비움 -> 🛠 기본 메시지 작동 확인
+    }
+
+    @GetMapping("/test/bad-credentials")
+    public void throwBadCredentials() {
+        throw new BadCredentialsException("비밀번호 불일치");
+    }
+
+    @GetMapping("/test/duplicate")
+    public void throwDuplicate() {
+        throw new DuplicateResourceException("이미 가입된 이메일입니다.");
+    }
+
+    @GetMapping("/test/runtime")
+    public void throwRuntime() {
+        throw new RuntimeException("DB 연결 오류");
+    }
+}

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import axiosInstance from './api/axios';
 import authStore from './store/authStore';
 import './App.css';
 
@@ -13,33 +12,46 @@ import FairValuePage from './pages/finances/FinanceFair';
 import LoginPage from './pages/members/LoginPage';
 import JoinPage from './pages/members/JoinPage';
 import ErrorPage from './pages/common/ErrorPage';
-import PrivateRoute from './components/common/PrivateRoute';
+import PrivateRoute from './components/auth/PrivateRoute';
+import { reissueMember } from './api/memberApi';
 
 
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
 
+  // 새로고침 혹은 사이트 처음 접속 시 실행
   useEffect(() => {
-    // 로그인/회원가입 페이지에서는 silent refresh 시도 안 함
-    if (globalThis.location.pathname === '/login' || globalThis.location.pathname === '/join') {
-      setAuthChecked(true);
-      return;
-    }
-    // Silent Refresh: 새로고침 후에도 Refresh Token 쿠키가 살아있으면 자동 로그인 유지
-    axiosInstance.post('/auth/reissue')
-      .then((res) => {
-        const token = res.headers['authorization']?.replace('Bearer ', '');
-        if (token) {
+    // 1. async 로직을 별도 함수로 분리
+    const initAuth = async () => {
+      const pathname = globalThis.location.pathname;
+
+      // 로그인/회원가입 페이지에서는 silent refresh 시도 안 함
+      if (pathname === '/login' || pathname === '/join') {
+        setAuthChecked(true);
+        return;
+      }
+
+      try {
+        // Silent Refresh 시도
+        const response = await reissueMember();
+        // memberApi의 응답 구조에 따라 적절히 수정 (예: response.data)
+        const { status, message, token } = response;
+
+        if ((status === 200 || status === 201) && token) {
+          console.log("자동 로그인 성공:", message);
           authStore.setToken(token);
         }
-      })
-      .catch(() => {
-        // Refresh Token이 없거나 만료됨 → 비로그인 상태 유지 (정상 케이스)
+      } catch (error) {
+        // 여기서 에러 처리는 '조용히' 실패하게 두는 것이 좋습니다.
+        // 세션이 없으면 그냥 로그아웃 상태로 시작하는 것이니까요.
+        console.warn(error);
         authStore.clearToken();
-      })
-      .finally(() => {
+      } finally {
         setAuthChecked(true);
-      });
+      }
+    };
+
+    initAuth();
   }, []);
 
 
@@ -75,7 +87,7 @@ function App() {
         {/* 에러 라우트 */}
         <Route path="/error" element={<ErrorPage />} />
 
-        {/* 명시한 엔드포인트 이외엔 에러 페이지로 */}
+        {/* 명시한 엔드포인트 이외엔 404 */}
         <Route path="*" element={<ErrorPage status="404" message="페이지를 찾을 수 없습니다." />} />
       </Route>
     </Routes>

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -14,9 +14,14 @@ const axiosInstance = axios.create({
     },
 });
 
-// ── 요청 인터셉터: Access Token 자동 첨부 ──────────────────
+// ── 요청 인터셉터(REQUEST): Access Token 자동 첨부 ──────────────────
 axiosInstance.interceptors.request.use(
     (config) => {
+        // reissue 요청일 때는 기존 토큰을 첨부하지 않음
+        if (config.url?.includes('/auth/reissue')) {
+            return config;
+        }
+
         const token = authStore.getToken();
         if (token && token !== 'null' && token !== 'undefined') {
             config.headers['Authorization'] = `Bearer ${token}`;
@@ -41,24 +46,47 @@ const processPendingQueue = (error, token = null) => {
     pendingQueue = [];
 };
 
-// ── 응답 인터셉터: 토큰 만료 시 자동 재발급 ───────────────
+// ── 응답 인터셉터(RESPONSE): 에러 처리, 만료 토큰 재발급 ───────────────
 axiosInstance.interceptors.response.use(
+    // 정상 response는 response 그대로 전달
     (response) => response,
+    // 에러가 난 경우에는 토큰 재발급 절차 진행
     async (error) => {
         const originalRequest = error.config;
 
-        // Silent Refresh 실패(비로그인 상태)는 조용히 넘깁니다
+        // reissue 요청 자체가 실패했을 때
         if (originalRequest.url === '/auth/reissue') {
+            authStore.clearToken();
+            isRefreshing = false;
+            processPendingQueue(error); // 대기 중인 다른 요청들 종료
+
+            // 리프레시 토큰도 만료된 것이므로 로그인 페이지로 이동
+            globalThis.location.href = '/login';
             throw error;
         }
 
+        // 일반 API 에러
         // ACCESS_TOKEN_EXPIRED 에러이고 재시도 안 한 요청이면 재발급 시도
         const isExpired =
             error.response?.status === 401 &&
             error.response?.data?.error === 'ACCESS_TOKEN_EXPIRED' &&
             !originalRequest._retry;
 
+        // 토큰 만료 이외 에러 
         if (!isExpired) {
+            const status = error.response?.status || 500;
+            const message = error.response?.data?.message || '알 수 없는 오류가 발생했습니다.';
+
+            // 개발 환경에서만 에러 상세 출력
+            if (import.meta.env.DEV) {
+                console.error(`[API Error] Status: ${status}, Message: ${message}`);
+            }
+
+            if (status === 404 || status >= 500) {
+                // 쿼리 스트링으로 데이터 전달
+                globalThis.location.href = `/error?status=${status}&message=${encodeURIComponent(message)}`;
+            }
+
             throw error;
         }
 
@@ -75,10 +103,19 @@ axiosInstance.interceptors.response.use(
         originalRequest._retry = true;
         isRefreshing = true;
 
+        // 실제 엑세스 토큰 재발급 파트
         try {
-            // Refresh Token은 HttpOnly 쿠키로 자동 전송됩니다
+            // Refresh Token은 HttpOnly 쿠키로 자동 전송(서버가 직접 쏨)
+            // 엑세스 토큰 재발급 `axiosInstance.post('/auth/reissue')`
+            // status: 200, data: "토큰이 재발급되었습니다."
+            // status: 400, data: "유효하지 않은 Refresh Token입니다."
+            // status: 400, data: "존재하지 않는 회원입니다."
+            // status: 400, data: "로그인 상태가 아닙니다."
+            // status: 400, data: "Refresh Token이 일치하지 않습니다."
             const response = await axiosInstance.post('/auth/reissue');
-            const newToken = response.headers['authorization']?.replace('Bearer ', '');
+            const authHeader = response.headers['authorization'] || response.headers['Authorization'];
+            const newToken = authHeader?.replace('Bearer ', '');
+
 
             if (!newToken) throw new Error('재발급된 토큰이 없습니다.');
 

--- a/finance-portfolio-frontend/src/api/financeApi.js
+++ b/finance-portfolio-frontend/src/api/financeApi.js
@@ -7,12 +7,8 @@ import axiosInstance from './axios';
      * expectedYield: 기대수익률
      */
 export const getFairValue = async (requestDto) => {
-    try {
-        // GET 대신 POST 사용, 두 번째 인자로 DTO 전달
-        const response = await axiosInstance.post('/fin/fair', requestDto);
-        return response.data; // { fairValue: 123.45, message: "..." }
-    } catch (error) {
-        console.error("API 호출 에러:", error);
-        throw error;
-    }
+
+    // GET 대신 POST 사용, 두 번째 인자로 DTO 전달
+    const response = await axiosInstance.post('/fin/fair', requestDto);
+    return response.data; // { fairValue: 123.45, message: "..." }
 };

--- a/finance-portfolio-frontend/src/api/memberApi.js
+++ b/finance-portfolio-frontend/src/api/memberApi.js
@@ -1,45 +1,46 @@
 import axiosInstance from './axios';
 
+// status, message만 반환하는 베이스 파서
+const parseBaseResponse = (response) => {
+    const { status, data } = response;
+    return {
+        status: status,
+        message: data
+    }
+};
+// 베이스에 엑세스 토큰 섞어서 반환
+const parseAuthResponse = (response) => {
+    const base = parseBaseResponse(response);
+    const authHeader = response.headers['authorization'] || response.headers['Authorization'];
+    const token = authHeader?.replace('Bearer ', '');
+
+    return {
+        ...base,
+        token: token
+    };
+};
+
 // 회원가입
 // status: 200, data: "회원가입이 성공적으로 완료되었습니다."
 // status: 400, data: "이미 존재하는 아이디입니다."
 // status: 500, data: "서버 이용에 불편을 드려 죄송합니다. 관리자에게 문의하세요."
 export const joinMember = async (form) => {
     const response = await axiosInstance.post('/member/join', form);
-    return {
-        status: response.status,
-        message: response.data
-    }
+    // 토큰 없음!
+    return parseBaseResponse(response);
 };
 
-// 로그인
+// 로그인(엑세스 토큰 발급)
 // status: 200, data: "로그인이 완료되었습니다."
 // status: 400, data: "존재하지 않는 회원입니다."
 // status: 500, data: "서버 이용에 불편을 드려 죄송합니다. 관리자에게 문의하세요."
 export const loginMember = async (form) => {
     const response = await axiosInstance.post('/member/login', form);
-    // response에서 엑세스 토큰 추출
-    const token = response.headers['authorization']?.replace('Bearer ', '');
-    return {
-        status: response.status,
-        message: response.data,
-        token: token
-    };
+    // 토큰 필요!
+    return parseAuthResponse(response);
 };
 
-// 로그아웃
-// status: 200, data: "로그아웃이 완료되었습니다."
-// status: 400, data: "존재하지 않는 회원입니다."
-// status: 500, data: "서버 이용에 불편을 드려 죄송합니다. 관리자에게 문의하세요."
-export const logoutMember = async () => {
-    const response = await axiosInstance.post('/member/logout');
-    return {
-        status: response.status,
-        message: response.data
-    }
-};
-
-// 토큰 재발급
+// 엑세스 토큰 재발급
 // status: 200, data: "토큰이 재발급되었습니다."
 // status: 400, data: "유효하지 않은 Refresh Token입니다."
 // status: 400, data: "존재하지 않는 회원입니다."
@@ -47,9 +48,18 @@ export const logoutMember = async () => {
 // status: 400, data: "Refresh Token이 일치하지 않습니다."
 export const reissueMember = async () => {
     const response = await axiosInstance.post('/auth/reissue');
-    return {
-        status: response.status,
-        message: response.data,
-        token: token
-    }
+    // 토큰 필요!
+    return parseAuthResponse(response);
 };
+
+
+// 로그아웃
+// status: 200, data: "로그아웃이 완료되었습니다."
+// status: 400, data: "존재하지 않는 회원입니다."
+// status: 500, data: "서버 이용에 불편을 드려 죄송합니다. 관리자에게 문의하세요."
+export const logoutMember = async () => {
+    const response = await axiosInstance.post('/member/logout');
+    // 토큰 없음!
+    return parseBaseResponse(response);
+};
+

--- a/finance-portfolio-frontend/src/components/auth/PrivateRoute.jsx
+++ b/finance-portfolio-frontend/src/components/auth/PrivateRoute.jsx
@@ -2,15 +2,17 @@ import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import authStore from '../../store/authStore';
 
-// 로그인하지 않은 사용자를 로그인 페이지로 리다이렉트합니다.
-// Access Token이 메모리에 없으면 미인증 상태로 판단합니다.
+// 인증 필요 라우트 접근시 동작
 const PrivateRoute = () => {
-    if (!authStore.isLoggedIn()) {
+    const isLogged = authStore.isLoggedIn();
+    // 로그인이 안 되어 있다면 로그인 페이지로
+    if (!isLogged) {
         return <Navigate to="/login" replace />;
     }
+
+    // 로그인 상태라면 자식 컴포넌트(Outlet) 렌더링
     return <Outlet />;
 };
-
 
 export default PrivateRoute;
 

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -12,13 +12,15 @@ const Navbar = () => {
             // 백엔드에 로그아웃 요청 (Refresh Token DB 삭제 + 쿠키 만료)
             const { status, message } = await logoutMember();
             if (status == 200 || status == 201) {
-                console.log(message);
+                alert(message);
             }
-        } catch {
-            // 로그아웃은 에러가 나도 클라이언트 상태는 정리합니다
+        } catch (error) {
+            const message = error.response?.data;
+            alert(message);
         } finally {
+            // 로그아웃은 에러가 나도 클라이언트 상태는 정리
             authStore.clearToken();
-            navigate('/login');
+            navigate('/', { replace: true });
         }
     };
 

--- a/finance-portfolio-frontend/src/pages/members/JoinPage.jsx
+++ b/finance-portfolio-frontend/src/pages/members/JoinPage.jsx
@@ -29,7 +29,6 @@ const JoinPage = () => {
             const { status, message } = await joinMember(form);
             if (status === 200 || status === 201) {
                 alert(message);
-                console.log(message);
                 navigate('/login');
             }
         } catch (error) {

--- a/finance-portfolio-frontend/src/pages/members/LoginPage.jsx
+++ b/finance-portfolio-frontend/src/pages/members/LoginPage.jsx
@@ -24,22 +24,16 @@ const LoginPage = () => {
         try {
             const { status, message, token } = await loginMember(form);
             if ((status === 200 || status === 201) && token) {
-                // 저장소에 토큰 저장
                 console.log(message);
+                // 저장소에 토큰 저장
                 authStore.setToken(token);
 
                 navigate('/posts');
             }
         } catch (error) {
-            const status = error.response?.status;
+            const message = error.response?.data;
 
-            if (status === 400) {
-                setError('아이디 또는 비밀번호가 올바르지 않습니다.');
-            } else if (status === 401) {
-                setError('인증에 실패했습니다.');
-            } else {
-                setError('서버 오류가 발생했습니다.');
-            }
+            setError(message);
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
## 개요
- **현황**: 초기 기능 구현에 매몰되어 방치했던 Spring Security 인증/인가 및 예외 처리 로직의 구조적 결함 노출.
- **문제상황**: 이슈 #83 해결 과정에서 발생한 '화면 멈춤' 현상을 코드 결함으로 오인, 3일간 동일 로직을 반복 수정하며 리소스를 낭비했으나, 최종적으로 브라우저 디버거 설정 문제임을 확인하며 '현상'이 아닌 '원인' 파악의 중요성을 직면함.
- **개선방안**: 근본적인 데이터 흐름을 장악하기 위해 리팩토링을 단행하고, 인증/인가 검증 및 예외 처리 아키텍처를 고도화하여 시스템 안정성 확보.

## 변경사항
- **인증/인가 및 예외처리 고도화**
  - 🍃**SecurityConfig**
    - **커스텀 401 응답**: 불투명한 기본 응답 대신, `exceptionHandling`을 `UNAUTHORIZED` JSON을 반환, 프론트엔드의 즉각적인 인터셉터 반응 유도.
    - **Cors 통합**: **WebConfig**에 흩어져있던 Cors 설정을 **SecurityConfig**에서 빈으로 통합하여 필터체인에서 검증 단일화.
    - **보안 취약점 방지**: `/error` 경로를 `permitAll()`하되, **application.yml**의 설정을 통해 정보 노출 최소화 설정.
  - 🍃**GlobalExceptionHandler**
    - **인증 예외 통합**: 기존 `UsernameNotFoundException` 외에 `AuthenticationException`, `BadCredentialsException` 등 인증 관련 예외를 통합 관리하여 401 응답 일관성 확보.
    - **응답 양식 표준화**: buildErrorResponse`, `resolveMessage` 메서드를 도입하여 중구난방이던 에러 메시지 포맷을 통일.
  - ⚛️**axios.js**:  `axiosInstance` 응답 인터셉터에서 토큰 재발급 이외의 에러일 시 `/error` 에러페이지로 유도.
  - **불필요 로직 제거**: ⚛️**financeApi.js** 등 개별 에러 처리를 삭제(단, 문자열 응답이 필수인 CKEditor 전용 어댑터 `imageUploadAdapter`는 예외적으로 유지.

- **프론트엔드 구조 최적화**
  - ⚛️**App.jsx**: `axiosInstance`를 직접 호출하던 재인증(Silent Refresh) 로직을 제거하고, **memberApi.js**로 역할을 이양하여 컴포넌트 비대화 방지.
  - ⚛️**재인증 복구**: 새로고침 시 메모리 휘발로 인한 로그인 풀림 현상을 방지하기 위해, **App.jsx** 내 초기 재인증(reissue) 절차를 복구.
  - ⚛️**캡슐화**: API 응답에서 반복되는 `status`, `token` 추출 과정을 단일 메서드로 캡슐화하여 가독성 및 유지보수성 향상.

- **검증**
  - 🍃**GlobalExceptionHandler**: 표준화된 에러 포맷 출력 여부 확인.
  - 🍃**SecurityConfigTest**: `permitAll` 경로와 보호된 리소스에 대한 401 응답 규격 검증.

## 결과 및 회고
- **무지의 비용**: 현상에 대한 객관적 판단이 선행되지 않은 개발이 큰 시간적 손실을 가져오는 것을 체감.
- **구조적 이해의 확장**: 며칠간의 비효율적인 트러블슈팅 Spring Security - JWT - Client Interceptor로 이어지는 인증 인프라의 전체 맵과 데이터 흐름을 이해하는 과정이 됨.
- **설계의 가치**: 코드 한 줄의 변경보다, 그 코드가 **'어느 계층에 위치해야 하는가'**에 대한 고민이 장기적인 유지보수 비용을 결정한다는 사실을 체득.

## 관련PR/이슈
- #85
- Closes #76
- Closes #83