### PR TITLE
[Fix] globalThis.location.href를 history 객체로 변경하여 403 에러 해결

### DIFF
--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "axios": "^1.13.5",
         "ckeditor5": "^47.5.0",
-        "history": "^5.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -344,6 +343,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4558,15 +4558,6 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
-      }
-    },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "axios": "^1.13.5",
         "ckeditor5": "^47.5.0",
+        "history": "^5.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -343,7 +344,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -421,484 +421,484 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.5.0.tgz",
-      "integrity": "sha512-fOAmkBcSIWrGFDoz7kdb9XE/8yU7MnmzJ5JNbDVGNnpX+IL/1xRwvsnipwJzvJn8i3vo25kbyKLrh7FA8CsFtA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.6.1.tgz",
+      "integrity": "sha512-X4l4KyLgSsmAyRd/YY8R/OArOXR2Ts8NyoW6k+tLtYxEmZOhJsa6ZFSho/OVTole7IqMl+Zo93b9YaAwX23brw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-upload": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.5.0.tgz",
-      "integrity": "sha512-XI+olNUE92MmD4EMbhPhDmk63wt/b+QGNssH0kG/KjNJ/awoQIe+T9r4/k8WzMK7B2j4mdycgI62+ib5rH6XPw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.6.1.tgz",
+      "integrity": "sha512-2u1+Eseelrm5gKKajE9X+gcPchVAIna3AkoJyCw3+Y4dBc6ElWZJEuCO7b6Omv5H7q3lQimbaqJnvIE1Z/nXOA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.5.0.tgz",
-      "integrity": "sha512-Z9f589prwjroiEJPLRNFqSzaALloOm3oPPUN4jH/YyyRnn1mv+7vI6TEPm7ZLKks3ztBN3yv1hFnrAd9oGqY+g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.6.1.tgz",
+      "integrity": "sha512-UI3HFyw7VCTM92IhE6hdIh5rp2nqOLL4vnnOFTgp7Lq6dLOVzuwsRJLIEfYxz4Xusy4UKu4zM8QX4FV1nOWsGQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-heading": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.5.0.tgz",
-      "integrity": "sha512-KKtgL/uJdVLP2srSXG6MbYEZTCjzC2sy3kVcKtkyD6T+q3SA8OWsjH6jCLIPBZkDLNNedNnKnaeUR9+Na4i7Bg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.6.1.tgz",
+      "integrity": "sha512-7om5OHf2hBDi/Md8lVZL6fF7gCBAMVZfg8zsJqTmAW6fwl5gfenD4rggPdSa4GVt+mZXbheZx9EWc0HX1psAew==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.5.0.tgz",
-      "integrity": "sha512-az6yy2hShx9TO9tk9oUEy4akO6V7CKl6d8R4PjGij+PxYeGbiHXSPRMjLrJkoRqj72okl+5S22YmhEf1KIpoPw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.6.1.tgz",
+      "integrity": "sha512-/8R59UxR/8quK8UmOLOS1xq47GnB+oMNySo8BgLHJl7qepRR5VnWU0hHB239idnFk46IVhuRciXQHjifrJiScQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.5.0.tgz",
-      "integrity": "sha512-x2T+dn+2CU/r5hmun8AaVwSqNviaod/z483oh0XoexxXDcXE6wLr2FN591INLIdzO4/N2ez3AhcBt0focXYAbg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.6.1.tgz",
+      "integrity": "sha512-wyDLqGrmcDVNlRmHxXTpXg2PKImgB4yIU3UDRofFKVJiuvnZvKKvx/Oh9USVv1G1zOAPoFyoK9AQzqYNOB7AMQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.5.0.tgz",
-      "integrity": "sha512-5EkwJE5BuVTMHjw3VDKscVbMoG4kxD0wDCN2DTnhRo/drPNZ3q2Jw+3SJigpUrFWYUtzhF0s7+Mm6TL94rSBaA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.6.1.tgz",
+      "integrity": "sha512-9HwVudGBEhbqMPkEXQTqSIACGYpOWlES7bOxdG6WfgOUOAdCiTPXFCc5f+HSMFbrwd7XJ40tycPLOa7XK14oEg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-link": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-link": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.5.0.tgz",
-      "integrity": "sha512-OvTjDZSU+XNNzEmny6X3D90lhGF14DsnS00TcYj7uRqiwOUtnWw0ba0Hw4ulJ9Jrfs2CzG+rz2YokMm5iMgQHw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.6.1.tgz",
+      "integrity": "sha512-v083Tnbsx4z1fFW+ghMXlsf5EgB3UaSldjfRsipjIYUiUeatccgRN00Qh6qGMlYz7zZcSdUUtrOfTWL/LYPWDg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-image": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-upload": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
         "blurhash": "2.0.5",
-        "ckeditor5": "47.5.0",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.5.0.tgz",
-      "integrity": "sha512-QoyPTGypDiPgehwaaykzfH8ZUzr2qhHKj0BC7pqhAuHZaWzdCl49g2ZTI2PlMZRIrYNWr0io5zxQq/elSOgwcA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.6.1.tgz",
+      "integrity": "sha512-ewgqgtQaDDZHQUGby/gg2/840Go280bvx959ExQH8Y7u4fPVw8NEFYAxjcm43W6EXgMnlmsEr8+G8q8g4iKT1w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-image": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.5.0.tgz",
-      "integrity": "sha512-LB+KSXasEOL9/3OC2WBPwbLaKd+tDkix+4RVaki9hciQb4XgwQB3q6TWIbKcR1lPjw3Ox8tT/Io11x9AEtOzkg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.6.1.tgz",
+      "integrity": "sha512-F3KQuCnnCavm8wXvX+d1KN/obh5ux/jT9qC/71QfMKdDvHxEOzi/t3YWa1r3sztlksDQ4LtODU4uWh0vVKUpkg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.5.0.tgz",
-      "integrity": "sha512-lsvOK5w99+GfwQz9UyXaKEbH70+DEy0+wvO+82lgd5vpOiqMYfHz18b1abi5ICCTMo+m3KZyFFj33NoelRWq6w==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.6.1.tgz",
+      "integrity": "sha512-yC9aqornbxjgNhHuUX4gcuvPTLv34sc8CbUOeFYLGbD9ujwoC0fzzjzSB7u5b8fWNg6cAjzriFooJATHBvu40g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.5.0.tgz",
-      "integrity": "sha512-DdfmlvIu4nRgX41bUTkGlkL0PGJEIKcL3vVRniLXjgqnNrAsR5kWdbYTOu+qSvlCVzr4Z11nAG49QZIJ/aeAGg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.6.1.tgz",
+      "integrity": "sha512-ntZBIEYLoC4/OTUgCkwwmyXwwqDk8QwFcx/1kZN7S4YtwocREZqpDH1wYT+GA2ZmGkjaBRxdTLwSVr/7bf+wqg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.5.0.tgz",
-      "integrity": "sha512-4LdO9HIJ/ygN+YC4pty5plmFqlvHmjuQx1zdzzmbL3VSR4MCsaongDX4vVqpUcRVLzxM/1kErP0Da6cpVbkqzw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.6.1.tgz",
+      "integrity": "sha512-6dtnquhjymLkNhdC9T6gk/Mf2bDnHSTZrhkByaXC96CbmQDriCgfcaAVY6pQgDNxBQ6fZrev0TnKBLfTItrMsg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-watchdog": "47.5.0",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-watchdog": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.5.0.tgz",
-      "integrity": "sha512-e71gKQyA0UnSun4XLXawg5SP+IV2N/jhw8mu4FoFcRxhqV51FAwonldzwfdNgfD9lpX6bhYi3gREPGnuwdVPgA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.6.1.tgz",
+      "integrity": "sha512-hWaqibO1ZUHRIkvvAO7O0qDAIw+GN6UWbdr0wcGNLc4DcSZMUIpAfoXuiyyvE9hQEJPpfTOwA3r0znS6wXtMCg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-upload": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.5.0.tgz",
-      "integrity": "sha512-UrMEb65RrEmV/v/DvPpGIfFVa8KCoVnONALyDRPQ8zsdp745vKuMi+i2jHGGdhKWz6SYDfzJROQ10dq3FMxuuQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.6.1.tgz",
+      "integrity": "sha512-geszCykoE9Sja2tBqyMww4etAzAExg4eGnlYbXSGiaUiC7Ks4OqRVeuvw37QsH8Q56J5FQC35ysq95nrLEB+0A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.5.0.tgz",
-      "integrity": "sha512-OPu3OiaXm03r+mGhzQMdRyMFnJYMT9VPC8+e91e52GVQh/8sR03rwoow2RbNvsznP/+fAVnH4LrIgRR8K5cgUg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.6.1.tgz",
+      "integrity": "sha512-w2QaF2ieqLqu6i9YldOpPnFezvAsXY/R/vp/c0D1ofvI1CtBRWhQ9/rRwADMoKgpcuyP2320sRG312anT8aiaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.5.0.tgz",
-      "integrity": "sha512-bO8+DysIcgdrqo26InvoZ6geyoCBExs/V6c3DPhbG/pUuMXc9F7Zfn/hmKo1iOWL8E+gEJosu7psP/PiYM8RAw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.6.1.tgz",
+      "integrity": "sha512-w047UpjHF106k0NeQLgWY03k29s5vIpS9M6Oj+f+IdKaf4TR7uSzl/CXsS+csfqwZEhtGwGV3LYJVzo35+SifA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.5.0.tgz",
-      "integrity": "sha512-L+YSTq7Hlt9nmip9xwPBAW1rNQlS8WGIfgXAgOhcdXsUE7r43PA5gjyckvRB0vKASOF5+c6PTDjiLpapNVnv4g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.6.1.tgz",
+      "integrity": "sha512-UJQHbMh1nvsHMuiijmRx3y/5ssdxeJTrVjrwDoPlUsI8tfRYjkdIucd9SsRhXnV65Vk31Ah5wiFyaBb5OLXZaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.5.0.tgz",
-      "integrity": "sha512-tpI5VMwT+O3dXktORZ1Z4eCDp9sFEsxxEDDv/mmGz/6s2h+9rjEIfi8KqVnRfEC+uW/H2pu+q6r5y6/S3c+unA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.6.1.tgz",
+      "integrity": "sha512-Jn55iVT2sg85NSPVe/mThLoiI0FTAEH5r48MXD1MKz1E5K0FkpdLiKyCR4onfdFLozWZW2NvU0faCkyI0BKaZQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-emoji": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.5.0.tgz",
-      "integrity": "sha512-NVSg4hMpzyq0eVmVugBmY//McJpiyK0/XsXx72qySSh1b4FfKVT1couNB0m1pM5sFm7hXYB33WXyTpB4imyKyA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.6.1.tgz",
+      "integrity": "sha512-bnnnvRk/eYrvKLLQpJrjSV++Abpm1/8N31BNVaZyeHzaI0pddE6ikS44Ju82u7BQJaqSi2SO2Glx3u3C14rm2g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-mention": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-mention": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5",
         "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.5.0.tgz",
-      "integrity": "sha512-4T6MzgjV5C7em5VgaHJ+RuN4gipryTErqtjtmb/RJXvfrEg37CYOpdHurM/VwY8hiD7yGUADB2iJGroLtytzCQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.6.1.tgz",
+      "integrity": "sha512-Xb398PRhkJqtUuQ1E1pdLXTG1REIOanr7PCIRPpWvpHAIZZAuxTIqyacZC4qVTS9xI+ObxYqosf8yNvFsEtu8w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.5.0.tgz",
-      "integrity": "sha512-knpo3bZwFURor6gnDN2oS2mAA9qoPvMsEjuS3hce5K6pQAKqyUHqGSIQax7dLBW1spaWExvI+OTi/UNtNyPLWA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.6.1.tgz",
+      "integrity": "sha512-H/d5L8JmZFmb5wYDi3NT4NICYuRueGUwiPgIpaaQ0gb8U3U0YVj4J5WVF/65KGiYdsuP2NupSwRqsdl8TilrdQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.5.0.tgz",
-      "integrity": "sha512-uEdq/jnWPuN2KL6RufpQW9smnJGnU2f5/a5/QuP+rIfzPmpCmwCjgQto+8/lpCzWvEjUoHUsuIHlIT4TFYUYEQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.6.1.tgz",
+      "integrity": "sha512-4A9E9GrOudYA/eWCXE9uLqEdw7RLO/OdmeY1KWGAF6B9fubieSCF+S69M3c5hMKS6KJoNjaVJ/iR91KfIyYmtw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-select-all": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-undo": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-select-all": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.5.0.tgz",
-      "integrity": "sha512-30yr8zzztiVxVmYzKgp8snDWh4sJJc1FbS3UM+u9coNGdlxzpuy9SdseNRPOi+tTXsK1OI6/amWJltYmDsAseA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.6.1.tgz",
+      "integrity": "sha512-ZbKlNpFYCP0DRICJlhyTLaRlPSwdJ5W9BBrMFjHhGsKNbFJ2KHlPCqTD6nAEWc838heDBZM21jRGTM6O92FLHA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.5.0.tgz",
-      "integrity": "sha512-qh9GLJ9+9DsdPXgZg8dH8D5mv/ZZ0mK+Ulwct0rSxIBLruFK5EhjXjngIG8HUv30BGCIpXPawGDTPv2txQ4vlw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.6.1.tgz",
+      "integrity": "sha512-ayMtG44tLbmPBjoEudnF7kFkqX3GUO0Cb1lLd6JR5B4uyoNFuQbN3nyrtx7hMvdu0N4jl0hWcWXjdu6vNL4I6g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-fullscreen": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.5.0.tgz",
-      "integrity": "sha512-cdgpNSOKrqKZMslG9hnQQoWRUy+tAVi7r0oGIbDfMezvLnaJDoG7GmYSWbGe1/+l90/TMtxKwYM7cQ6dmqutFA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.6.1.tgz",
+      "integrity": "sha512-LvA7vzeAkuc/z64kuRu17zm7EIFe0Bqt9xPA5GhfR6T9mBVG4wu62ElqylFUjFJ+macvkjSe68tBYQTAPyUWqg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-editor-classic": "47.5.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.5.0.tgz",
-      "integrity": "sha512-TEHY+unz+1fnx3554TgoYNGw27Vct7aDm0qw0U5/+PkZIyAxLcElkzRqXu3HhAPy6qs6pqxpPfKWWtREJhKluQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.6.1.tgz",
+      "integrity": "sha512-4kVuMaaAylkxYkJ0PA4hUQCDTARoeokkqKh0dE3DwEZTvvWDZjBEAhIKaSVX116ByeGfImbLkBRAoNCljKNCHQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-paragraph": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-paragraph": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.5.0.tgz",
-      "integrity": "sha512-ajLkP2jA51B+K83g/Ujyuvpe+Wst9iniPBASmMn03pkC3ZNkdDRtCmz1Kkhe0UpYIvhCIKeWHIaH+7BS0DlbAQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.6.1.tgz",
+      "integrity": "sha512-hEIAZAImLAGRsz7/d+bbh3k+9s854AxuYoTmCAN2u07muYX/pmrLrLm6cZcazjmi9J/Bow6sP/D5GeoYMWKkLA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.5.0.tgz",
-      "integrity": "sha512-/lPpkiish+KLFCV+oSJ11XldS4MJdOogfKAtWkpdlzLS64/Duw0fxOUTk8lzo3tHAgZgP7Ji9FJM1HtiNehTNw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.6.1.tgz",
+      "integrity": "sha512-YTSpxdrp8NteaWARH89dA+qUWAf3agw/Q1dRQF+XdiF2kaSXRPQCXJruvmy490H+3xtwUZVs/hSlwX9gT77Skg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.5.0.tgz",
-      "integrity": "sha512-7gDouRaElSoICODnCwmziNxKJnvApur/QPLt374q7gz2l3sCrSM7LuDuCDAXWTQGQGkA1291OrOKQtuXGwY/xQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.6.1.tgz",
+      "integrity": "sha512-z4iYN6Il/PqpOBm+7OYM1mpXLUCbA7cMjq3MGIAwGwRHNFq8BWq/1by3P8FiF4ozaUyj8YgXXyWoggBC2qQRig==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.5.0.tgz",
-      "integrity": "sha512-e/OuWdlh6EbE1ZrQDu0/QnMd+V1XdwTmUJkOQrwwZ0x8CSKvKOt+Nb40ac0ShjTE190dMD1tGfOjM0yDpp0neQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.6.1.tgz",
+      "integrity": "sha512-F25LY88VYx0gZTrrThmt+kqF2thrwg52ZCIQeRujMd3RIueYEAEn7ZJ0p5iArDvm9qQXtLzsaijEyZr2edstPA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-heading": "47.5.0",
-        "@ckeditor/ckeditor5-image": "47.5.0",
-        "@ckeditor/ckeditor5-list": "47.5.0",
-        "@ckeditor/ckeditor5-remove-format": "47.5.0",
-        "@ckeditor/ckeditor5-table": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-remove-format": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-icons": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.5.0.tgz",
-      "integrity": "sha512-1LKzMsMrKHOEtLc9rw2C6iV5Wx6YCjd8I4WxFKQnxtW+F7+e4H4+rWU7ILpUxYjubEx0FSUJsyyNB9B98GMUgg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.6.1.tgz",
+      "integrity": "sha512-OEk5hPdMpE5/Cb2lZFtJL2XyMwy/S8xQzuAk2b2P2bJx33rJgU3pk9RUrayxCSa3p+tKqibOzm5GcshLJ7s7Tg==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.5.0.tgz",
-      "integrity": "sha512-Zm9Qvj5UUC+bKHtQNmPJisTS9Sy1z6UQ6pbH2OxKPcw7ckhozQIeRtZQqoSSKQWq9B9iJ+CPvE3b+7FYkOXkew==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.6.1.tgz",
+      "integrity": "sha512-yy7b/7WQqN0c7/VC1Ng5svQU1btXWauBfQjFgVV3AzGa+nVeJ1ZIcV2fAkUa6mB+lCu+5ziv7b7ord22baJYzg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-undo": "47.5.0",
-        "@ckeditor/ckeditor5-upload": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.5.0.tgz",
-      "integrity": "sha512-ZioulqHdwXBqirZGwESdkXWiYa1AE+EVbhegMO+a8tNa+SCDIt4do5PsrWxyz+PtW5jGBTKY831TY4NIGTihvQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.6.1.tgz",
+      "integrity": "sha512-SaokgxUJevRrYfu5PKEMvVrUliybmxpb3Cx/f/JtOnPbyJSFrt05+/mt3XsqsSB0g8LaHH2PXQfD4vncGzE6DQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-heading": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-list": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-integrations-common": {
@@ -914,66 +914,67 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.5.0.tgz",
-      "integrity": "sha512-BSSUxiqXNGEz9knYTgMJF6wpKjCY9NEsFBmfVzsXiIuNpYSXrS281Efl49E1ivjlnsgyEJLvmed6DOa+mkUHpQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.6.1.tgz",
+      "integrity": "sha512-YZpySDIa4Y40T9wwKIFsAlDujELkgUtoKw/+4Wl8BHlDnq/40VxXFbOSSXu4TnnVeqVFcnzTjp6Zv8CHtmY3yw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.5.0.tgz",
-      "integrity": "sha512-sxsB0dSEsJL1g+GTJ4dTQ33eulS4/mZ2wwU8TgN5EtpPjGR1DcsFM/Hbhpr+nC6pyGfYzjV5GnhgOT/aYGE2lg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.6.1.tgz",
+      "integrity": "sha512-A/gjF7e00R/ESUotqR08EeGM91V031DiHiGwYn7b+iZ1bejsdEu3yQK707bZ4U6ByEYBUOMtq1bOMYUtGJl6EA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-image": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.5.0.tgz",
-      "integrity": "sha512-9Yq2Jsgebbdxe6As3jviwFXL4CH38Mb+YUjlO2oEZZEw6fDvwjc83ziBXA/t+6cyBTdLjibbFhGLyPeiy+Y0Lw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.6.1.tgz",
+      "integrity": "sha512-k7lXRJpZ8vkMQy0EWoYD8U6rQqYuKEbrTshlIjZSuBOQ9qlAb9llJ80OO0gteYZBOCMde1BJGjCeVxSNAI6eFA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-font": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-font": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.5.0.tgz",
-      "integrity": "sha512-sxttfFji9jTHDKdDklN13w480tI+tLwATIOHO2xTDbsA18tp8opeBFNUUfEeQ8XoZkAxckwv5tFu9Au2XuAdJg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.6.1.tgz",
+      "integrity": "sha512-bt4UsDKTmq5iyu5TkmxpC/Z5zZEsw8bcCr5egjgNtV5ozJF1E+54iQBjKIYNYIWRdD0PAEEGFE15QoWzSHBtxw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
         "@types/hast": "3.0.4",
-        "ckeditor5": "47.5.0",
+        "ckeditor5": "47.6.1",
         "hast-util-from-dom": "5.0.1",
         "hast-util-to-html": "9.0.5",
         "hast-util-to-mdast": "10.1.2",
@@ -991,87 +992,87 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.5.0.tgz",
-      "integrity": "sha512-aA+MALRNzyeXcfXoEKDJiun0VU5p8llVrXibrXKBK4Kpx53TdBd75+OUe4z8wOcKYN50ntRf7YSGCLB0yqJuLw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.6.1.tgz",
+      "integrity": "sha512-G18SeOxXVy+k0SQYHkw1HQtS6/PkqpX2Mv6zM7os9aG3OpPmX8tCqDK+X7TaMx3FRJlDV0ujOy5Qfs71SJrqKA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-undo": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.5.0.tgz",
-      "integrity": "sha512-AhfdHcG6TNRLP/gEJIPdZM792vbjzQUR6lwXy7vFRIfVwDZ+qanEIKsTJue0x1oJYkdxC0hSRx2ZN+4QHwEOFw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.6.1.tgz",
+      "integrity": "sha512-/53LFzYqcgvd8pL02XlNBduucfnakDVvY86vC02spDuTsUH5qUMqLaz2FHSo9AH2y3kNVp98KDnqI/QjNZCd+Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.5.0.tgz",
-      "integrity": "sha512-GarVZ6e29UY6KWlKZcCQRgEggU1oqep3J6wiXJ0hxrcvYOsDS06Zo326xdcs9zQEC3M/siBO/4WW77gBZdjB0Q==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.6.1.tgz",
+      "integrity": "sha512-ksKOy4wxzs3pkhfzVtnnsu5rgJxqYHMKM7X8Rkhx9BSshcKFeuNIUVsSh+7QWDQStWKSZ/qAx+0rezdJCm6gvQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.5.0.tgz",
-      "integrity": "sha512-e7//l3ls4vVsRXcsX9Lg6r9EBjT5Aq6UfHB5KWpi3bH+S2tqE8CoeQZPKFF7fa6W2V1BVUolkUeN72iiOkCi6w==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.6.1.tgz",
+      "integrity": "sha512-KBE1tLsnyIsh0v+S6p0G+WglkvfWvKCkOESmap+gct5xwmOE0HEgRVp6xFFBfHYuGSjSISvgUU4ofdnhseZivA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.5.0.tgz",
-      "integrity": "sha512-dEOJ876f8kvpkNBCOSj9g+2x6Ig9e41k0Gdp3WrkNcX+3QCthNeWa5XJfPDsQqTINldv+L9GBwxgFEMRi0Fq/g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.6.1.tgz",
+      "integrity": "sha512-6FXs94lSb6n7V7Puwp1c9BMyjycOfsAjdPRSVGTx1THqQBziQZHuZeU9LBxJZBA1mzoQOfmFaC3v+wb8odBgAQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.5.0.tgz",
-      "integrity": "sha512-xF9TXExWPPVgIEA1gxf+oFNMVSOsbpGgRSNKS23gN5scxLupNGN/G1hj0UGTgHaYczBiOqW44bu82Lgduz7/GQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.6.1.tgz",
+      "integrity": "sha512-Lt/V8/q59WuPURpwS9Z1UWUU1q5fF7YUbDAapWatzJlK9J/c969nRMG2aXm3z+BjXv3Kdu9qs4Oqngw0sJ0KiA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-react": {
@@ -1088,152 +1089,152 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.5.0.tgz",
-      "integrity": "sha512-QTR9ye1iWfnGu7h5a4RONEf2e4y21dC847opNUozO06g51/e7G6iXybEcRtBqs51gpVddKelUbxUV2Zp7tm8iw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.6.1.tgz",
+      "integrity": "sha512-2lQvT4+OVIFQs67yKh54exnT5UV1rPjEZX7MqyhZ3Dr0rzyEW7b9tpFz7bP/EUOSa2LpFktNoLFOSnIAZnQdyQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.5.0.tgz",
-      "integrity": "sha512-hL6pr3L1xaERwGBNG37AcLwj5XVXqAzYUWKF/pDbT8FnHymA7jn1dbsUHHbmPaqXtk8zu7W9k+aGKXwrkPUFVg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.6.1.tgz",
+      "integrity": "sha512-ufWtexBPqBxJNNjjIw9XQe8Q+cnwLV4en6PTvdBX/zXHq87QdjpFk6NRSLCgDTpNmO2GiXnl+FsqUjGJF27zDQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.5.0.tgz",
-      "integrity": "sha512-g+bLHv5aqgtuGhqLo9FNYS4aSGZztb15myydHXvUBJ7OgY3YlVDILi0xd9WrySPpO+Axi0ATdl9evO42rPYVJg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.6.1.tgz",
+      "integrity": "sha512-NKhujjJ04UdM/pObi45+q6Em0fD6pQ1m+g5qLgTsTyoFUq2rFhMZqeRSPGEXlfuR5dImA7hP8uQtXNtt/GpZ7g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.5.0.tgz",
-      "integrity": "sha512-G902a+fvVv9IMcLm634yaehf7VYwWrSZqRQtD+rpV2wDaHcps5aXCHSPNrk5JdbInheF1d+V3uiySzbkc823IA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.6.1.tgz",
+      "integrity": "sha512-9MdxI7TjccCOcbdlzX+SBjFvt8CsdxCgyoJxZ2NYut6QJAJ6WPjH0yVxckZXC3LSkqIPzrIOJxHc7e2n+oFFvA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.5.0.tgz",
-      "integrity": "sha512-YmTaRSVkbx441xa9foOz/z+cYqJ385yKC6cW+MACsDVdHj2ruvj1QUDrRpvPc8T0irTSAuhxQhhmCSIEnt61WQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.6.1.tgz",
+      "integrity": "sha512-/NeN6KvgdlvmBzOGH1Uxk26zGti8HvvmBbHLOCzFqfXZRLHB+47BG+GtzOa82t6YnLjK7pvR23opyAApRf6zIA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-theme-lark": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.5.0.tgz",
-      "integrity": "sha512-Wou/dBJnv3Qiuz7io8YTL5LJGS3JqiGwpw6nLKPxADinZfI8Rr+ZOvw5BL8ifYkPudOwLFKFwMY3/4I7tZQAhA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.6.1.tgz",
+      "integrity": "sha512-O+WRAaDh3m/i3lWF+MaB0G++nBusB/uaB+koN+gwqiIfDHpGJ9HKr+KXrMZZYb0MjiGV0J5gswuwL+YvzNZ6rg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.5.0.tgz",
-      "integrity": "sha512-JmXOZQvRoOeNotZyXdColDncBw9GIl6nFbL8lVHZL/BF6wFxRHlJSjy7W/VdYAsHv3GaOKlKWMRg72k+17mgUg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.6.1.tgz",
+      "integrity": "sha512-WD9lzsgIk3sB+Ec/mpgbYIZXr8cRBOcDAjFndfjuSQMZRYM5kCMpIz0qpvjGp1Glz2bmeg7CwfuLDvbZSqZrfA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-html-support": "47.5.0",
-        "@ckeditor/ckeditor5-list": "47.5.0",
-        "@ckeditor/ckeditor5-table": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-html-support": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.5.0.tgz",
-      "integrity": "sha512-aB4Sn9+DLuDHd5pn5d/QdSGQYzGBLJg2+zlzSddcxSeUS0gj7qtOhtce2ChY899D1pszbdQHXbM/Lnwgy1ZrCQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.6.1.tgz",
+      "integrity": "sha512-zFJWnqL0PpdlSs8U1m5Mu/gcuoJfi0GSpDqr174dqXLtFcMfIsftVWVTbY5d4f+OKAp8LifxOg3CMvLD1YNSGA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.5.0.tgz",
-      "integrity": "sha512-vmQJyT6UnsmTF9rIWhYWWRGGpDhoxo9vd7aJ+m3b+gJqCLMziGadP6Dz3dezDQpbaW41Fk5CF61QPnMqaHuk7g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.6.1.tgz",
+      "integrity": "sha512-iaRFqt6ExGAAsOc4AfJNbMyY+jnh//gMzGendqklhQzkwV3RGzN6buRtV0Fps+pKXnpRcbqaVHWv0GOIOaG58Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "47.5.0"
+        "@ckeditor/ckeditor5-ui": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.5.0.tgz",
-      "integrity": "sha512-/MoO59Cl/XJ4f79ecc5BHBb0sEnZttMosXpm1wjhwRKE7PyEICt2t+Uqi0zp9txl21O2z+Gmjz716X5InMa/4w==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.6.1.tgz",
+      "integrity": "sha512-yuMJCK6+KpYyXHxkBKRtVuOF1L42eyhUlCCq4sNFHjoJfD3q3gunmesoGIkdezMZR5RpqpGSfrOapEG9orOBTg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.5.0.tgz",
-      "integrity": "sha512-wn55rqImjQ44CPavijdc9+MGHZZJ9lS9++NEAmt95b45ywd9nAyJ4QcuXDZ6f+xjwfeTuLX7jhBSuz7w8FWcwA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.6.1.tgz",
+      "integrity": "sha512-zBEfMSpR26rVPvc9X4KXxQd0wQG42EM+37VHdrfwJL47PFlqXTGlbsZ9BBjlElNM1mpViWSW9zpt5JdE6vtHCQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
         "@types/color-convert": "2.0.4",
         "color-convert": "3.1.0",
         "color-parse": "2.0.2",
@@ -1263,77 +1264,77 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.5.0.tgz",
-      "integrity": "sha512-StiwvLrAlRqog1BSR8YZ5S6pdUdFB5BCPWPPJEAcMiBfRmG4pSzs+k3LIMgnyVoGwGBUcjdLVayqaESxe89Oeg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.6.1.tgz",
+      "integrity": "sha512-kxckLxZHglOTv0yd7cROpZAgOQFR7uJEKy+ehGaPrPy5eMrIhUqHcDWHv4sLNJfNg1IgQrsqYNHeIaTzT38RvQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.5.0.tgz",
-      "integrity": "sha512-F1DPVYUGsb9P1/35vqPk7E+Y7wlubyb51DDR9irjUCAFyqQzolVQJ2bcsvrUXx+P8LT63sLCzH2do0pwMacGyQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.6.1.tgz",
+      "integrity": "sha512-GFMKl6pct+r26EQ4K2D22xokyDQIoRYQZSZFoPl4L04FFPVRuG60pA1YSNtyi7Am+T1fR3qOVBHAuXsANyeL6g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.5.0.tgz",
-      "integrity": "sha512-gkjlbVLjqkmZXo1lacY0kHRi9FTZjfJfL/OkF6WGauh0VLoDAIJHIv73PjqH6Sh7nF0Dx2p78NJ42W0t/KWxug==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.6.1.tgz",
+      "integrity": "sha512-gJl5DikvPjMEsv9DZmEVv6GOZEjHQN3kgaxvaAYpfg4VcT1RENHw46BfvPN/zUHsYwZlh7DxG3+o7h3M8Pzj1w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "47.5.0",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.5.0.tgz",
-      "integrity": "sha512-nmSnCvCvf9ChNS2C5YIdszSMeoGQRvd+CD4cDtLmkmaBqSuV/kePr5nGvqT8lMt5MrMtdqG/KmgE/xxmE4QIHg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.6.1.tgz",
+      "integrity": "sha512-mHum5WRT5PKiL80UwNMXiw//s1486smeCO2sgYJKZGrqlz7cSSHDOc8iUi8Cn2YuHvTfjgRjgcZxn0u9uhr1Mw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.5.0.tgz",
-      "integrity": "sha512-o8wFSP5Dx2kR6t2XDzpdw1IZoqOrCXdJ51iZvClsUn6zQ+EosZonlmej8oA96ZsRK/nw9GOSt2cM0Snzv3zDtQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.6.1.tgz",
+      "integrity": "sha512-rURYZlY9w+qjumkQ+VQ1cO32JJbuxuGoWIPj2lTC3uFjn6kDzYB9KvNItOykBJM/V11R7sEEOWvpKlnsMmlnzg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.5.0.tgz",
-      "integrity": "sha512-zsATU4eI7iFWC+3axpj9JG7Gm6IRzDzjW8fQqYho0xMc3hN71XxgIbPZR7jLpwNo29WirCsNxAfqi4Q2Ws8c6w==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.6.1.tgz",
+      "integrity": "sha512-q/8jRqtEFQ5SQEY8GsJBtatD7OdQT2f1o7KdKVDcZ4UZTQCo2hi9d2zvHEkQ7drA0LO+D3WJrHNEd+B6wk1slg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "ckeditor5": "47.5.0",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
         "es-toolkit": "1.39.5"
       }
     },
@@ -2715,9 +2716,9 @@
       "license": "MIT"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -3172,9 +3173,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3328,72 +3329,72 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "47.5.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.5.0.tgz",
-      "integrity": "sha512-Ow4eLxOxXoaIeuugBh4fCidLuu3zICInWO6ugB0+nZRGn9dfz9ENfdk6UlShyV2B0C5Ocu2n6Fm6I5hlByC/qA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.6.1.tgz",
+      "integrity": "sha512-Za7+Dyju3RgfH4TF+zam7lvfOSr+Rd+0tABfR16HEtsARRPEmNBHYgS5nM3PZtNK4+ScliL6Ch3GFk7cd/TiOw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "47.5.0",
-        "@ckeditor/ckeditor5-alignment": "47.5.0",
-        "@ckeditor/ckeditor5-autoformat": "47.5.0",
-        "@ckeditor/ckeditor5-autosave": "47.5.0",
-        "@ckeditor/ckeditor5-basic-styles": "47.5.0",
-        "@ckeditor/ckeditor5-block-quote": "47.5.0",
-        "@ckeditor/ckeditor5-bookmark": "47.5.0",
-        "@ckeditor/ckeditor5-ckbox": "47.5.0",
-        "@ckeditor/ckeditor5-ckfinder": "47.5.0",
-        "@ckeditor/ckeditor5-clipboard": "47.5.0",
-        "@ckeditor/ckeditor5-cloud-services": "47.5.0",
-        "@ckeditor/ckeditor5-code-block": "47.5.0",
-        "@ckeditor/ckeditor5-core": "47.5.0",
-        "@ckeditor/ckeditor5-easy-image": "47.5.0",
-        "@ckeditor/ckeditor5-editor-balloon": "47.5.0",
-        "@ckeditor/ckeditor5-editor-classic": "47.5.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "47.5.0",
-        "@ckeditor/ckeditor5-editor-inline": "47.5.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.5.0",
-        "@ckeditor/ckeditor5-emoji": "47.5.0",
-        "@ckeditor/ckeditor5-engine": "47.5.0",
-        "@ckeditor/ckeditor5-enter": "47.5.0",
-        "@ckeditor/ckeditor5-essentials": "47.5.0",
-        "@ckeditor/ckeditor5-find-and-replace": "47.5.0",
-        "@ckeditor/ckeditor5-font": "47.5.0",
-        "@ckeditor/ckeditor5-fullscreen": "47.5.0",
-        "@ckeditor/ckeditor5-heading": "47.5.0",
-        "@ckeditor/ckeditor5-highlight": "47.5.0",
-        "@ckeditor/ckeditor5-horizontal-line": "47.5.0",
-        "@ckeditor/ckeditor5-html-embed": "47.5.0",
-        "@ckeditor/ckeditor5-html-support": "47.5.0",
-        "@ckeditor/ckeditor5-icons": "47.5.0",
-        "@ckeditor/ckeditor5-image": "47.5.0",
-        "@ckeditor/ckeditor5-indent": "47.5.0",
-        "@ckeditor/ckeditor5-language": "47.5.0",
-        "@ckeditor/ckeditor5-link": "47.5.0",
-        "@ckeditor/ckeditor5-list": "47.5.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "47.5.0",
-        "@ckeditor/ckeditor5-media-embed": "47.5.0",
-        "@ckeditor/ckeditor5-mention": "47.5.0",
-        "@ckeditor/ckeditor5-minimap": "47.5.0",
-        "@ckeditor/ckeditor5-page-break": "47.5.0",
-        "@ckeditor/ckeditor5-paragraph": "47.5.0",
-        "@ckeditor/ckeditor5-paste-from-office": "47.5.0",
-        "@ckeditor/ckeditor5-remove-format": "47.5.0",
-        "@ckeditor/ckeditor5-restricted-editing": "47.5.0",
-        "@ckeditor/ckeditor5-select-all": "47.5.0",
-        "@ckeditor/ckeditor5-show-blocks": "47.5.0",
-        "@ckeditor/ckeditor5-source-editing": "47.5.0",
-        "@ckeditor/ckeditor5-special-characters": "47.5.0",
-        "@ckeditor/ckeditor5-style": "47.5.0",
-        "@ckeditor/ckeditor5-table": "47.5.0",
-        "@ckeditor/ckeditor5-theme-lark": "47.5.0",
-        "@ckeditor/ckeditor5-typing": "47.5.0",
-        "@ckeditor/ckeditor5-ui": "47.5.0",
-        "@ckeditor/ckeditor5-undo": "47.5.0",
-        "@ckeditor/ckeditor5-upload": "47.5.0",
-        "@ckeditor/ckeditor5-utils": "47.5.0",
-        "@ckeditor/ckeditor5-watchdog": "47.5.0",
-        "@ckeditor/ckeditor5-widget": "47.5.0",
-        "@ckeditor/ckeditor5-word-count": "47.5.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "47.6.1",
+        "@ckeditor/ckeditor5-alignment": "47.6.1",
+        "@ckeditor/ckeditor5-autoformat": "47.6.1",
+        "@ckeditor/ckeditor5-autosave": "47.6.1",
+        "@ckeditor/ckeditor5-basic-styles": "47.6.1",
+        "@ckeditor/ckeditor5-block-quote": "47.6.1",
+        "@ckeditor/ckeditor5-bookmark": "47.6.1",
+        "@ckeditor/ckeditor5-ckbox": "47.6.1",
+        "@ckeditor/ckeditor5-ckfinder": "47.6.1",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-code-block": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-easy-image": "47.6.1",
+        "@ckeditor/ckeditor5-editor-balloon": "47.6.1",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.1",
+        "@ckeditor/ckeditor5-editor-inline": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-emoji": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-essentials": "47.6.1",
+        "@ckeditor/ckeditor5-find-and-replace": "47.6.1",
+        "@ckeditor/ckeditor5-font": "47.6.1",
+        "@ckeditor/ckeditor5-fullscreen": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-highlight": "47.6.1",
+        "@ckeditor/ckeditor5-horizontal-line": "47.6.1",
+        "@ckeditor/ckeditor5-html-embed": "47.6.1",
+        "@ckeditor/ckeditor5-html-support": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-indent": "47.6.1",
+        "@ckeditor/ckeditor5-language": "47.6.1",
+        "@ckeditor/ckeditor5-link": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-markdown-gfm": "47.6.1",
+        "@ckeditor/ckeditor5-media-embed": "47.6.1",
+        "@ckeditor/ckeditor5-mention": "47.6.1",
+        "@ckeditor/ckeditor5-minimap": "47.6.1",
+        "@ckeditor/ckeditor5-page-break": "47.6.1",
+        "@ckeditor/ckeditor5-paragraph": "47.6.1",
+        "@ckeditor/ckeditor5-paste-from-office": "47.6.1",
+        "@ckeditor/ckeditor5-remove-format": "47.6.1",
+        "@ckeditor/ckeditor5-restricted-editing": "47.6.1",
+        "@ckeditor/ckeditor5-select-all": "47.6.1",
+        "@ckeditor/ckeditor5-show-blocks": "47.6.1",
+        "@ckeditor/ckeditor5-source-editing": "47.6.1",
+        "@ckeditor/ckeditor5-special-characters": "47.6.1",
+        "@ckeditor/ckeditor5-style": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-watchdog": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "@ckeditor/ckeditor5-word-count": "47.6.1"
       }
     },
     "node_modules/color-convert": {
@@ -4111,9 +4112,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4557,6 +4558,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -6029,9 +6039,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6744,9 +6754,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/finance-portfolio-frontend/package.json
+++ b/finance-portfolio-frontend/package.json
@@ -16,7 +16,6 @@
     "@ckeditor/ckeditor5-react": "^11.0.1",
     "axios": "^1.13.5",
     "ckeditor5": "^47.5.0",
-    "history": "^5.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/finance-portfolio-frontend/package.json
+++ b/finance-portfolio-frontend/package.json
@@ -16,6 +16,7 @@
     "@ckeditor/ckeditor5-react": "^11.0.1",
     "axios": "^1.13.5",
     "ckeditor5": "^47.5.0",
+    "history": "^5.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import authStore from './store/authStore';
-import { history } from './utils/history';
 import './App.css';
 
 import Layout from './components/layout/Layout';
@@ -19,13 +18,6 @@ import { reissueMember } from './api/memberApi';
 
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
-
-  // 네비게이션 객체 주입
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    history.navigate = navigate;
-  }, [navigate]);
 
   // 새로고침 혹은 사이트 처음 접속 시 실행
   useEffect(() => {

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, useNavigate } from 'react-router-dom';
 import authStore from './store/authStore';
+import { history } from './utils/history';
 import './App.css';
 
 import Layout from './components/layout/Layout';
@@ -19,14 +20,23 @@ import { reissueMember } from './api/memberApi';
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
 
+  // 네비게이션 객체 주입
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    history.navigate = navigate;
+  }, [navigate]);
+
   // 새로고침 혹은 사이트 처음 접속 시 실행
   useEffect(() => {
     // 1. async 로직을 별도 함수로 분리
     const initAuth = async () => {
       const pathname = globalThis.location.pathname;
+      const hasAuthCookie = document.cookie.includes('isLoggedIn=true');
 
       // 로그인/회원가입 페이지에서는 silent refresh 시도 안 함
-      if (pathname === '/login' || pathname === '/join') {
+      // 로그인 흔적도 없으면 silent refresh 시도 안 함
+      if (pathname === '/login' || pathname === '/join' || !hasAuthCookie) {
         setAuthChecked(true);
         return;
       }
@@ -41,10 +51,7 @@ function App() {
           console.log("자동 로그인 성공:", message);
           authStore.setToken(token);
         }
-      } catch (error) {
-        // 여기서 에러 처리는 '조용히' 실패하게 두는 것이 좋습니다.
-        // 세션이 없으면 그냥 로그아웃 상태로 시작하는 것이니까요.
-        console.warn(error);
+      } catch {
         authStore.clearToken();
       } finally {
         setAuthChecked(true);

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -15,7 +15,6 @@ import ErrorPage from './pages/common/ErrorPage';
 import PrivateRoute from './components/auth/PrivateRoute';
 import { reissueMember } from './api/memberApi';
 
-
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
 

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import authStore from '../store/authStore';
+import { history } from '../utils/history';
 
 // 1. axios 인스턴스 생성
 const axiosInstance = axios.create({
@@ -61,7 +62,7 @@ axiosInstance.interceptors.response.use(
             processPendingQueue(error); // 대기 중인 다른 요청들 종료
 
             // 리프레시 토큰도 만료된 것이므로 로그인 페이지로 이동
-            globalThis.location.href = '/login';
+            history.push('/login');
             throw error;
         }
 
@@ -82,9 +83,12 @@ axiosInstance.interceptors.response.use(
                 console.error(`[API Error] Status: ${status}, Message: ${message}`);
             }
 
-            if (status === 404 || status >= 500) {
+            // 로그인 요청(`/auth/login`)에서 발생한 에러는 비지니스 로직상 실패: 에러 페이지로 보내지 않음!
+            const isLoginRequest = originalRequest.url.includes('/auth/login');
+
+            if (!isLoginRequest && (status === 404 || status >= 500)) {
                 // 쿼리 스트링으로 데이터 전달
-                globalThis.location.href = `/error?status=${status}&message=${encodeURIComponent(message)}`;
+                history.push(`/error?status=${status}&message=${encodeURIComponent(message)}`);
             }
 
             throw error;
@@ -129,8 +133,8 @@ axiosInstance.interceptors.response.use(
             // 재발급 실패 = Refresh Token도 만료 → 강제 로그아웃
             authStore.clearToken();
             processPendingQueue(reissueError);
-            // 로그인 페이지로 이동 (router를 여기서 import하면 순환참조 위험 → window 사용)
-            globalThis.location.href = '/login';
+            // 로그인 페이지로 이동 
+            history.push('/login');
             throw reissueError;
         } finally {
             isRefreshing = false;

--- a/finance-portfolio-frontend/src/main.jsx
+++ b/finance-portfolio-frontend/src/main.jsx
@@ -1,13 +1,14 @@
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
+import { history } from './utils/history';
 import './index.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HistoryRouter history={history}>
       <App />
-    </BrowserRouter>
+    </HistoryRouter>
   </React.StrictMode>
 );

--- a/finance-portfolio-frontend/src/main.jsx
+++ b/finance-portfolio-frontend/src/main.jsx
@@ -1,14 +1,22 @@
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
-import { history } from './utils/history';
+import { BrowserRouter, useNavigate } from 'react-router-dom';
+import { navRef } from './utils/history';
 import './index.css';
 import App from './App.jsx';
 
+// 리액트 외부에서 라우터 사용을 하기 위한 컴포넌트
+const NavigateSetter = () => {
+  const navigate = useNavigate();
+  navRef.navigate = navigate;
+  return null;
+};
+
 createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <HistoryRouter history={history}>
+  <StrictMode>
+    <BrowserRouter>
+      <NavigateSetter />
       <App />
-    </HistoryRouter>
-  </React.StrictMode>
+    </BrowserRouter>
+  </StrictMode>
 );

--- a/finance-portfolio-frontend/src/pages/members/JoinPage.jsx
+++ b/finance-portfolio-frontend/src/pages/members/JoinPage.jsx
@@ -33,13 +33,22 @@ const JoinPage = () => {
             }
         } catch (error) {
             const status = error.response?.status;
-            const message = error.response?.data;
+            const errorData = error.response?.data; // message 대신 data라는 이름을 주로 씁니다.
 
-            if (status === 400 && typeof message === 'string') {
-                setError(message);
-            } else {
-                setError('서버 오류가 발생했습니다.');
+            let errorMessage = '서버 오류가 발생했습니다..'; // 기본 메시지
+
+            if (status >= 400 && status < 500) {
+                // 1. 서버가 객체로 보냈을 경우 ({ message: "..." })
+                if (errorData && typeof errorData === 'object' && errorData.message) {
+                    errorMessage = errorData.message;
+                }
+                // 2. 서버가 단순 문자열로 보냈을 경우 ("이미 존재하는...")
+                else if (typeof errorData === 'string') {
+                    errorMessage = errorData;
+                }
             }
+
+            setError(errorMessage);
         } finally {
             setLoading(false);
         }

--- a/finance-portfolio-frontend/src/pages/members/LoginPage.jsx
+++ b/finance-portfolio-frontend/src/pages/members/LoginPage.jsx
@@ -31,9 +31,12 @@ const LoginPage = () => {
                 navigate('/posts');
             }
         } catch (error) {
-            const message = error.response?.data;
-
-            setError(message);
+            // 객체 아닌 문자열만 추출
+            const errorData = error.response?.data;
+            const errorMessage = typeof errorData === 'object'
+                ? errorData.message
+                : (errorData || "로그인에 실패했습니다..");
+            setError(errorMessage);
         } finally {
             setLoading(false);
         }

--- a/finance-portfolio-frontend/src/utils/history.js
+++ b/finance-portfolio-frontend/src/utils/history.js
@@ -1,4 +1,32 @@
-import { createBrowserHistory } from 'history';
+export const navRef = {
+    navigate: null, // 여기에 useNavigate 훅이 담길 예정
+};
 
-// 브라우저의 History API를 래핑한 객체를 직접 생성
-export const history = createBrowserHistory();
+export const history = {
+    push(url) {
+        if (navRef.navigate) {
+            // 리액트 엔진이 로드된 상태라면 SPA 라우팅 실행 (깜빡임 X)
+            navRef.navigate(url);
+        } else {
+            // 만약 앱 로딩 전이나 특수 상황이라면 브라우저 강제 이동 (Fallback)
+            console.warn("Navigation 호출 시점에 리액트 엔진이 준비되지 않았습니다.");
+            globalThis.location.href = url;
+        }
+    },
+
+    goBack() {
+        if (navRef.navigate) {
+            navRef.navigate(-1); // 리액트 라우터의 뒤로 가기 방식
+        } else {
+            globalThis.history.back(); // 브라우저 네이티브 뒤로 가기
+        }
+    },
+
+    replace(url) {
+        if (navRef.navigate) {
+            navRef.navigate(url, { replace: true });
+        } else {
+            globalThis.location.replace(url);
+        }
+    }
+};

--- a/finance-portfolio-frontend/src/utils/history.js
+++ b/finance-portfolio-frontend/src/utils/history.js
@@ -1,0 +1,13 @@
+
+
+export const history = {
+    navigate: null,
+    push(url) {
+        if (this.navigate) {
+            this.navigate(url);
+        } else {
+            console.warn("Navigate is not initialized yet.");
+            globalThis.location.href = url;
+        }
+    }
+};

--- a/finance-portfolio-frontend/src/utils/history.js
+++ b/finance-portfolio-frontend/src/utils/history.js
@@ -1,13 +1,4 @@
+import { createBrowserHistory } from 'history';
 
-
-export const history = {
-    navigate: null,
-    push(url) {
-        if (this.navigate) {
-            this.navigate(url);
-        } else {
-            console.warn("Navigate is not initialized yet.");
-            globalThis.location.href = url;
-        }
-    }
-};
+// 브라우저의 History API를 래핑한 객체를 직접 생성
+export const history = createBrowserHistory();


### PR DESCRIPTION
## 개요
### 문제 발생
- **현황**: 로컬은 정상이나, AWS 배포 환경에서 `/login`를 호출 시 `403 Forbidden` 발생.
- **문제상황**: 배포환경의 접속 단계부터 `403 Forbidden`이 발생하며 이용자체가 불가능한 매우 수정이 시급한 상황.
- **에러메시지**: 개발자 도구 디버그 모드 단계별 동작 콘솔 응답
  - 브라우저1: 정상 동작
`AxiosError: Request failed with status code 401`
`POST https://dev.ljh-finance.com/api/auth/reissue 401 (Unauthorized)`
  - 브라우저2: 정상 동작, but `SyntaxError` 수정 필요
`SyntaxError: Unexpected token 'R', "Refresh Token이 없습니다." is not valid JSON`
`POST https://dev.ljh-finance.com/api/auth/reissue 401 (Unauthorized)`
    - `SyntaxError` 이슈 수정됨: #88.
  - 브라우저3: 정상 동작
`AxiosError: Request failed with status code 401`
`POST https://dev.ljh-finance.com/api/auth/reissue 401 (Unauthorized)`

  - 서버 응답: `/api/posts` Get요청은 정상 작동함을 알 수 있음.
`INFO 1 --- [finance-portfolio] [nio-8080-exec-1] c.f.f.d.post.controller.PostController   : 게시글 목록 조회 - 개수: 9`

  - **브라우저4: 비정상 동작**
`GET https://dev.ljh-finance.com/login 403 (Forbidden)`

- 실제 브라우저 출력
<img width="456" height="130" alt="image" src="https://github.com/user-attachments/assets/9816203e-e8c8-457a-a40d-b83ecdbcecf1" />

### 원인 분석
  - **범인**: `globalThis.location.href = '/login'`
  - `react-router-dom`의 네비게이션 기능은 엔드포인트가 주어졌을 때 `index.html`을 통해 라우팅 포인트를 선제적으로 찾는 방식으로 동작하지만.
  -  `location.href`을 통해 페이지를 요청하는 경우 브라우저는 프론트의 내부 라우팅을 타는 게 아니라 페이지 전체를 새로고침하며 서버에 `/login`경로로 다이렉트 GET요청을 하는 CSR에서는 적합하지 않은 방식.
  - 따라서 `/api/*` 형태를 거치지 않고 서버에 다이렉트 엑세스를 시도되었기에 `CloudFrontHeaderFilter`에 의해 차단당하여 `403 Forbidden`이 발생.
### 해결방안
  - **A**: 순수 객체 및 `location.href` 혼용 방식
    - **설명**: `globalThis.location.href`의 서버 요청을 피하기 위해, `history` 커스텀 객체를 직접 작성하는 유사 라우팅 방식.
    - **문제점**
      - **UX**: 브라우저의 앞으로 가기 등의 버튼과 프론트의 상태가 연동되지 않아 UX 저하.
      - **효율**: 히스토리 스택 관리 로직을 직접 작성해야하며, 초기화되지 않은 상태에서 호출 시 런타임 에러 위험.

  - **B**: `createBrowserHistory` 라이브러리 방식
    - **설명**: 외부 `history` 라이브러리를 통해 브라우저 히스토리 스택을 제어.
    - **문제점**: 깔끔한 구현이 가능하지만 React Router v6부터는 지원하지 않아 `unstable_HistoryRouter`를 강제로 사용해야함 - 라이브러리 업데이트 시 코드가 깨질 수 있다는 매우 심각한 위험 존재.

  - **C(최종 채택✅)**: navRef (Custom Wrapper) 방식
    - **설명**: React Router의 정식 API인 `useNavigate` 훅을 전역 객체(navRef)에 구독시켜 사용.
    - **장점**
      - **안전성**: `BrowserRouter`와 `useNavigate`라는 정식 API를 활용.
      - **전역 제어**: Axios 인터셉터 같은 리액트 외부 영역에서도 페이지 새로고침 없이**(UX)** SPA 내부 라우팅 제어 가능.
      -  **상태 보존**: 이전 페이지에서 불러온 데이터나 사용자의 입력값을 그대로 유지하며 라우팅 가능.
## 변경사항
- ~**라이브러리 설치**: `npm install history`~
- **navRef  객체 생성 및 구독**
  - **history.js**: `navRef`에 `useNavigate` 훅 보관 및 `push`, `goback`, `replace` 라우팅 기능 대체.
  - **main.jsx**: `NavigateSetter` 컴포넌트를 통해 `navRef`를 `BrowserRouter` 내부에 삽입.
  - **axios.js**: `globalThis.location.href`를 `history.push()`로 변경.
## 결과
- **403 제거**: 서버에서 프론트 페이지를 찾는 잘못된 구조를 수정하여 페이지 호출 정상화.
- **UX**: `location.href`의 리다이렉트가 아닌 대체 라우팅을 사용하여 데이터 보존 및 부드러운 전환.

(불필요한 콘솔 메시지도 제거된 모습)
<img width="981" height="675" alt="image" src="https://github.com/user-attachments/assets/90ad7f80-d4af-4928-80a6-8820cb187e96" />

## 관련PR/이슈
- #88
- Closes #87