### PR TITLE
[Fix] 커스텀 예외 추가를 통한 생문자열 대신 JSON 객체 전달 - Syntex Error 방지

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -1,12 +1,13 @@
 package com.finance.finportfolio.domain.member.controller;
 
 import com.finance.finportfolio.domain.member.service.MemberService;
+import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +29,7 @@ public class TokenReissueController {
         String refreshToken = extractRefreshTokenFromCookie(request);
 
         if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh Token이 없습니다.");
+            throw new RefreshTokenNotFoundException("Refresh Token이 없습니다.");
         }
 
         String[] tokens = memberService.reissue(refreshToken);

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
+import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -91,10 +92,18 @@ public class GlobalExceptionHandler {
             code = "BAD_CREDENTIALS";
         }
         // 3순위: 그 외 기타 인증 에러 (토큰 만료, 접근 거부 등)
-        // 여기서는 기본 설정된 defaultMsg와 code가 사용됩니다.
+        // 여기서는 기본 설정된 defaultMsg와 code 반환.
 
         String message = resolveMessage(e.getMessage(), defaultMsg);
         return buildErrorResponse(HttpStatus.UNAUTHORIZED, code, message);
+    }
+
+    // 401 UNAUTHORIZED
+    // REFRESH_TOKEN_NOT_FOUND: 리프레쉬 토큰 없음
+    @ExceptionHandler(RefreshTokenNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleAuthException(RefreshTokenNotFoundException e) {
+        String message = resolveMessage(e.getMessage(), "🛠Refresh Token이 없습니다.");
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", message);
     }
 
     // 409 CONFLICT

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -101,7 +101,7 @@ public class GlobalExceptionHandler {
     // 401 UNAUTHORIZED
     // REFRESH_TOKEN_NOT_FOUND: 리프레쉬 토큰 없음
     @ExceptionHandler(RefreshTokenNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleAuthException(RefreshTokenNotFoundException e) {
+    public ResponseEntity<ErrorResponse> handleRefreshTokenNotFoundException(RefreshTokenNotFoundException e) {
         String message = resolveMessage(e.getMessage(), "🛠Refresh Token이 없습니다.");
         return buildErrorResponse(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", message);
     }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/RefreshTokenNotFoundException.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,13 @@
+package com.finance.finportfolio.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+// 리프레쉬 토큰 찾지 못함
+// 401 UNAUTHORIZED
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class RefreshTokenNotFoundException extends RuntimeException {
+    public RefreshTokenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -65,13 +66,19 @@ class TokenReissueControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("Refresh Token 쿠키가 없으면 401 Unauthorized를 반환한다")
+        @DisplayName("Refresh Token 쿠키가 없으면 401과 함께 에러 JSON을 반환한다")
         void reissue_Fail_NoCookie() throws Exception {
                 mockMvc.perform(post("/api/auth/reissue"))
                                 .andExpect(status().isUnauthorized())
-                                .andExpect(content().string("Refresh Token이 없습니다."));
+                                // 1. JSON 응답의 status 필드 확인
+                                .andExpect(jsonPath("$.status").value(401))
+                                // 2. 정의한 에러 코드(REFRESH_TOKEN_NOT_FOUND) 확인
+                                .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_NOT_FOUND"))
+                                // 3. 메시지 내용 확인 (resolveMessage가 작동하므로 포함 여부로 확인하는 게 안전)
+                                .andExpect(jsonPath("$.message")
+                                                .value(org.hamcrest.Matchers.containsString("Refresh Token이 없습니다.")));
 
-                // 쿠키 없으면 서비스 호출 안 해야 함
+                // 쿠키 없으면 서비스 호출 안 해야 함 (검증 로직은 그대로 유지)
                 verify(memberService, never()).reissue(any());
         }
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
@@ -47,8 +47,20 @@ class GlobalExceptionHandlerTest {
     void handleBadCredentialsTest() throws Exception {
         mockMvc.perform(get("/test/bad-credentials"))
                 .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
                 .andExpect(jsonPath("$.code").value("BAD_CREDENTIALS"))
-                .andExpect(jsonPath("$.message").value("비밀번호 불일치"))
+                .andExpect(jsonPath("$.message").value("🛠아이디 또는 비밀번호가 일치하지 않습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("BadCredentialsException 발생 시 401 에러와 전용 코드를 반환한다")
+    void RefreshTokenNotFoundExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/refresh-token-not-found"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("🛠Refresh Token이 없습니다."))
                 .andDo(print());
     }
 
@@ -57,6 +69,7 @@ class GlobalExceptionHandlerTest {
     void handleDuplicateExceptionTest() throws Exception {
         mockMvc.perform(get("/test/duplicate"))
                 .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.code").value("DUPLICATE_RESOURCE"))
                 .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."))
                 .andDo(print());
@@ -67,6 +80,7 @@ class GlobalExceptionHandlerTest {
     void handleAllExceptionTest() throws Exception {
         mockMvc.perform(get("/test/runtime"))
                 .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
                 .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
                 .andExpect(jsonPath("$.message").value("DB 연결 오류"))
                 .andDo(print());

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
@@ -1,6 +1,8 @@
 package com.finance.finportfolio.global.error;
 
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
+import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -10,7 +12,7 @@ public class TestExceptionController {
 
     @GetMapping("/test/illegal-argument")
     public void throwIllegalArgument() {
-        throw new IllegalArgumentException("특정 값이 잘못되었습니다.");
+        throw new IllegalArgumentException("특정 값이 잘못되었습니다."); // 메시지 넣음 -> 명시 메시지 작동 확인
     }
 
     @GetMapping("/test/illegal-state-default")
@@ -20,7 +22,12 @@ public class TestExceptionController {
 
     @GetMapping("/test/bad-credentials")
     public void throwBadCredentials() {
-        throw new BadCredentialsException("비밀번호 불일치");
+        throw new BadCredentialsException("");
+    }
+
+    @GetMapping("/test/refresh-token-not-found")
+    public void throwRefreshTokenNotFound() {
+        throw new RefreshTokenNotFoundException("");
     }
 
     @GetMapping("/test/duplicate")


### PR DESCRIPTION
## 개요
- **현황**: 이슈 #87 를 해결하기 위한 수정 과정에서 에러메시지 분석 중 `SyntaxError` 발견.
- **에러메시지**: `SyntaxError: Unexpected token 'R', "Refresh Token이 없습니다." is not valid JSON`
- **원인**: 토큰 재발급 과정에서 리프레쉬 토큰이 없는 경우 `ResponseEntity`로 생 문자열을 전송하여 `SyntexError` 발생.
- **개선방안**: 커스텀 예외를 작성하여 `throw`시 **GlobalExceptionHandler**가 `JSON`을 전달하도록 변경.
## 변경사항
- **응답 방식 변경**
  - **TokenReissueController**
    - `ResponseEntity...body("Refresh Token이 없습니다.")` 삭제.
    - `RefreshTokenNotFoundException`으로 예외 `throw` 하도록 변경
- **커스텀 예외 추가**
  - **RefreshTokenNotFoundException**: 커스텀 예외 작성
  - **GlobalExceptionHandler**: 커스텀 예외 수신부 추가
## 결과
- **오류 수정**: 생 문자열 전달로 인한 `SyntaxError` 제거.
- **유지보수**:  `JSON`을 통해 온전한 예외 상황 데이터 확인 가능.
## 관련이슈
- #87