### PR TITLE
[Feat] ⚛️ 에러페이지 인자 수신 다변화

### DIFF
--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -53,7 +53,7 @@ const Navbar = () => {
                 {authStore.isLoggedIn() ? (
                     <>
                         <span className="text-light badge bg-secondary px-3 py-2">
-                            `사용자`님 {/* authStore.nickname 교체 예정 */}
+                            사용자님 {/* authStore.nickname 교체 예정 */}
                         </span>
                         <button onClick={onLogout} className="btn btn-outline-light btn-sm">
                             로그아웃

--- a/finance-portfolio-frontend/src/pages/common/ErrorPage.jsx
+++ b/finance-portfolio-frontend/src/pages/common/ErrorPage.jsx
@@ -1,12 +1,26 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 
-const ErrorPage = ({ status, message }) => {
+
+// prop으로 값 수신
+const ErrorPage = ({ status: propStatus, message: propMessage }) => {
+
     const navigate = useNavigate();
+    // 엔드포인트로 값 수신
+    const [searchParams] = useSearchParams();
+    // 메모리로 값 수신
+    const location = useLocation();
+
+    // 엔드포인트(인터셉터) || props(라우트) || 메모리(네비게이트) || 기본 문구
+    const status = searchParams.get('status') || location.state?.status || propStatus || '오류';
+    const message = searchParams.get('message') || location.state?.message || propMessage || '알 수 없는 오류가 발생했습니다.';
+
+    console.log(searchParams.get('status'));
+    console.log(location.state?.status);
 
     return (
         <div className="container mt-5 text-center">
-            <h2>{status || '오류'}</h2>
-            <p>{message || '알 수 없는 오류가 발생했습니다.'}</p>
+            <h2>{status}</h2>
+            <p>{message}</p>
             <button onClick={() => navigate('/')} className="btn btn-secondary">
                 홈으로
             </button>

--- a/finance-portfolio-frontend/src/pages/posts/PostList.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostList.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { getAllPosts, cleanUpFiles } from '../../api/postApi';
 import LoadingPage from '../common/LoadingPage';
+import { navRef } from '../../utils/history';
 
 const PostList = () => {
     const [posts, setPosts] = useState([]);
@@ -34,6 +35,10 @@ const PostList = () => {
         }
     };
 
+    const toErrorPageTest = () => {
+        navRef.navigate('/error', { state: { status: '999', message: '메시지 전달' } });
+    }
+
     if (loading) return <LoadingPage />;
 
     return (
@@ -42,6 +47,7 @@ const PostList = () => {
             <div className="mb-3 d-flex gap-2">
                 <button onClick={() => navigate('/editor')} className="btn btn-warning">새 글</button>
                 <button onClick={onCleanUpFiles} className="btn btn-warning">미참조 이미지 삭제</button>
+                <button onClick={() => toErrorPageTest()} className="btn btn-warning">에러테스트</button>
             </div>
 
             <table className="table table-hover">


### PR DESCRIPTION
## 개요
- **문제상황**: Axios 인터셉터에서 쿼리 스트링을 통해 엔드포인트를 송신할 때, 기존 `prop` 방식만으로는 에러 페이지에 인자가 정상적으로 전달되지 않아 기본 문구가 출력.
- **개선방안**: prop, 쿼리 스트링, 메모리 등 인자 수신 경로를 다변화하여 호출 환경(라우트, 리액트 외부, 네비게이트)에 관계없이 에러 메시지가 출력되도록 개선.
## 변경사항
- **인자 수신 다변화**
  - **ErrorPage.jsx**
    - `prop`: 리액트 내부 직접 전달.
    - `useSearchParams`: URL 쿼리 스트링을 통한 외부 엔드포인트 스트링 전달.
    - `useLocation`: `Maps` 시 `state`를 통한 메모리 인자 전달.
  - **PostList.jsx**: 에러 페이지의 다변화된 인자 수신 기능 검증을 위한 테스트 버튼 구현.
## 결과
- **유연성 확보**: 인자 전달 방식의 제약을 해소하여 리액트 내/외부 환경 차이와 무관하게 에러 페이지 정상 동작 보장.
