### PR TITLE
[Infra] ☁️ CloudFront 403/404 응답 페이지 추가 및 예외처리 고도화

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
@@ -112,6 +113,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleDuplicateException(DuplicateResourceException e) {
         String message = resolveMessage(e.getMessage(), "🛠이미 존재하는 리소스입니다.");
         return buildErrorResponse(HttpStatus.CONFLICT, "DUPLICATE_RESOURCE", message);
+    }
+
+    // 500 INTERNAL_SERVER_ERROR
+    // CloudFrontConfigurationException: CloudFront Header Filter 쪽 런타임 에러.
+    @ExceptionHandler(CloudFrontConfigurationException.class)
+    public ResponseEntity<ErrorResponse> handleCloudFrontConfigurationException(Exception e) {
+        log.error("CloudFront 설정 에러 발생!", e.getMessage(), e);
+        String message = resolveMessage(e.getMessage(), "시스템 보안 설정에 문제가 발생했습니다.");
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "CLOUDFRONT_CONFIG_ERROR", message);
     }
 
     // 500 INTERNAL_SERVER_ERROR

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/CloudFrontConfigurationException.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/CloudFrontConfigurationException.java
@@ -1,0 +1,15 @@
+package com.finance.finportfolio.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class CloudFrontConfigurationException extends RuntimeException {
+    public CloudFrontConfigurationException(String message) {
+        super(message);
+    }
+
+    public CloudFrontConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/DuplicateResourceException.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/DuplicateResourceException.java
@@ -10,4 +10,8 @@ public class DuplicateResourceException extends RuntimeException {
     public DuplicateResourceException(String message) {
         super(message);
     }
+
+    public DuplicateResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/RefreshTokenNotFoundException.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/RefreshTokenNotFoundException.java
@@ -10,4 +10,8 @@ public class RefreshTokenNotFoundException extends RuntimeException {
     public RefreshTokenNotFoundException(String message) {
         super(message);
     }
+
+    public RefreshTokenNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilter.java
@@ -4,7 +4,12 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
+
 import java.io.IOException;
 
 // Component에 등록하면 호출과 무관하게 헤더 검증 로직이 작동하는 문제가 있음!: @Value 사용 불가
@@ -20,9 +25,9 @@ public class CloudFrontHeaderFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         try {
             // 1. OPTIONS 요청(CORS) 무조건 통과
@@ -50,7 +55,7 @@ public class CloudFrontHeaderFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         } catch (Exception e) {
-            throw new RuntimeException("CloudFront Header Filter 초기화 실패: " + e.getMessage());
+            throw new CloudFrontConfigurationException("CloudFront Header Filter 초기화 실패: " + e.getMessage());
         }
 
     }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -7,18 +7,18 @@ import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
-@Import(SecurityConfig.class)
+@Import({ SecurityConfig.class, TokenCookieManager.class })
 class MemberControllerTest {
 
     @Autowired
@@ -42,16 +42,16 @@ class MemberControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private MemberService memberService;
 
-    @SpyBean
+    @MockitoSpyBean
     private TokenCookieManager tokenCookieManager;
 
-    @MockBean
+    @MockitoBean
     private AuthenticationManager authenticationManager;
 
-    @MockBean
+    @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
     @Autowired

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -2,7 +2,6 @@ package com.finance.finportfolio.domain.member.controller;
 
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
-import com.finance.finportfolio.global.error.GlobalExceptionHandler;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import jakarta.servlet.http.Cookie;
@@ -10,12 +9,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -38,16 +37,16 @@ class TokenReissueControllerTest {
         @Autowired
         private MockMvc mockMvc;
 
-        @MockBean
+        @MockitoBean
         private MemberService memberService;
 
-        @SpyBean
+        @MockitoSpyBean
         private TokenCookieManager tokenCookieManager;
 
-        @MockBean
+        @MockitoBean
         private AuthenticationManager authenticationManager;
 
-        @MockBean
+        @MockitoBean
         private JwtTokenProvider jwtTokenProvider;
 
         // ── 정상 재발급 ────────────────────────────────────────────

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/CustomUserDetailsServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/CustomUserDetailsServiceTest.java
@@ -3,7 +3,6 @@ package com.finance.finportfolio.domain.member.service;
 import com.finance.finportfolio.domain.member.entity.Member;
 import com.finance.finportfolio.domain.member.entity.Role;
 import com.finance.finportfolio.domain.member.repository.MemberRepository;
-import com.finance.finportfolio.domain.member.service.CustomUserDetailsService;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -42,20 +42,20 @@ class SecurityConfigTest {
         private MockMvc mockMvc;
 
         // PostController 의존성 Mock
-        @MockBean
+        @MockitoBean
         private com.finance.finportfolio.domain.post.service.PostService postService;
 
         // MemberController 타고 들어온 의존성
-        @MockBean
+        @MockitoBean
         private TokenCookieManager tokenCookieManager;
 
-        @MockBean
+        @MockitoBean
         private MemberService memberService;
 
-        @MockBean
+        @MockitoBean
         private JwtTokenProvider jwtTokenProvider;
 
-        @MockBean
+        @MockitoBean
         private AuthenticationManager authenticationManager;
 
         @Test

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
@@ -43,6 +43,17 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("UsernameNotFoundException 발생 시 401 에러와 전용 코드를 반환한다")
+    void handleUsernameNotFoundExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/user-not-found"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("🛠존재하지 않는 사용자입니다."))
+                .andDo(print());
+    }
+
+    @Test
     @DisplayName("BadCredentialsException 발생 시 401 에러와 전용 코드를 반환한다")
     void handleBadCredentialsTest() throws Exception {
         mockMvc.perform(get("/test/bad-credentials"))
@@ -72,6 +83,17 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.code").value("DUPLICATE_RESOURCE"))
                 .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("CloudFront 설정 에러 발생 시 500 에러를 반환한다")
+    void handleCloudFrontConfigurationExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/cloudfront-config-error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.code").value("CLOUDFRONT_CONFIG_ERROR"))
+                .andExpect(jsonPath("$.message").value("시스템 보안 설정에 문제가 발생했습니다."))
                 .andDo(print());
     }
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
@@ -1,11 +1,13 @@
 package com.finance.finportfolio.global.error;
 
+import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 @RestController
 public class TestExceptionController {
@@ -18,6 +20,11 @@ public class TestExceptionController {
     @GetMapping("/test/illegal-state-default")
     public void throwIllegalStateDefault() {
         throw new IllegalStateException(""); // 메시지 비움 -> 🛠 기본 메시지 작동 확인
+    }
+
+    @GetMapping("/test/user-not-found")
+    public void throUsernameNotFound() {
+        throw new UsernameNotFoundException("");
     }
 
     @GetMapping("/test/bad-credentials")
@@ -33,6 +40,11 @@ public class TestExceptionController {
     @GetMapping("/test/duplicate")
     public void throwDuplicate() {
         throw new DuplicateResourceException("이미 가입된 이메일입니다.");
+    }
+
+    @GetMapping("/test/cloudfront-config-error")
+    public void throwCloudFrontConfiguration() {
+        throw new CloudFrontConfigurationException("");
     }
 
     @GetMapping("/test/runtime")

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/CloudFrontConfigurationExceptionTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/CloudFrontConfigurationExceptionTest.java
@@ -1,0 +1,33 @@
+package com.finance.finportfolio.global.error.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CloudFrontConfigurationExceptionTest {
+
+    @Test
+    @DisplayName("메시지를 담은 예외가 정상적으로 생성되고 던져진다")
+    void exceptionMessageTest() {
+        String message = "CloudFront Header Filter 초기화 실패";
+
+        assertThatThrownBy(() -> {
+            throw new CloudFrontConfigurationException(message);
+        }).isInstanceOf(CloudFrontConfigurationException.class)
+                .hasMessage(message);
+    }
+
+    @Test
+    @DisplayName("원인 예외(Cause)를 포함하여 던질 수 있다")
+    void exceptionWithCauseTest() {
+        Throwable cause = new IllegalArgumentException("원본 에러");
+        String message = "래핑된 에러 메시지";
+
+        CloudFrontConfigurationException ex = new CloudFrontConfigurationException(message, cause);
+
+        assertThat(ex.getMessage()).isEqualTo(message);
+        assertThat(ex.getCause()).isEqualTo(cause);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/DuplicateResourceExceptionTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/DuplicateResourceExceptionTest.java
@@ -1,0 +1,33 @@
+package com.finance.finportfolio.global.error.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DuplicateResourceExceptionTest {
+
+    @Test
+    @DisplayName("메시지를 담은 예외가 정상적으로 생성되고 던져진다")
+    void exceptionMessageTest() {
+        String message = "이미 존재하는 아이디입니다.";
+
+        assertThatThrownBy(() -> {
+            throw new DuplicateResourceException(message);
+        }).isInstanceOf(DuplicateResourceException.class)
+                .hasMessage(message);
+    }
+
+    @Test
+    @DisplayName("원인 예외(Cause)를 포함하여 던질 수 있다")
+    void exceptionWithCauseTest() {
+        Throwable cause = new IllegalArgumentException("원본 에러");
+        String message = "래핑된 에러 메시지";
+
+        DuplicateResourceException ex = new DuplicateResourceException(message, cause);
+
+        assertThat(ex.getMessage()).isEqualTo(message);
+        assertThat(ex.getCause()).isEqualTo(cause);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/RefreshTokenNotFoundExceptionTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/RefreshTokenNotFoundExceptionTest.java
@@ -1,0 +1,33 @@
+package com.finance.finportfolio.global.error.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenNotFoundExceptionTest {
+
+    @Test
+    @DisplayName("메시지를 담은 예외가 정상적으로 생성되고 던져진다")
+    void exceptionMessageTest() {
+        String message = "Refresh Token이 없습니다.";
+
+        assertThatThrownBy(() -> {
+            throw new RefreshTokenNotFoundException(message);
+        }).isInstanceOf(RefreshTokenNotFoundException.class)
+                .hasMessage(message);
+    }
+
+    @Test
+    @DisplayName("원인 예외(Cause)를 포함하여 던질 수 있다")
+    void exceptionWithCauseTest() {
+        Throwable cause = new IllegalArgumentException("원본 에러");
+        String message = "래핑된 에러 메시지";
+
+        RefreshTokenNotFoundException ex = new RefreshTokenNotFoundException(message, cause);
+
+        assertThat(ex.getMessage()).isEqualTo(message);
+        assertThat(ex.getCause()).isEqualTo(cause);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilterTest.java
@@ -6,12 +6,20 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import com.finance.finportfolio.domain.member.controller.MemberController;
+import com.finance.finportfolio.domain.member.controller.TokenCookieManager;
+import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class CloudFrontHeaderFilterTest {
@@ -91,5 +99,40 @@ class CloudFrontHeaderFilterTest {
 
         // then
         verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("예외 발생 시 지정된 메시지가 포함된 CloudFrontConfigurationException을 던진다")
+    void throwCloudFrontConfigurationException() {
+        // given
+        String originalErrorMessage = "Access Key is missing";
+        String expectedPrefix = "CloudFront Header Filter 초기화 실패: ";
+
+        // when & then
+        assertThatThrownBy(() -> {
+            try {
+                // 의도적으로 예외 상황 발생
+                throw new RuntimeException(originalErrorMessage);
+            } catch (Exception e) {
+                // 작성하신 catch 블록 로직
+                throw new CloudFrontConfigurationException(expectedPrefix + e.getMessage());
+            }
+        })
+                .isInstanceOf(CloudFrontConfigurationException.class)
+                .hasMessage(expectedPrefix + originalErrorMessage);
+    }
+
+    @Test
+    @DisplayName("예외가 발생해도 원인(Cause)이 유지되는지 확인")
+    void exceptionCausePersistence() {
+        // given
+        RuntimeException cause = new RuntimeException("Original Cause");
+
+        // when
+        CloudFrontConfigurationException exception = new CloudFrontConfigurationException("Test Message", cause);
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo("Test Message");
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilterTest.java
@@ -6,14 +6,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-
-import com.finance.finportfolio.domain.member.controller.MemberController;
-import com.finance.finportfolio.domain.member.controller.TokenCookieManager;
 import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 
 import java.io.IOException;
@@ -25,8 +19,8 @@ import static org.mockito.Mockito.*;
 class CloudFrontHeaderFilterTest {
 
     private CloudFrontHeaderFilter filter;
-    private final String HEADER_NAME = "X-Custom-CF-Header";
-    private final String HEADER_VALUE = "secret-value-123";
+    private static final String HEADER_NAME = "X-Custom-CF-Header";
+    private static final String HEADER_VALUE = "secret-value-123";
 
     @BeforeEach
     void setUp() {
@@ -106,20 +100,15 @@ class CloudFrontHeaderFilterTest {
     void throwCloudFrontConfigurationException() {
         // given
         String originalErrorMessage = "Access Key is missing";
-        String expectedPrefix = "CloudFront Header Filter 초기화 실패: ";
+        String expectedMessage = "CloudFront Header Filter 초기화 실패: " + originalErrorMessage;
 
         // when & then
+        // 람다 내부 로직을 예외를 직접 던지는 단일 호출로 리팩토링
         assertThatThrownBy(() -> {
-            try {
-                // 의도적으로 예외 상황 발생
-                throw new RuntimeException(originalErrorMessage);
-            } catch (Exception e) {
-                // 작성하신 catch 블록 로직
-                throw new CloudFrontConfigurationException(expectedPrefix + e.getMessage());
-            }
+            throw new CloudFrontConfigurationException("CloudFront Header Filter 초기화 실패: " + originalErrorMessage);
         })
                 .isInstanceOf(CloudFrontConfigurationException.class)
-                .hasMessage(expectedPrefix + originalErrorMessage);
+                .hasMessage(expectedMessage);
     }
 
     @Test

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -14,6 +14,7 @@ import JoinPage from './pages/members/JoinPage';
 import ErrorPage from './pages/common/ErrorPage';
 import PrivateRoute from './components/auth/PrivateRoute';
 import { reissueMember } from './api/memberApi';
+import LoadingPage from './pages/common/LoadingPage';
 
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
@@ -53,11 +54,7 @@ function App() {
 
 
   if (!authChecked) {
-    return (
-      <div className="loading-screen">
-        인증 검사 중...
-      </div>
-    );
+    return <LoadingPage />;
   }
 
   return (

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -47,7 +47,7 @@ const Navbar = () => {
     }
 
     return (
-        <nav className="navbar navbar-expand-lg navbar-dark card-theme-custom fixed-top shadow">
+        <nav className="navbar navbar-expand-sm navbar-dark card-theme-custom fixed-top shadow">
             <div className="container">
                 {/* 브랜드 로고 */}
                 <NavLink to="/" className="navbar-brand fw-bold">
@@ -69,7 +69,7 @@ const Navbar = () => {
 
                 {/* 메뉴 영역 */}
                 <div className="collapse navbar-collapse" id="navbarNav">
-                    <ul className="navbar-nav me-auto gap-2">
+                    <ul className="navbar-nav me-auto gap-2 ">
                         <li className="nav-item">
                             <NavLink to="/posts" className={navLinkClass}>
                                 게시판
@@ -86,6 +86,8 @@ const Navbar = () => {
                             </NavLink>
                         </li>
                     </ul>
+
+                    <br />
 
                     {/* 우측 로그인 세션 */}
                     <div className="d-flex align-items-center gap-3">

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -24,23 +24,6 @@ const Navbar = () => {
         }
     };
 
-    // 미참조 이미지 삭제 버튼(admin 용으로 변경 예정)
-    const onCleanUpFiles = async () => {
-        if (globalThis.confirm('미참조 이미지를 삭제하시겠습니까?')) {
-            try {
-                await cleanUpFiles();
-            } catch (error) {
-                console.error("삭제 중 오류 발생:", error);
-                alert("삭제에 실패했습니다.");
-            }
-        }
-    };
-
-    // 에러페이지 동작 테스트(admin 용으로 변경 예정)
-    const toErrorPageTest = () => {
-        navref.navigate('/error', { state: { status: '999', message: '메시지 전달' } });
-    }
-
     // 활성화 된 페이지 표시
     const navLinkClass = ({ isActive }) => {
         return `nav-link ${isActive ? 'text-white fw-bold' : 'text-secondary'}`;

--- a/finance-portfolio-frontend/src/pages/members/JoinPage.jsx
+++ b/finance-portfolio-frontend/src/pages/members/JoinPage.jsx
@@ -82,7 +82,7 @@ const JoinPage = () => {
 
                             <div className="mb-3">
                                 <label htmlFor="password" className="form-label">
-                                    비밀번호
+                                    비밀번호{' '}
                                     <span className="text-muted ms-1" style={{ fontSize: '0.8rem' }}>
                                         (4자 이상)
                                     </span>


### PR DESCRIPTION
## 개요
- **문제상황**: 루트(`/`) 이외의 엔드포인트(`/posts` 등)에서 새로고침 시 `403 Forbidden` 발생.
- **에러메시지**
  - 콘솔: `the server responded with a status of 403 ()`
  - 반환 JSON:
```
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
</Error>
```
- **원인**: CloudFront에 `Default root object` 설정으로 인해 루트 접속 시에는 `index.html`이 정상 반환되나, 그 외의 경로로 직접 접근 시 S3 내 객체를 서버에서 찾으려 시도함. 이 과정에서 /api/* 경로가 아닌 요청이 CloudFront Behavior 설정에 의해 차단되어 `403 Forbidden`가 발생.
- **개선방안**: CloudFront의 사용자 정의 오류 응답(Custom Error Response) 설정을 활용. `403` 및 `404` 오류 발생 시 응답 페이지로 `/index.html`을 반환하도록 구성하여, 클라이언트 사이드 라우팅이 요청을 처리하도록 유도.

## 변경사항
- ☁️**CloudFront**: 사용자 정의 오류 응답 생성을 통해 `403`, `404` 오류 코드 발생 시 응답페이지를 `/index.html`로 매핑하고 응답코드를 `200`으로 전환하도록 변경.

<img width="567" height="78" alt="image" src="https://github.com/user-attachments/assets/e781dc41-c3e1-459f-91dd-f698aa887134" />


- 🍃**서버**
  - **커스텀 예외처리 추가**: `CloudFrontConfigurationException`를 추가하여 CloudFront Header Filter에서 발생하는 `500`에러 처리를 구분.
  - **Mock 마이그레이션**: Spring Boot 3.4+ 표준에 따라 `@MockBean`, `@SpyBean`을`@MockitoBean`, `MockitoSpyBean`으로 교체하여 테스트 코드 현대화.

## 결과
- **라우팅 오류 해결**: 루트 이외의 경로로 직접 접근하거나 새로고침 시에도 `index.html`을 정상적으로 응답받아 SPA 라우팅이 원활하게 작동함.
- **예외처리 고도화**: 인프라 기인 오류를 별도 예외로 분리하여 장애 원인 파악 및 대응 속도 향상.
- **유지보수성 강화**: 최신 Spring Boot API 적용을 통해 프레임워크 업데이트 시 발생할 수 있는 잠재적인 제거(Removal) 리스크를 선제적으로 제거.