### PR TITLE
[Feat] 🍃 게시판 카테고리 추가

### DIFF
--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -97,7 +97,7 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.exclusions", "**/domain/post/**, **/*Dto*, **/*Request*, **/*Response*, **/*Entity*"
+        property "sonar.coverage.exclusions", "**/domain/post/**, **/domain/category/**, **/*Dto*, **/*Request*, **/*Response*, **/*Entity*"
     }
 }
 

--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -88,6 +88,7 @@ jacocoTestReport {
                 "**/*Response*",
                 "**/*Entity*",
 				"**/domain/post/**",
+				"**/domain/category/**",
                 "**/FinalPortfolioApplication*" // 메인 클래스 제외
             ])
         }))

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/controller/CategoryController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/controller/CategoryController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/categories")
+@RequestMapping("/api/category")
 public class CategoryController {
 
     private final CategoryService categoryService;

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/controller/CategoryController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/controller/CategoryController.java
@@ -1,0 +1,52 @@
+package com.finance.finportfolio.domain.category.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.finance.finportfolio.domain.category.dto.CategoryRequestDto;
+import com.finance.finportfolio.domain.category.dto.CategoryResponseDto;
+import com.finance.finportfolio.domain.category.service.CategoryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    // 조회
+    @GetMapping
+    public ResponseEntity<List<CategoryResponseDto>> getCategories() {
+        return ResponseEntity.ok(categoryService.findAllOrderByOrder());
+    }
+
+    // 생성
+    @PostMapping
+    public ResponseEntity<Long> save(@RequestBody CategoryRequestDto requestDto) {
+        return ResponseEntity.ok(categoryService.save(requestDto));
+    }
+
+    // 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<Long> update(@PathVariable Long id, @RequestBody CategoryRequestDto requestDto) {
+        categoryService.update(id, requestDto);
+        return ResponseEntity.ok(id);
+    }
+
+    // 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Long> delete(@PathVariable Long id) {
+        categoryService.delete(id);
+        return ResponseEntity.ok(id);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/dto/CategoryRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/dto/CategoryRequestDto.java
@@ -1,0 +1,19 @@
+package com.finance.finportfolio.domain.category.dto;
+
+import com.finance.finportfolio.domain.category.entity.Category;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record CategoryRequestDto(
+        @NotBlank(message = "카테고리 이름은 필수입니다.") String name,
+
+        int sortOrder) {
+    // DTO -> Entity
+    public Category toEntity() {
+        return Category.builder()
+                .name(name)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/dto/CategoryResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/dto/CategoryResponseDto.java
@@ -1,0 +1,16 @@
+package com.finance.finportfolio.domain.category.dto;
+
+import com.finance.finportfolio.domain.category.entity.Category;
+
+public record CategoryResponseDto(
+        Long id,
+        String name,
+        int sortOrder) {
+    // Entity -> DTO 변환 생성자
+    public CategoryResponseDto(Category category) {
+        this(
+                category.getId(),
+                category.getName(),
+                category.getSortOrder());
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/entity/Category.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/entity/Category.java
@@ -1,0 +1,42 @@
+package com.finance.finportfolio.domain.category.entity;
+
+// JPA
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+// Lombok
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "category", indexes = @Index(name = "idx_sort_order", columnList = "sortOrder"))
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private int sortOrder = 0;
+
+    @Builder
+    public Category(String name, int sortOrder) {
+        this.name = name;
+        this.sortOrder = sortOrder;
+    }
+
+    public void update(String name, int sortOrder) {
+        this.name = name;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/repository/CategoryRepository.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.finance.finportfolio.domain.category.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.finance.finportfolio.domain.category.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findAllByOrderBySortOrderAsc();
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/service/CategoryService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/service/CategoryService.java
@@ -1,0 +1,51 @@
+package com.finance.finportfolio.domain.category.service;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.finance.finportfolio.domain.category.dto.CategoryRequestDto;
+import com.finance.finportfolio.domain.category.dto.CategoryResponseDto;
+import com.finance.finportfolio.domain.category.entity.Category;
+import com.finance.finportfolio.domain.category.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    // 생성
+    @Transactional
+    public Long save(CategoryRequestDto requestDto) {
+        return categoryRepository.save(requestDto.toEntity()).getId();
+    }
+
+    // 수정 (더티 체킹)
+    @Transactional
+    public void update(Long id, CategoryRequestDto requestDto) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 없습니다. id=" + id));
+
+        // Category 엔티티에 update 메서드 구현 필요
+        category.update(requestDto.name(), requestDto.sortOrder());
+    }
+
+    // 삭제
+    @Transactional
+    public void delete(Long id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 없습니다. id=" + id));
+        categoryRepository.delete(category);
+    }
+
+    // 목록 조회
+    public List<CategoryResponseDto> findAllOrderByOrder() {
+        return categoryRepository.findAllByOrderBySortOrderAsc().stream()
+                .map(CategoryResponseDto::new)
+                .toList();
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
@@ -1,12 +1,15 @@
 package com.finance.finportfolio.domain.post.dto;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import com.finance.finportfolio.domain.category.entity.Category;
 import com.finance.finportfolio.domain.post.entity.Post;
 
 // PostResponseDto - Post 엔티티 Get용 DTO
 public record PostResponseDto(
         Long id,
+        String categoryName,
         String author,
         String title,
         String content,
@@ -14,12 +17,15 @@ public record PostResponseDto(
         LocalDateTime createdAt) {
     // Entity -> DTO 변환을 위한 생성자
     public PostResponseDto(Post post) {
-        this(post, null);
+        this(post, post.getContent());
     }
 
     public PostResponseDto(Post post, String processedContent) {
         this(
                 post.getId(),
+                Optional.ofNullable(post.getCategory())
+                        .map(Category::getName)
+                        .orElse("미분류"),
                 post.getAuthor(),
                 post.getTitle(),
                 processedContent,

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
@@ -1,5 +1,6 @@
 package com.finance.finportfolio.domain.post.dto;
 
+import com.finance.finportfolio.domain.category.entity.Category;
 import com.finance.finportfolio.domain.post.entity.Post;
 
 import lombok.Builder;
@@ -7,23 +8,26 @@ import lombok.Builder;
 // PostSaveRequestDto - Post 엔티티 Set 용 DTO
 @Builder
 public record PostSaveRequestDto(
+                Long categoryId,
                 String author,
                 String title,
                 String content,
                 Boolean hasImage) {
 
         public PostSaveRequestDto {
+                java.util.Objects.requireNonNull(categoryId, "categoryId는 필수입니다.");
                 if (hasImage == null) {
                         hasImage = false;
                 }
         }
 
-        // DTO -> Entity 변환 (DB 저장용)
-        public Post toEntity() {
+        // DTO -> Entity 변환 (DB 저장용 builder)
+        public Post toEntity(Category category, String cleanedContent, Boolean hasImage) {
                 return Post.builder()
+                                .category(category)
                                 .author(author)
                                 .title(title)
-                                .content(content)
+                                .content(cleanedContent)
                                 .hasImage(hasImage)
                                 .build();
         }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostUpdateRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostUpdateRequestDto.java
@@ -4,7 +4,8 @@ import lombok.Builder;
 
 @Builder
 public record PostUpdateRequestDto(
-                String title,
-                String content,
-                Boolean hasImage) {
+        Long categoryId,
+        String title,
+        String content,
+        Boolean hasImage) {
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/entity/Post.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/entity/Post.java
@@ -6,13 +6,18 @@ import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.finance.finportfolio.domain.category.entity.Category;
+
 // JPA
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners; //JPA 시간용
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 // Lombok
@@ -29,6 +34,12 @@ public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // Category DB와 JOIN
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     private String author;
 
     private String title;
@@ -43,14 +54,16 @@ public class Post {
     private LocalDateTime createdAt;
 
     @Builder
-    private Post(String author, String title, String content, boolean hasImage) {
+    private Post(Category category, String author, String title, String content, boolean hasImage) {
+        this.category = category;
         this.author = author;
         this.title = title;
         this.content = content;
         this.hasImage = hasImage;
     }
 
-    public void update(String title, String content, boolean hasImage) {
+    public void update(Category category, String title, String content, boolean hasImage) {
+        this.category = category;
         this.title = title;
         this.content = content;
         this.hasImage = hasImage;

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/repository/PostRepository.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.finance.finportfolio.domain.post.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.lang.NonNull;
 
 import com.finance.finportfolio.domain.post.entity.Post;
@@ -17,4 +20,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @NonNull
     Page<Post> findAll(@NonNull Pageable pageable);
+
+    // n+1 방지
+    @Query("select p from Post p join fetch p.category")
+    List<Post> findAllWithCategory();
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -13,12 +13,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.finance.finportfolio.domain.category.entity.Category;
+import com.finance.finportfolio.domain.category.repository.CategoryRepository;
 import com.finance.finportfolio.domain.post.dto.PostResponseDto;
 import com.finance.finportfolio.domain.post.dto.PostSaveRequestDto;
 import com.finance.finportfolio.domain.post.dto.PostUpdateRequestDto;
 import com.finance.finportfolio.domain.post.entity.Post;
 import com.finance.finportfolio.domain.post.repository.PostRepository;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,12 +39,9 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final FileService fileService;
+    private final CategoryRepository categoryRepository;
 
     // Jsoup 소독 메서드
-    private String cleanText(String text) {
-        return (text == null || text.isEmpty()) ? "" : Jsoup.clean(text, Safelist.none());
-    }
-
     private String cleanHtml(String text) {
         return (text == null || text.isEmpty()) ? "" : Jsoup.clean(text, HTML_SAFE_LIST);
     }
@@ -85,12 +85,11 @@ public class PostService {
         String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
 
-        Post post = Post.builder()
-                .author(cleanText(requestDto.author()))
-                .title(cleanText(requestDto.title()))
-                .content(cleanedContent)
-                .hasImage(hasImage)
-                .build();
+        // 카테고리 존재 여부 확인 및 조회
+        Category category = categoryRepository.findById(requestDto.categoryId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. ID: " + requestDto.categoryId()));
+
+        Post post = requestDto.toEntity(category, cleanedContent, hasImage);
 
         return postRepository.save(post).getId();
     }
@@ -106,8 +105,11 @@ public class PostService {
         String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
 
+        Category category = categoryRepository.findById(requestDto.categoryId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. ID: " + requestDto.categoryId()));
+
         // 여기서 엔티티 값 바꿔서 스냅샷이랑 차이나게 -> 더티체킹으로 DB update
-        post.update(cleanText(requestDto.title()), cleanedContent, hasImage);
+        post.update(category, requestDto.title(), cleanedContent, hasImage);
     }
 
     // 게시글 삭제

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/post/entity/PostTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/post/entity/PostTest.java
@@ -3,6 +3,8 @@ package com.finance.finportfolio.domain.post.entity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.finance.finportfolio.domain.category.entity.Category;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PostTest {
@@ -42,12 +44,17 @@ class PostTest {
                 .hasImage(false)
                 .build();
 
+        Category newCategory = Category.builder()
+                .name("수정된 카테고리")
+                .sortOrder(2)
+                .build();
+
         String newTitle = "수정된 제목";
         String newContent = "<h1>수정된 내용</h1>";
         boolean newHasImage = true;
 
         // when
-        post.update(newTitle, newContent, newHasImage);
+        post.update(newCategory, newTitle, newContent, newHasImage);
 
         // then
         assertThat(post.getTitle()).isEqualTo(newTitle);


### PR DESCRIPTION
## 개요
- 게시글을 성격에 따라 분류, 정보를 빠르게 찾을 수 있도록 카테고리 시스템을 구축.

## 작업내용
- **Category 도메인 추가**
  - **Entity**: `Category` (id, name, sortOrder) 생성
  - **Repository**: `findAllByOrderBySortOrderAsc` 메서드를 구현하여 정렬된 카테고리 목록 조회 지원
  - **DTO**: 요청/응답 처리를 위한 `CategoryRequestDto`, `CategoryResponseDto` 구현
  - **Service/Controller**: 카테고리 관리를 위한 CRUD API 구현 (`/api/category/`)

- **Post 도메인 수정**
  - **Entity**: `Post`와 `Category` 간의 ManyToOne 연관 관계 매핑 (Lazy Loading 적용)
  - **Repository**: N+1 문제를 방지하기 위해 `join fetch`를 사용하는 `findAllWithCategory` 메서드 추가
  - **DTO**:
    - `PostResponseDto`: `categoryName` 필드 추가
    - `PostSaveRequestDto`, `PostUpdateRequestDto`: `categoryId` 필드를 통해 연관 관계 수신
  - **Service**: 게시글 저장/수정 시 `categoryId`를 검증하고 엔티티에 매핑하는 로직 반영

## 결과
  - **성능 최적화**: 게시글 목록 조회 시 카테고리 정보를 한 번의 쿼리로 가져오도록 Fetch Join을 적용하여 쿼리 효율성을 높였습니다.
  - **데이터 안정성**: DTO 내 방어 로직을 추가하여, 카테고리가 없는 게시글 조회 시 발생할 수 있는 `NullPointerException`을 방지.

## 관련이슈
- #16