### PR TITLE
[Fix] 새로고침 시 인증 상태 유지를 위한 isLoggedIn 쿠키 플래그 토큰 추가 및 로딩페이지 등 중복 코드 통합

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
@@ -2,9 +2,7 @@ package com.finance.finportfolio.domain.member.controller;
 
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
-import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
 import com.finance.finportfolio.domain.member.service.MemberService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final TokenCookieManager tokenCookieManager;
 
     @PostMapping("/join")
     public ResponseEntity<String> join(@Valid @RequestBody MemberJoinRequestDto request) {
@@ -33,23 +32,23 @@ public class MemberController {
     public ResponseEntity<String> login(@Valid @RequestBody MemberLoginRequestDto loginRequest,
             HttpServletResponse response) {
 
-        // 1. 로그인 처리 → Access Token + Refresh Token 발급
-        String[] tokens = memberService.login(loginRequest);
-        String accessToken = tokens[0];
-        String refreshToken = tokens[1];
+        try {
+            // 1. 로그인 처리 → Access Token + Refresh Token 발급
+            String[] tokens = memberService.login(loginRequest);
+            String accessToken = tokens[0];
+            String refreshToken = tokens[1];
 
-        // 2. Refresh Token → HttpOnly 쿠키로 전달 (JS 접근 불가 → XSS 방어)
-        Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
-        refreshCookie.setHttpOnly(true); // JS에서 접근 불가
-        refreshCookie.setSecure(true); // HTTPS 환경에서만 전송
-        refreshCookie.setPath("/"); // 모든 경로에서 쿠키 전송
-        refreshCookie.setMaxAge(7 * 24 * 60 * 60); // 7일
-        response.addCookie(refreshCookie);
+            // 2. 토큰 쿠키 전달 (리프레쉬 토큰, 로그인 플래그)
+            tokenCookieManager.setAuthCookies(response, refreshToken);
 
-        // 3. Access Token → 응답 헤더로 전달 (프론트에서 메모리에 저장)
-        response.setHeader("Authorization", "Bearer " + accessToken);
+            // 3. Access Token → 응답 헤더로 전달 (프론트에서 authStore 메모리에 저장)
+            response.setHeader("Authorization", "Bearer " + accessToken);
 
-        return ResponseEntity.ok("로그인이 완료되었습니다.");
+            return ResponseEntity.ok("로그인이 완료되었습니다.");
+        } catch (Exception e) {
+            tokenCookieManager.expireAuthCookies(response);
+            throw e; // 기존 예외 처리가 작동하도록 던짐
+        }
     }
 
     @PostMapping("/logout")
@@ -59,13 +58,8 @@ public class MemberController {
 
         memberService.logout(loginId);
 
-        // Refresh Token 쿠키 만료 처리
-        Cookie refreshCookie = new Cookie("refreshToken", null);
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setSecure(true);
-        refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(0); // 즉시 만료
-        response.addCookie(refreshCookie);
+        // 2. 토큰 쿠키 만료 처리 (리프레쉬 토큰, 로그인 플래그)
+        tokenCookieManager.expireAuthCookies(response);
 
         return ResponseEntity.ok("로그아웃이 완료되었습니다.");
     }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenCookieManager.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenCookieManager.java
@@ -1,0 +1,59 @@
+package com.finance.finportfolio.domain.member.controller;
+
+import java.util.Arrays;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class TokenCookieManager {
+
+    private static final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
+
+    // 쿠키 생성
+    public void setAuthCookies(HttpServletResponse response, String refreshToken) {
+        addCookieInternal(response, refreshToken, COOKIE_MAX_AGE);
+    }
+
+    // 쿠키 만료
+    public void expireAuthCookies(HttpServletResponse response) {
+        addCookieInternal(response, "", 0);
+    }
+
+    private void addCookieInternal(HttpServletResponse response, String value, int maxAge) {
+        String flagValue = (maxAge > 0) ? "true" : "false";
+
+        ResponseCookie refCookie = createCookie("refreshToken", value, maxAge, true);
+        ResponseCookie loginFlag = createCookie("isLoggedIn", flagValue, maxAge, false);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, loginFlag.toString());
+    }
+
+    private ResponseCookie createCookie(String name, String value, int maxAge, boolean httpOnly) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(true) // HTTPS 필수
+                .path("/")
+                .maxAge(maxAge) // maxAge가 0이면 삭제용, 그 외에는 생성용
+                .sameSite("Lax") // CSRF 방지(Lax: 링크 타고 온 건 허용)
+                .build();
+    }
+
+    // 쿠키 추출
+    public String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null)
+            return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -21,41 +21,36 @@ import java.util.Arrays;
 public class TokenReissueController {
 
     private final MemberService memberService;
+    private final TokenCookieManager tokenCookieManager;
 
+    // 토큰 재발급
     @PostMapping("/reissue")
     public ResponseEntity<String> reissue(HttpServletRequest request,
             HttpServletResponse response) {
 
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        // 쿠키 추출
+        String refreshToken = tokenCookieManager.extractRefreshTokenFromCookie(request);
 
         if (refreshToken == null) {
+            // 혹시 모르니 토큰 즉시 만료
+            tokenCookieManager.expireAuthCookies(response);
             throw new RefreshTokenNotFoundException("Refresh Token이 없습니다.");
         }
 
-        String[] tokens = memberService.reissue(refreshToken);
-        String newAccessToken = tokens[0];
-        String newRefreshToken = tokens[1];
+        try {
+            String[] tokens = memberService.reissue(refreshToken);
+            String newAccessToken = tokens[0];
+            String newRefreshToken = tokens[1];
 
-        Cookie refreshCookie = new Cookie("refreshToken", newRefreshToken);
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setSecure(true);
-        refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(7 * 24 * 60 * 60);
-        response.addCookie(refreshCookie);
+            tokenCookieManager.setAuthCookies(response, newRefreshToken);
 
-        response.setHeader("Authorization", "Bearer " + newAccessToken);
+            response.setHeader("Authorization", "Bearer " + newAccessToken);
 
-        return ResponseEntity.ok("토큰이 재발급되었습니다.");
+            return ResponseEntity.ok("토큰이 재발급되었습니다.");
+        } catch (Exception e) {
+            tokenCookieManager.expireAuthCookies(response);
+            throw e; // 기존 예외 처리가 작동하도록 던짐
+        }
     }
 
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() == null)
-            return null;
-
-        return Arrays.stream(request.getCookies())
-                .filter(cookie -> "refreshToken".equals(cookie.getName()))
-                .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
-    }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -43,6 +44,9 @@ class MemberControllerTest {
 
     @MockBean
     private MemberService memberService;
+
+    @SpyBean
+    private TokenCookieManager tokenCookieManager;
 
     @MockBean
     private AuthenticationManager authenticationManager;
@@ -113,11 +117,14 @@ class MemberControllerTest {
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("로그인이 완료되었습니다."))
-                // Access Token → Authorization 헤더 확인
+                // Access Token 검증
                 .andExpect(header().string("Authorization", "Bearer accessToken"))
-                // Refresh Token → HttpOnly 쿠키 확인
+                // Refresh Token 쿠키 검증 (HttpOnly)
                 .andExpect(cookie().value("refreshToken", "refreshToken"))
-                .andExpect(cookie().httpOnly("refreshToken", true));
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                // isLoggedIn 플래그 쿠키 검증 (JS 접근 가능)
+                .andExpect(cookie().value("isLoggedIn", "true"))
+                .andExpect(cookie().httpOnly("isLoggedIn", false));
     }
 
     @Test
@@ -147,20 +154,38 @@ class MemberControllerTest {
         verify(memberService, never()).login(any());
     }
 
+    // 로그인 try 실패 시 catch
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그인 실패 시 기존 인증 정보를 지우기 위해 쿠키를 만료시킨다")
+    void login_Fail_And_Expire_Cookies() throws Exception {
+        MemberLoginRequestDto loginRequest = new MemberLoginRequestDto("wrongId", "wrongPw");
+        // 서비스에서 예외 발생 시나리오
+        given(memberService.login(any())).willThrow(new RuntimeException("로그인 실패"));
+
+        mockMvc.perform(post("/api/member/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isInternalServerError()) // 또는 설정한 ExceptionHandler의 응답값
+                // 실패 시에도 쿠키 만료 로직이 실행되었는지 확인
+                .andExpect(cookie().maxAge("refreshToken", 0))
+                .andExpect(cookie().maxAge("isLoggedIn", 0));
+    }
+
     // ── 로그아웃 ───────────────────────────────────────────────
 
     @Test
     @WithMockUser
     @DisplayName("로그아웃 성공 시 refreshToken 쿠키가 즉시 만료된다")
     void logout_Success() throws Exception {
-        MemberLoginRequestDto loginRequest = new MemberLoginRequestDto("testId", "password123");
-
         mockMvc.perform(post("/api/member/logout")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(loginRequest)))
+                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string("로그아웃이 완료되었습니다."))
-                // 쿠키 maxAge = 0 → 즉시 만료 확인
-                .andExpect(cookie().maxAge("refreshToken", 0));
+                // 모든 쿠키 maxAge = 0 확인
+                .andExpect(cookie().maxAge("refreshToken", 0))
+                .andExpect(cookie().maxAge("isLoggedIn", 0));
     }
+
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,11 +27,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hamcrest.Matchers;
 
 @WebMvcTest(TokenReissueController.class)
-@Import(SecurityConfig.class)
+@Import({ SecurityConfig.class, TokenCookieManager.class })
 class TokenReissueControllerTest {
 
         @Autowired
@@ -38,7 +41,7 @@ class TokenReissueControllerTest {
         @MockBean
         private MemberService memberService;
 
-        @MockBean
+        @SpyBean
         private TokenCookieManager tokenCookieManager;
 
         @MockBean
@@ -59,7 +62,8 @@ class TokenReissueControllerTest {
                 String newRefreshToken = "newRefreshToken";
 
                 // 1. 추출 로직 Mocking
-                given(tokenCookieManager.extractRefreshTokenFromCookie(any())).willReturn(oldRefreshToken);
+                org.mockito.Mockito.doReturn(oldRefreshToken)
+                                .when(tokenCookieManager).extractRefreshTokenFromCookie(any());
 
                 // 2. 서비스 로직 Mocking
                 given(memberService.reissue(oldRefreshToken))
@@ -91,7 +95,8 @@ class TokenReissueControllerTest {
         @DisplayName("Refresh Token 쿠키가 없으면 401 에러를 반환한다")
         void reissue_Fail_NoCookie() throws Exception {
                 // given
-                given(tokenCookieManager.extractRefreshTokenFromCookie(any())).willReturn(null);
+                org.mockito.Mockito.doReturn(null)
+                                .when(tokenCookieManager).extractRefreshTokenFromCookie(any());
 
                 // when & then
                 mockMvc.perform(post("/api/auth/reissue"))
@@ -108,8 +113,8 @@ class TokenReissueControllerTest {
         @WithMockUser
         @DisplayName("유효하지 않은 Refresh Token이면 400 Bad Request를 반환한다")
         void reissue_Fail_InvalidToken() throws Exception {
-                given(tokenCookieManager.extractRefreshTokenFromCookie(any()))
-                                .willReturn("invalidToken");
+                org.mockito.Mockito.doReturn("invalidToken")
+                                .when(tokenCookieManager).extractRefreshTokenFromCookie(any());
 
                 given(memberService.reissue(any()))
                                 .willThrow(new IllegalStateException("유효하지 않은 Refresh Token입니다."));
@@ -125,8 +130,8 @@ class TokenReissueControllerTest {
         @WithMockUser
         @DisplayName("탈취 감지 시 (토큰 불일치) 400 Bad Request를 반환한다")
         void reissue_Fail_TokenMismatch() throws Exception {
-                given(tokenCookieManager.extractRefreshTokenFromCookie(any()))
-                                .willReturn("stolenToken");
+                org.mockito.Mockito.doReturn("stolenToken")
+                                .when(tokenCookieManager).extractRefreshTokenFromCookie(any());
 
                 given(memberService.reissue(any()))
                                 .willThrow(new IllegalStateException("Refresh Token이 일치하지 않습니다."));
@@ -134,5 +139,51 @@ class TokenReissueControllerTest {
                 mockMvc.perform(post("/api/auth/reissue")
                                 .cookie(new Cookie("refreshToken", "stolenToken")))
                                 .andExpect(status().isBadRequest());
+        }
+
+        // -- TokenCookieManager의 extractRefreshTokenFromCookie 메서드 테스트 --
+
+        @Test
+        @DisplayName("쿠키 목록에 refreshToken이 있으면 해당 값을 추출한다")
+        void extractRefreshToken_Success() {
+                // given
+                MockHttpServletRequest request = new MockHttpServletRequest();
+                Cookie refreshTokenCookie = new Cookie("refreshToken", "test-refresh-token");
+                Cookie otherCookie = new Cookie("other", "value");
+                request.setCookies(refreshTokenCookie, otherCookie);
+
+                // when
+                String result = tokenCookieManager.extractRefreshTokenFromCookie(request);
+
+                // then
+                assertThat(result).isEqualTo("test-refresh-token");
+        }
+
+        @Test
+        @DisplayName("쿠키 목록이 null이면 null을 반환한다")
+        void extractRefreshToken_NullCookies() {
+                // given
+                MockHttpServletRequest request = new MockHttpServletRequest();
+                // request.setCookies를 하지 않음 (기본 null)
+
+                // when
+                String result = tokenCookieManager.extractRefreshTokenFromCookie(request);
+
+                // then
+                assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("refreshToken이라는 이름의 쿠키가 없으면 null을 반환한다")
+        void extractRefreshToken_NoTargetCookie() {
+                // given
+                MockHttpServletRequest request = new MockHttpServletRequest();
+                request.setCookies(new Cookie("accessToken", "some-value"));
+
+                // when
+                String result = tokenCookieManager.extractRefreshTokenFromCookie(request);
+
+                // then
+                assertThat(result).isNull();
         }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -2,6 +2,7 @@ package com.finance.finportfolio.domain.member.controller;
 
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
+import com.finance.finportfolio.global.error.GlobalExceptionHandler;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import jakarta.servlet.http.Cookie;
@@ -21,10 +22,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import org.hamcrest.Matchers;
 
 @WebMvcTest(TokenReissueController.class)
 @Import(SecurityConfig.class)
@@ -35,6 +37,9 @@ class TokenReissueControllerTest {
 
         @MockBean
         private MemberService memberService;
+
+        @MockBean
+        private TokenCookieManager tokenCookieManager;
 
         @MockBean
         private AuthenticationManager authenticationManager;
@@ -48,37 +53,52 @@ class TokenReissueControllerTest {
         @WithMockUser
         @DisplayName("유효한 Refresh Token 쿠키로 요청 시 새 토큰이 발급된다")
         void reissue_Success() throws Exception {
-                given(memberService.reissue(any()))
-                                .willReturn(new String[] { "newAccessToken", "newRefreshToken" });
+                // given
+                String oldRefreshToken = "validOldRefreshToken";
+                String newAccessToken = "newAccessToken";
+                String newRefreshToken = "newRefreshToken";
 
+                // 1. 추출 로직 Mocking
+                given(tokenCookieManager.extractRefreshTokenFromCookie(any())).willReturn(oldRefreshToken);
+
+                // 2. 서비스 로직 Mocking
+                given(memberService.reissue(oldRefreshToken))
+                                .willReturn(new String[] { newAccessToken, newRefreshToken });
+
+                // 3. (중요) 실제 Response에 쿠키를 심어주는 동작 정의
+                org.mockito.Mockito.doAnswer(invocation -> {
+                        jakarta.servlet.http.HttpServletResponse response = invocation.getArgument(0);
+                        String token = invocation.getArgument(1);
+                        // 테스트용 간이 쿠키 추가
+                        response.addCookie(new Cookie("refreshToken", token));
+                        response.addCookie(new Cookie("isLoggedIn", "true"));
+                        return null;
+                }).when(tokenCookieManager).setAuthCookies(any(), any());
+
+                // when & then
                 mockMvc.perform(post("/api/auth/reissue")
-                                .cookie(new Cookie("refreshToken", "validRefreshToken")))
+                                .cookie(new Cookie("refreshToken", oldRefreshToken)))
+                                .andDo(print()) // 이제 출력이 정상적으로 나옵니다.
                                 .andExpect(status().isOk())
-                                .andExpect(content().string("토큰이 재발급되었습니다."))
-                                // 새 Access Token이 Authorization 헤더에 담겨야 함
-                                .andExpect(header().string("Authorization", "Bearer newAccessToken"))
-                                // 새 Refresh Token이 HttpOnly 쿠키로 내려와야 함
-                                .andExpect(cookie().value("refreshToken", "newRefreshToken"))
-                                .andExpect(cookie().httpOnly("refreshToken", true));
+                                .andExpect(cookie().value("refreshToken", newRefreshToken))
+                                .andExpect(cookie().value("isLoggedIn", "true"));
         }
 
         // ── Refresh Token 없는 경우 ────────────────────────────────
 
         @Test
         @WithMockUser
-        @DisplayName("Refresh Token 쿠키가 없으면 401과 함께 에러 JSON을 반환한다")
+        @DisplayName("Refresh Token 쿠키가 없으면 401 에러를 반환한다")
         void reissue_Fail_NoCookie() throws Exception {
+                // given
+                given(tokenCookieManager.extractRefreshTokenFromCookie(any())).willReturn(null);
+
+                // when & then
                 mockMvc.perform(post("/api/auth/reissue"))
                                 .andExpect(status().isUnauthorized())
-                                // 1. JSON 응답의 status 필드 확인
-                                .andExpect(jsonPath("$.status").value(401))
-                                // 2. 정의한 에러 코드(REFRESH_TOKEN_NOT_FOUND) 확인
                                 .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_NOT_FOUND"))
-                                // 3. 메시지 내용 확인 (resolveMessage가 작동하므로 포함 여부로 확인하는 게 안전)
-                                .andExpect(jsonPath("$.message")
-                                                .value(org.hamcrest.Matchers.containsString("Refresh Token이 없습니다.")));
+                                .andExpect(jsonPath("$.message", Matchers.containsString("Refresh Token이 없습니다.")));
 
-                // 쿠키 없으면 서비스 호출 안 해야 함 (검증 로직은 그대로 유지)
                 verify(memberService, never()).reissue(any());
         }
 
@@ -88,6 +108,9 @@ class TokenReissueControllerTest {
         @WithMockUser
         @DisplayName("유효하지 않은 Refresh Token이면 400 Bad Request를 반환한다")
         void reissue_Fail_InvalidToken() throws Exception {
+                given(tokenCookieManager.extractRefreshTokenFromCookie(any()))
+                                .willReturn("invalidToken");
+
                 given(memberService.reissue(any()))
                                 .willThrow(new IllegalStateException("유효하지 않은 Refresh Token입니다."));
 
@@ -102,6 +125,9 @@ class TokenReissueControllerTest {
         @WithMockUser
         @DisplayName("탈취 감지 시 (토큰 불일치) 400 Bad Request를 반환한다")
         void reissue_Fail_TokenMismatch() throws Exception {
+                given(tokenCookieManager.extractRefreshTokenFromCookie(any()))
+                                .willReturn("stolenToken");
+
                 given(memberService.reissue(any()))
                                 .willThrow(new IllegalStateException("Refresh Token이 일치하지 않습니다."));
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
@@ -1,6 +1,7 @@
 package com.finance.finportfolio.global.config;
 
 import com.finance.finportfolio.domain.member.controller.MemberController;
+import com.finance.finportfolio.domain.member.controller.TokenCookieManager;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.domain.post.controller.PostController;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
@@ -31,128 +32,132 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @Import(SecurityConfig.class)
 class SecurityConfigTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    // PostController 의존성 Mock
-    @MockBean
-    private com.finance.finportfolio.domain.post.service.PostService postService;
+        // PostController 의존성 Mock
+        @MockBean
+        private com.finance.finportfolio.domain.post.service.PostService postService;
 
-    @MockBean
-    private MemberService memberService;
+        // MemberController 타고 들어온 의존성
+        @MockBean
+        private TokenCookieManager tokenCookieManager;
 
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
+        @MockBean
+        private MemberService memberService;
 
-    @MockBean
-    private AuthenticationManager authenticationManager;
+        @MockBean
+        private JwtTokenProvider jwtTokenProvider;
 
-    @Test
-    @DisplayName("CORS Preflight 요청(OPTIONS)은 인증 없이 200 OK를 반환해야 한다")
-    void corsPreflightTest() throws Exception {
-        mockMvc.perform(options("/api/posts")
-                .header("Origin", "http://localhost:3000")
-                .header("Access-Control-Request-Method", "GET"))
-                .andExpect(status().isOk())
-                .andExpect(header().exists("Access-Control-Allow-Origin"))
-                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"));
-    }
+        @MockBean
+        private AuthenticationManager authenticationManager;
 
-    @Test
-    @DisplayName("로그인 경로는 permitAll이므로 접근 시 401이 발생하지 않는다")
-    void loginPath_ShouldNotReturn401() throws Exception {
-        mockMvc.perform(post("/api/member/login") // POST로 변경
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"email\":\"test@test.com\", \"password\":\"1234\"}")) // 가짜 바디
-                .andDo(print())
-                .andExpect(result -> org.assertj.core.api.Assertions
-                        .assertThat(result.getResponse().getStatus())
-                        .isNotEqualTo(401));
-    }
+        @Test
+        @DisplayName("CORS Preflight 요청(OPTIONS)은 인증 없이 200 OK를 반환해야 한다")
+        void corsPreflightTest() throws Exception {
+                mockMvc.perform(options("/api/posts")
+                                .header("Origin", "http://localhost:3000")
+                                .header("Access-Control-Request-Method", "GET"))
+                                .andExpect(status().isOk())
+                                .andExpect(header().exists("Access-Control-Allow-Origin"))
+                                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"));
+        }
 
-    @Test
-    @DisplayName("인증이 필요한 경로에 토큰 없이 접근하면 401 에러가 발생해야 한다")
-    void authenticatedPathFailTest() throws Exception {
-        mockMvc.perform(get("/api/admin/some-resource")
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized()); // Custom EntryPoint 작동 확인
-    }
+        @Test
+        @DisplayName("로그인 경로는 permitAll이므로 접근 시 401이 발생하지 않는다")
+        void loginPath_ShouldNotReturn401() throws Exception {
+                mockMvc.perform(post("/api/member/login") // POST로 변경
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"email\":\"test@test.com\", \"password\":\"1234\"}")) // 가짜 바디
+                                .andDo(print())
+                                .andExpect(result -> org.assertj.core.api.Assertions
+                                                .assertThat(result.getResponse().getStatus())
+                                                .isNotEqualTo(401));
+        }
 
-    // ── authenticationEntryPoint 핵심 검증 ────────────────────
+        @Test
+        @DisplayName("인증이 필요한 경로에 토큰 없이 접근하면 401 에러가 발생해야 한다")
+        void authenticatedPathFailTest() throws Exception {
+                mockMvc.perform(get("/api/admin/some-resource")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isUnauthorized()); // Custom EntryPoint 작동 확인
+        }
 
-    @Test
-    @DisplayName("인증 없이 보호된 엔드포인트에 접근하면 401과 UNAUTHORIZED JSON을 반환한다")
-    void accessProtectedResource_WithoutAuth_Returns401WithJson() throws Exception {
-        // POST /api/posts 는 anyRequest().authenticated() 대상
-        mockMvc.perform(post("/api/posts")
-                .contentType("application/json")
-                .content("{}"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(content().contentType("application/json;charset=UTF-8"))
-                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
-    }
+        // ── authenticationEntryPoint 핵심 검증 ────────────────────
 
-    @Test
-    @DisplayName("인증 없이 DELETE 요청을 하면 401과 UNAUTHORIZED JSON을 반환한다")
-    void deletePost_WithoutAuth_Returns401WithJson() throws Exception {
-        mockMvc.perform(delete("/api/posts/1"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(content().contentType("application/json;charset=UTF-8"))
-                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
-    }
+        @Test
+        @DisplayName("인증 없이 보호된 엔드포인트에 접근하면 401과 UNAUTHORIZED JSON을 반환한다")
+        void accessProtectedResource_WithoutAuth_Returns401WithJson() throws Exception {
+                // POST /api/posts 는 anyRequest().authenticated() 대상
+                mockMvc.perform(post("/api/posts")
+                                .contentType("application/json")
+                                .content("{}"))
+                                .andExpect(status().isUnauthorized())
+                                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+        }
 
-    @Test
-    @DisplayName("인증 없이 PATCH 요청을 하면 401과 UNAUTHORIZED JSON을 반환한다")
-    void patchPost_WithoutAuth_Returns401WithJson() throws Exception {
-        mockMvc.perform(patch("/api/posts/1")
-                .contentType("application/json")
-                .content("{}"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(content().contentType("application/json;charset=UTF-8"))
-                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
-    }
+        @Test
+        @DisplayName("인증 없이 DELETE 요청을 하면 401과 UNAUTHORIZED JSON을 반환한다")
+        void deletePost_WithoutAuth_Returns401WithJson() throws Exception {
+                mockMvc.perform(delete("/api/posts/1"))
+                                .andExpect(status().isUnauthorized())
+                                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+        }
 
-    // ── 공개 허용 경로 검증 ────────────────────────────────────
+        @Test
+        @DisplayName("인증 없이 PATCH 요청을 하면 401과 UNAUTHORIZED JSON을 반환한다")
+        void patchPost_WithoutAuth_Returns401WithJson() throws Exception {
+                mockMvc.perform(patch("/api/posts/1")
+                                .contentType("application/json")
+                                .content("{}"))
+                                .andExpect(status().isUnauthorized())
+                                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+        }
 
-    @Test
-    @DisplayName("GET /api/posts 는 인증 없이도 200을 반환한다 (permitAll)")
-    void getAllPosts_WithoutAuth_Returns200() throws Exception {
-        // postService.getAllPosts()는 기본 Mock → 빈 리스트 반환
-        org.mockito.BDDMockito.given(postService.getAllPosts())
-                .willReturn(java.util.List.of());
+        // ── 공개 허용 경로 검증 ────────────────────────────────────
 
-        mockMvc.perform(get("/api/posts"))
-                .andExpect(status().isOk());
-    }
+        @Test
+        @DisplayName("GET /api/posts 는 인증 없이도 200을 반환한다 (permitAll)")
+        void getAllPosts_WithoutAuth_Returns200() throws Exception {
+                // postService.getAllPosts()는 기본 Mock → 빈 리스트 반환
+                org.mockito.BDDMockito.given(postService.getAllPosts())
+                                .willReturn(java.util.List.of());
 
-    @Test
-    @DisplayName("GET /api/posts/{id} 는 인증 없이도 접근 가능하다 (permitAll)")
-    void getPostById_WithoutAuth_IsPermitted() throws Exception {
-        // 존재하지 않는 ID → 서비스에서 예외 발생하더라도 인증 문제는 아님
-        // 여기서는 401이 아닌 것만 확인 (404 or 400은 서비스 레이어 동작)
-        mockMvc.perform(get("/api/posts/999"))
-                .andExpect(result -> org.assertj.core.api.Assertions
-                        .assertThat(result.getResponse().getStatus())
-                        .isNotEqualTo(401));
-    }
+                mockMvc.perform(get("/api/posts"))
+                                .andExpect(status().isOk());
+        }
 
-    // ── 응답 형식 검증 ─────────────────────────────────────────
+        @Test
+        @DisplayName("GET /api/posts/{id} 는 인증 없이도 접근 가능하다 (permitAll)")
+        void getPostById_WithoutAuth_IsPermitted() throws Exception {
+                // 존재하지 않는 ID → 서비스에서 예외 발생하더라도 인증 문제는 아님
+                // 여기서는 401이 아닌 것만 확인 (404 or 400은 서비스 레이어 동작)
+                mockMvc.perform(get("/api/posts/999"))
+                                .andExpect(result -> org.assertj.core.api.Assertions
+                                                .assertThat(result.getResponse().getStatus())
+                                                .isNotEqualTo(401));
+        }
 
-    @Test
-    @DisplayName("401 응답의 Content-Type은 application/json;charset=UTF-8이어야 한다")
-    void unauthorizedResponse_ContentType_IsJson() throws Exception {
-        mockMvc.perform(post("/api/posts")
-                .contentType("application/json")
-                .content("{}"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(content().contentType("application/json;charset=UTF-8"));
-    }
+        // ── 응답 형식 검증 ─────────────────────────────────────────
 
-    @Test
-    @DisplayName("401 응답 바디에 error 필드가 UNAUTHORIZED 값으로 포함되어야 한다")
-    void unauthorizedResponse_Body_ContainsErrorField() throws Exception {
-        mockMvc.perform(delete("/api/posts/1"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
-    }
+        @Test
+        @DisplayName("401 응답의 Content-Type은 application/json;charset=UTF-8이어야 한다")
+        void unauthorizedResponse_ContentType_IsJson() throws Exception {
+                mockMvc.perform(post("/api/posts")
+                                .contentType("application/json")
+                                .content("{}"))
+                                .andExpect(status().isUnauthorized())
+                                .andExpect(content().contentType("application/json;charset=UTF-8"));
+        }
+
+        @Test
+        @DisplayName("401 응답 바디에 error 필드가 UNAUTHORIZED 값으로 포함되어야 한다")
+        void unauthorizedResponse_Body_ContainsErrorField() throws Exception {
+                mockMvc.perform(delete("/api/posts/1"))
+                                .andExpect(status().isUnauthorized())
+                                .andExpect(jsonPath("$.error").value("UNAUTHORIZED"));
+        }
 }

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -36,7 +36,7 @@ function App() {
         // Silent Refresh 시도
         const response = await reissueMember();
         // memberApi의 응답 구조에 따라 적절히 수정 (예: response.data)
-        const { status, message, token } = response;
+        const { status, token } = response;
 
         if ((status === 200 || status === 201) && token) {
           authStore.setToken(token);

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -39,7 +39,6 @@ function App() {
         const { status, message, token } = response;
 
         if ((status === 200 || status === 201) && token) {
-          console.log("자동 로그인 성공:", message);
           authStore.setToken(token);
         }
       } catch {
@@ -56,7 +55,7 @@ function App() {
   if (!authChecked) {
     return (
       <div className="loading-screen">
-        로딩 중...
+        인증 검사 중...
       </div>
     );
   }

--- a/finance-portfolio-frontend/src/pages/common/LoadingPage.jsx
+++ b/finance-portfolio-frontend/src/pages/common/LoadingPage.jsx
@@ -1,0 +1,10 @@
+
+const LoadingPage = () => {
+    return (
+        <div className="container mt-5 text-center">
+            <h2>잠시만 기다려주세요...</h2>
+        </div>
+    );
+};
+
+export default LoadingPage;

--- a/finance-portfolio-frontend/src/pages/members/LoginPage.jsx
+++ b/finance-portfolio-frontend/src/pages/members/LoginPage.jsx
@@ -48,9 +48,8 @@ const LoginPage = () => {
                 <div className="col-12 col-sm-8 col-md-5">
                     <div className="card shadow-sm">
                         <div className="card-body p-4">
-                            <h3 className="card-title text-center mb-1">📈 Finance Portfolio</h3>
                             <p className="text-center text-muted mb-4">
-                                로그인하여 포트폴리오를 관리하세요
+                                로그인 정보를 입력하세요
                             </p>
 
                             <form onSubmit={handleSubmit}>

--- a/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
@@ -37,7 +37,7 @@ const PostDetail = () => {
         }
     };
 
-    if (loading) return <div className="container mt-5">로딩 중...</div>;
+    if (loading) return <LoadingPage />;
     if (!post) return null;
 
     return (

--- a/finance-portfolio-frontend/src/pages/posts/PostEditor.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostEditor.jsx
@@ -83,6 +83,7 @@ const PostEditor = () => {
                     <label htmlFor="content" className="form-label">내용</label>
                     <CKEditor
                         id="content"
+                        className=".ck-editor__wrapper"
                         editor={ClassicEditor}
                         data={content}
                         onReady={(editor) => {

--- a/finance-portfolio-frontend/src/pages/posts/PostList.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostList.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { getAllPosts, cleanUpFiles } from '../../api/postApi';
+import LoadingPage from '../common/LoadingPage';
 
 const PostList = () => {
     const [posts, setPosts] = useState([]);
@@ -33,13 +34,10 @@ const PostList = () => {
         }
     };
 
-    if (loading) return <div>로딩 중...</div>;
+    if (loading) return <LoadingPage />;
 
     return (
         <div className="container mt-5">
-            <div className="d-flex justify-content-between align-items-center mb-3">
-                <h2>금융 포트폴리오 게시판</h2>
-            </div>
 
             <div className="mb-3 d-flex gap-2">
                 <button onClick={() => navigate('/editor')} className="btn btn-warning">새 글</button>

--- a/finance-portfolio-frontend/src/store/authStore.js
+++ b/finance-portfolio-frontend/src/store/authStore.js
@@ -1,3 +1,5 @@
+// 엑세스 토큰 저장소(메모리)
+
 let accessToken = null;
 
 const authStore = {


### PR DESCRIPTION
## 개요
- **문제상황**: 사이트 첫 접속 및 새로고침 시 리프레쉬 토큰이 존재함에도 `silent refresh`가 작동하지 않는 문제 발생.
- **원인**:  `httponly`로 제작된 보안 쿠키는 브라우저에서 존재 유무조차 파악할 수 없기에 `document.cookie`를 통한 리프레쉬 토큰 체크 기능이 작동하지 않음.
- **개선방안**: 브라우저에서 `httponly` 쿠키는 절대로 인식할 수 없는 것이 보안 상 정상이기 때문에 리프레쉬 토큰과 동시에  `httponly=false`인 상태 표시 쿠키를 전달받아 토큰 존재 유무를 파악.
- **추가개선**
  - 각 컨트롤러에 분산되어있던 쿠키 관련 로직(생성 및 만료, 토큰 추출)을 별도 메서드로 분리하여 역할 명확화 및 중복 제거.
  - 각 페이지에 분산되어있던 로딩 페이지를 별도 `jsx`로 분리하여 중복 제거.

## 변경사항
- 🍃**서버**
  - **인증 상태 관리 개선**
    - **MemberController**, **TokenReissueController**: 쿠키 제어 로직을 `TokenCookieManager`로 위임하여 컨트롤러 **책임 분리**.
    - **TokenCookieManager** 추가
      - `refreshToken`(보안)과 `isLoggedIn`(상태 표시) 쿠키의 생명주기를 동기화.
      - 쿠키 생성/만료/추출 로직을 캡슐화하여 코드 중복 제거 및 유지보수성 향상.
  - **보안 개선**
    - **TokenCookieManager**: `addCookie` 방식에서 `addHeader` + `ResponseCookie` 방식으로 변경하여 `sameSite("Lax")`옵션을 통해 CSRF 공격에 대한 방어 계층 추가.

- ⚛️**프론트**
  - **App.jsx**: `document.cookie.includes('isLoggedIn=true')`를 통해 로그인 상태 플래그 체크.
  - **로딩페이지 분리**: 각 페이지 별로 분산되어있던 로딩페이지를 분리하여 통합 관리.
    - **LoadingPage.jsx**: 각 페이지에 산재해 있던 로딩 UI를 공통 컴포넌트로 분리하여 UI 일관성 확보 및 재사용성 증대.
## 결과
- **보안강화**: `sameSite`를 통해 CSRF 방어 단계 추가.
- **작업효율증대**: 불필요하게 분산/중복되어있던 코드들을 별도로 분리, 통합 관리하여 재사용성과 가독성 등 개발 효율 증가.
  - 쿠키 관련 정책을 수정하려면 `TokenCookieManager` 한 곳만 확인하면 되도록 개선

## 관련이슈
- #89 : 프론트 `document.cookie` 체크 추가