### PR TITLE
[Feat] 사용자 데이터 처리 안정성 개선 및 플래그 쿠키를 통한 전달(데이터 처리 방식 의사결정 명세 포함)

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.finance.finportfolio.domain.member.controller;
 
+import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
 import com.finance.finportfolio.domain.member.service.MemberService;
@@ -33,16 +34,14 @@ public class MemberController {
             HttpServletResponse response) {
 
         try {
-            // 1. 로그인 처리 → Access Token + Refresh Token 발급
-            String[] tokens = memberService.login(loginRequest);
-            String accessToken = tokens[0];
-            String refreshToken = tokens[1];
+            // 1. 로그인 처리 → Access Token + Refresh Token + 고객정보 발급
+            LoginResultDto loginResult = memberService.login(loginRequest);
 
             // 2. 토큰 쿠키 전달 (리프레쉬 토큰, 로그인 플래그)
-            tokenCookieManager.setAuthCookies(response, refreshToken);
+            tokenCookieManager.setAuthCookies(response, loginResult.refreshToken(), loginResult.memberResponseDto());
 
             // 3. Access Token → 응답 헤더로 전달 (프론트에서 authStore 메모리에 저장)
-            response.setHeader("Authorization", "Bearer " + accessToken);
+            response.setHeader("Authorization", "Bearer " + loginResult.accessToken());
 
             return ResponseEntity.ok("로그인이 완료되었습니다.");
         } catch (Exception e) {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenCookieManager.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenCookieManager.java
@@ -1,14 +1,19 @@
 package com.finance.finportfolio.domain.member.controller;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
 
 @Component
 public class TokenCookieManager {
@@ -16,27 +21,58 @@ public class TokenCookieManager {
     private static final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
 
     // 쿠키 생성
-    public void setAuthCookies(HttpServletResponse response, String refreshToken) {
-        addCookieInternal(response, refreshToken, COOKIE_MAX_AGE);
+    public void setAuthCookies(HttpServletResponse response,
+            String refreshToken,
+            MemberResponseDto memberResponseDto) {
+        addCookieInternal(response, refreshToken, memberResponseDto, COOKIE_MAX_AGE);
     }
 
     // 쿠키 만료
     public void expireAuthCookies(HttpServletResponse response) {
-        addCookieInternal(response, "", 0);
+        addCookieInternal(response, "", null, 0);
     }
 
-    private void addCookieInternal(HttpServletResponse response, String value, int maxAge) {
-        String flagValue = (maxAge > 0) ? "true" : "false";
+    private void addCookieInternal(HttpServletResponse response,
+            String refreshToken,
+            MemberResponseDto memberResponseDto,
+            int maxAge) {
 
-        ResponseCookie refCookie = createCookie("refreshToken", value, maxAge, true);
+        // 2. 비보안 플래그 쿠키 설정 데이터 준비
+        String flagValue = "false";
+        String nickname = "";
+        String role = "";
+        if (maxAge > 0 && memberResponseDto != null) {
+            flagValue = "true";
+            nickname = memberResponseDto.nickname();
+            role = memberResponseDto.role() != null ? memberResponseDto.role().name() : "";
+        }
+
+        // 리프레쉬 쿠키(보안)
+        ResponseCookie refCookie = createCookie("refreshToken", refreshToken, maxAge, true);
+        // 각종 플래그 쿠키(비보안)
         ResponseCookie loginFlag = createCookie("isLoggedIn", flagValue, maxAge, false);
+        ResponseCookie nickNameCookie = createCookie("userNickname", nickname, maxAge, false);
+        ResponseCookie roleCookie = createCookie("userRole", role, maxAge, false);
 
+        // 리프레쉬 쿠키 헤더에 포함
         response.addHeader(HttpHeaders.SET_COOKIE, refCookie.toString());
+        // 플래그 쿠키 헤더에 포함
         response.addHeader(HttpHeaders.SET_COOKIE, loginFlag.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, nickNameCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, roleCookie.toString());
     }
 
-    private ResponseCookie createCookie(String name, String value, int maxAge, boolean httpOnly) {
-        return ResponseCookie.from(name, value)
+    private ResponseCookie createCookie(@NonNull String name, String value, int maxAge, boolean httpOnly) {
+        // 쿠키 값의 Null 체크 및
+        String safeValue = (value == null) ? "" : value;
+
+        // 인코딩 처리 (한글 등 Non-ASCII 문자 대응)
+        if ("userNickname".equals(name) && value != null) {
+            safeValue = URLEncoder.encode(value, StandardCharsets.UTF_8)
+                    .replace("\\+", "%20"); // 공백 처리 호환성
+        }
+
+        return ResponseCookie.from(name, safeValue)
                 .httpOnly(httpOnly)
                 .secure(true) // HTTPS 필수
                 .path("/")

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -4,7 +4,6 @@ import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Arrays;
 
 @RestController
 @RequiredArgsConstructor

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -1,5 +1,6 @@
 package com.finance.finportfolio.domain.member.controller;
 
+import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
@@ -38,13 +39,11 @@ public class TokenReissueController {
         }
 
         try {
-            String[] tokens = memberService.reissue(refreshToken);
-            String newAccessToken = tokens[0];
-            String newRefreshToken = tokens[1];
+            LoginResultDto loginResult = memberService.reissue(refreshToken);
 
-            tokenCookieManager.setAuthCookies(response, newRefreshToken);
+            tokenCookieManager.setAuthCookies(response, loginResult.refreshToken(), loginResult.memberResponseDto());
 
-            response.setHeader("Authorization", "Bearer " + newAccessToken);
+            response.setHeader("Authorization", "Bearer " + loginResult.accessToken());
 
             return ResponseEntity.ok("토큰이 재발급되었습니다.");
         } catch (Exception e) {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/dto/LoginResultDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/dto/LoginResultDto.java
@@ -1,0 +1,11 @@
+package com.finance.finportfolio.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResultDto(
+        String accessToken,
+        String refreshToken,
+        MemberResponseDto memberResponseDto) {
+
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/dto/MemberResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/dto/MemberResponseDto.java
@@ -1,6 +1,8 @@
 package com.finance.finportfolio.domain.member.dto;
 
-public record MemberResponseDto(
-                String nickname) {
+import com.finance.finportfolio.domain.member.entity.Role;
 
+public record MemberResponseDto(
+        String nickname,
+        Role role) {
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.finance.finportfolio.domain.member.service;
 
+import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
+import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
 import com.finance.finportfolio.domain.member.entity.Member;
 import com.finance.finportfolio.domain.member.entity.RefreshToken;
 import com.finance.finportfolio.domain.member.entity.Role;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,24 +57,29 @@ public class MemberService {
                 return memberRepository.save(member).getId();
         }
 
-        // ── 로그인 → [accessToken, refreshToken] 반환 ─────────────
+        // ── 로그인 ─────────────
+        // LoginResultDto: 서버 내부 DTO [accessToken, refreshToken, MemberResponseDto]
+        // MemberResponseDto: 프론트 반환 DTO [nickname, role]
         @Transactional
-        public String[] login(MemberLoginRequestDto request) {
+        public LoginResultDto login(MemberLoginRequestDto request) {
 
-                // 1. 아이디/비밀번호 인증
+                // 아이디/비밀번호 인증
                 Authentication authentication = authenticationManager.authenticate(
                                 new UsernamePasswordAuthenticationToken(
                                                 request.loginId(), request.password()));
 
                 String loginId = authentication.getName();
-                String role = authentication.getAuthorities().iterator().next().getAuthority();
 
-                // 2. 토큰 생성
-                String accessToken = jwtTokenProvider.createAccessToken(loginId, role);
-                String refreshToken = jwtTokenProvider.createRefreshToken(loginId);
-
-                // 3. Refresh Token DB 저장 (없으면 insert, 있으면 rotate)
+                // DB에서 loginId로 Member find
                 Member member = findMemberByLoginId(loginId);
+
+                // 고객 정보 get
+                String nickName = member.getNickname();
+                Role role = member.getRole();
+
+                // 토큰 생성
+                String accessToken = jwtTokenProvider.createAccessToken(loginId, role.name());
+                String refreshToken = jwtTokenProvider.createRefreshToken(loginId);
 
                 refreshTokenRepository.findByMember(member)
                                 .ifPresentOrElse(
@@ -84,7 +92,13 @@ public class MemberService {
                                                         refreshTokenRepository.save(newToken);
                                                 });
 
-                return new String[] { accessToken, refreshToken };
+                // 토큰 및 고객정보 반환
+                MemberResponseDto memberResponseDto = new MemberResponseDto(nickName, role);
+                return LoginResultDto.builder()
+                                .accessToken(accessToken)
+                                .refreshToken(refreshToken)
+                                .memberResponseDto(memberResponseDto)
+                                .build();
         }
 
         // ── 로그아웃 → Refresh Token DB에서 삭제 ──────────────────
@@ -97,8 +111,10 @@ public class MemberService {
         }
 
         // ── 토큰 재발급 (Refresh Token Rotation) ──────────────────
+        // LoginResultDto: 서버 내부 DTO [accessToken, refreshToken, MemberResponseDto]
+        // MemberResponseDto: 프론트 반환 DTO [nickname, role]
         @Transactional
-        public String[] reissue(String refreshToken) {
+        public LoginResultDto reissue(String refreshToken) {
 
                 // 1. Refresh Token 유효성 검증
                 if (!jwtTokenProvider.validateToken(refreshToken)) {
@@ -107,10 +123,10 @@ public class MemberService {
 
                 String loginId = jwtTokenProvider.getLoginId(refreshToken);
 
-                // 2. DB에 저장된 토큰과 일치 여부 확인 (탈취 감지)
-
+                // DB에서 loginId로 Member find
                 Member member = findMemberByLoginId(loginId);
 
+                // 토큰 생성
                 RefreshToken savedToken = refreshTokenRepository.findByMember(member)
                                 .orElseThrow(() -> new IllegalStateException("로그인 상태가 아닙니다."));
 
@@ -120,13 +136,22 @@ public class MemberService {
                         throw new IllegalStateException("Refresh Token이 일치하지 않습니다.");
                 }
 
-                // 3. 새 토큰 발급 + Rotation
-                String role = member.getRole().getKey();
-                String newAccessToken = jwtTokenProvider.createAccessToken(loginId, role);
-                String newRefreshToken = jwtTokenProvider.createRefreshToken(loginId);
+                // 고객 정보 get
+                String nickName = member.getNickname();
+                Role role = member.getRole();
 
+                // 새 토큰 발급
+                String newAccessToken = jwtTokenProvider.createAccessToken(loginId, role.name());
+                String newRefreshToken = jwtTokenProvider.createRefreshToken(loginId);
+                // 더티 체킹 업데이트
                 savedToken.rotate(newRefreshToken);
 
-                return new String[] { newAccessToken, newRefreshToken };
+                // 토큰 및 고객정보 반환
+                MemberResponseDto memberResponseDto = new MemberResponseDto(nickName, role);
+                return LoginResultDto.builder()
+                                .accessToken(newAccessToken)
+                                .refreshToken(newRefreshToken)
+                                .memberResponseDto(memberResponseDto)
+                                .build();
         }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 
         private final JwtTokenProvider jwtTokenProvider;
 
+        // 기본 Rounds 10(실무 표준은 10~12, 복잡도는 1상승 시 2배 씩 증가)
         @Bean
         public PasswordEncoder passwordEncoder() {
                 return new BCryptPasswordEncoder();

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -1,8 +1,11 @@
 package com.finance.finportfolio.domain.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
+import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
+import com.finance.finportfolio.domain.member.entity.Role;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
@@ -26,10 +29,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @WebMvcTest(MemberController.class)
 @Import({ SecurityConfig.class, TokenCookieManager.class })
@@ -108,12 +115,20 @@ class MemberControllerTest {
     @WithMockUser
     @DisplayName("로그인 성공 시 Authorization 헤더와 refreshToken 쿠키가 반환된다")
     void login_Success() throws Exception {
+
+        String nickname = "테스터";
+        String encodedNickname = URLEncoder.encode(nickname, StandardCharsets.UTF_8);
+
         MemberLoginRequestDto loginRequest = new MemberLoginRequestDto("testId", "password123");
-        given(memberService.login(any())).willReturn(new String[] { "accessToken", "refreshToken" });
+        MemberResponseDto memberResponseDto = new MemberResponseDto("테스터", Role.USER);
+        LoginResultDto loginResult = new LoginResultDto("accessToken", "refreshToken", memberResponseDto);
+
+        given(memberService.login(any(MemberLoginRequestDto.class))).willReturn(loginResult);
 
         mockMvc.perform(post("/api/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)))
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string("로그인이 완료되었습니다."))
                 // Access Token 검증
@@ -121,18 +136,27 @@ class MemberControllerTest {
                 // Refresh Token 쿠키 검증 (HttpOnly)
                 .andExpect(cookie().value("refreshToken", "refreshToken"))
                 .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
                 // isLoggedIn 플래그 쿠키 검증 (JS 접근 가능)
                 .andExpect(cookie().value("isLoggedIn", "true"))
-                .andExpect(cookie().httpOnly("isLoggedIn", false));
+                .andExpect(cookie().httpOnly("isLoggedIn", false))
+                .andExpect(cookie().value("userNickname", encodedNickname))
+                .andExpect(cookie().value("userRole", "USER"));
     }
 
     @Test
     @WithMockUser
-    @DisplayName("JWT 방식에서는 CSRF 없이도 로그인 요청이 성공한다")
+    @DisplayName("JWT 방식(Stateless)이므로 CSRF 토큰 없이도 로그인 요청이 성공한다")
     void login_Success_WithoutCsrf() throws Exception {
+        // given
         MemberLoginRequestDto loginRequest = new MemberLoginRequestDto("testId", "password123");
-        given(memberService.login(any())).willReturn(new String[] { "accessToken", "refreshToken" });
+        MemberResponseDto memberResponseDto = new MemberResponseDto("테스터", Role.USER);
+        // 서비스 응답 객체 생성 (기존 String[]에서 LoginResultDto로 변경)
+        LoginResultDto loginResult = new LoginResultDto("accessToken", "refreshToken", memberResponseDto);
 
+        given(memberService.login(any(MemberLoginRequestDto.class))).willReturn(loginResult);
+
+        // when & then
         mockMvc.perform(post("/api/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)))

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -1,5 +1,8 @@
 package com.finance.finportfolio.domain.member.controller;
 
+import com.finance.finportfolio.domain.member.dto.LoginResultDto;
+import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
+import com.finance.finportfolio.domain.member.entity.Role;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
@@ -26,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hamcrest.Matchers;
@@ -53,38 +57,62 @@ class TokenReissueControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("유효한 Refresh Token 쿠키로 요청 시 새 토큰이 발급된다")
+        @DisplayName("유효한 Refresh Token 쿠키로 요청 시 새 토큰과 플래그 쿠키가 발급된다")
         void reissue_Success() throws Exception {
                 // given
                 String oldRefreshToken = "validOldRefreshToken";
                 String newAccessToken = "newAccessToken";
                 String newRefreshToken = "newRefreshToken";
+                String rawNickname = "테스터"; // 원본 닉네임
 
-                // 1. 추출 로직 Mocking
+                // 검증 시 사용할 인코딩된 닉네임 미리 정의
+                String encodedNickname = java.net.URLEncoder.encode(rawNickname,
+                                java.nio.charset.StandardCharsets.UTF_8);
+
+                MemberResponseDto memberResponseDto = new MemberResponseDto(rawNickname, Role.USER);
+
+                // 서비스 응답 객체 (LoginResultDto)
+                LoginResultDto loginResult = new LoginResultDto(newAccessToken, newRefreshToken, memberResponseDto);
+
+                // 1. 쿠키 추출 로직 Mocking
                 org.mockito.Mockito.doReturn(oldRefreshToken)
-                                .when(tokenCookieManager).extractRefreshTokenFromCookie(any());
+                                .when(tokenCookieManager)
+                                .extractRefreshTokenFromCookie(any());
 
-                // 2. 서비스 로직 Mocking
-                given(memberService.reissue(oldRefreshToken))
-                                .willReturn(new String[] { newAccessToken, newRefreshToken });
+                // 2. 서비스 로직 Mocking (새로운 DTO 반환 타입 적용)
+                given(memberService.reissue(oldRefreshToken)).willReturn(loginResult);
 
-                // 3. (중요) 실제 Response에 쿠키를 심어주는 동작 정의
+                // 3. TokenCookieManager의 setAuthCookies 동작 정의
+                // 파라미터: (response, refreshToken, memberResponseDto) - 총 3개
                 org.mockito.Mockito.doAnswer(invocation -> {
                         jakarta.servlet.http.HttpServletResponse response = invocation.getArgument(0);
                         String token = invocation.getArgument(1);
-                        // 테스트용 간이 쿠키 추가
-                        response.addCookie(new Cookie("refreshToken", token));
-                        response.addCookie(new Cookie("isLoggedIn", "true"));
+                        MemberResponseDto dto = invocation.getArgument(2);
+
+                        // 실제 로직과 유사하게 테스트용 쿠키 주입
+                        response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE,
+                                        "refreshToken=" + token + "; Secure; HttpOnly; Path=/");
+                        response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE,
+                                        "userNickname=" + encodedNickname + "; Secure; Path=/");
+                        response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE,
+                                        "isLoggedIn=true; Secure; Path=/");
+                        response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE,
+                                        "userRole=" + dto.role().name() + "; Secure; Path=/");
                         return null;
-                }).when(tokenCookieManager).setAuthCookies(any(), any());
+                }).when(tokenCookieManager).setAuthCookies(any(), any(), any());
 
                 // when & then
-                mockMvc.perform(post("/api/auth/reissue")
+                mockMvc.perform(post("/api/auth/reissue") // 엔드포인트 경로 확인 필요
                                 .cookie(new Cookie("refreshToken", oldRefreshToken)))
-                                .andDo(print()) // 이제 출력이 정상적으로 나옵니다.
                                 .andExpect(status().isOk())
+                                // Access Token 헤더 검증
+                                .andExpect(header().string("Authorization", "Bearer " + newAccessToken))
+                                // Refresh Token 및 플래그 쿠키 검증
                                 .andExpect(cookie().value("refreshToken", newRefreshToken))
-                                .andExpect(cookie().value("isLoggedIn", "true"));
+                                .andDo(print())
+                                .andExpect(cookie().value("isLoggedIn", "true"))
+                                .andExpect(cookie().value("userNickname", encodedNickname))
+                                .andExpect(cookie().value("userRole", "USER"));
         }
 
         // ── Refresh Token 없는 경우 ────────────────────────────────

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.finance.finportfolio.domain.member.service;
 
+import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
 import com.finance.finportfolio.domain.member.entity.Member;
@@ -102,25 +103,37 @@ class MemberServiceTest {
         // ── login ──────────────────────────────────────────────────
 
         @Test
-        @DisplayName("로그인 성공 - Access Token과 Refresh Token이 반환된다")
+        @DisplayName("로그인 성공 - Access Token, Refresh Token 및 회원 정보가 반환된다")
         void login_Success() {
+                // given
                 MemberLoginRequestDto request = new MemberLoginRequestDto("testId", "rawPassword");
-                Member member = createMember("testId");
+                Member member = createMember("testId"); // 닉네임, 역할 등이 포함된 Member 객체
 
                 Authentication authentication = new UsernamePasswordAuthenticationToken(
                                 "testId", null,
                                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
                 given(authenticationManager.authenticate(any())).willReturn(authentication);
                 given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
                 given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("accessToken");
                 given(jwtTokenProvider.createRefreshToken(any())).willReturn("refreshToken");
+
+                // 최초 로그인 시나리오 (기존 토큰 없음)
                 given(refreshTokenRepository.findByMember(member)).willReturn(Optional.empty());
 
-                String[] tokens = memberService.login(request);
+                // when
+                // 리턴 타입 반영: String[] -> LoginResultDto
+                LoginResultDto result = memberService.login(request);
 
-                assertThat(tokens[0]).isEqualTo("accessToken");
-                assertThat(tokens[1]).isEqualTo("refreshToken");
-                // 최초 로그인 → save 호출 확인
+                // then
+                assertThat(result.accessToken()).isEqualTo("accessToken");
+                assertThat(result.refreshToken()).isEqualTo("refreshToken");
+
+                // 추가된 회원 정보(플래그 쿠키용) 검증
+                assertThat(result.memberResponseDto().nickname()).isEqualTo(member.getNickname());
+                assertThat(result.memberResponseDto().role().name()).isEqualTo("USER");
+
+                // 최초 로그인 시 RefreshToken 엔티티가 새롭게 저장(save)되는지 검증
                 verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
         }
 
@@ -192,8 +205,9 @@ class MemberServiceTest {
         // ── reissue ────────────────────────────────────────────────
 
         @Test
-        @DisplayName("토큰 재발급 성공 - 새 토큰 2개가 반환되고 DB 토큰이 교체된다")
+        @DisplayName("토큰 재발급 성공 - 새 토큰과 회원 정보가 반환되고 DB 토큰이 교체된다")
         void reissue_Success() {
+                // given
                 Member member = createMember("testId");
                 RefreshToken savedToken = RefreshToken.builder()
                                 .member(member)
@@ -204,14 +218,23 @@ class MemberServiceTest {
                 given(jwtTokenProvider.getLoginId("validRefreshToken")).willReturn("testId");
                 given(memberRepository.findByLoginId("testId")).willReturn(Optional.of(member));
                 given(refreshTokenRepository.findByMember(member)).willReturn(Optional.of(savedToken));
+
+                // 새 토큰들 생성 Mocking
                 given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("newAccessToken");
                 given(jwtTokenProvider.createRefreshToken(any())).willReturn("newRefreshToken");
 
-                String[] tokens = memberService.reissue("validRefreshToken");
+                // when
+                // 리턴 타입이 String[]에서 LoginResultDto로 변경됨
+                LoginResultDto result = memberService.reissue("validRefreshToken");
 
-                assertThat(tokens[0]).isEqualTo("newAccessToken");
-                assertThat(tokens[1]).isEqualTo("newRefreshToken");
-                // DB 토큰이 rotate()로 교체됐는지 확인
+                // then
+                assertThat(result.accessToken()).isEqualTo("newAccessToken");
+                assertThat(result.refreshToken()).isEqualTo("newRefreshToken");
+
+                // 닉네임과 역할 정보도 함께 오는지 확인 (플래그 쿠키 생성용)
+                assertThat(result.memberResponseDto().nickname()).isEqualTo(member.getNickname());
+
+                // DB 토큰이 rotate()를 통해 교체되었는지 확인
                 assertThat(savedToken.getToken()).isEqualTo("newRefreshToken");
         }
 

--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -12,6 +12,8 @@
         "axios": "^1.13.5",
         "bootstrap": "^5.3.8",
         "ckeditor5": "^47.5.0",
+        "js-cookie": "^3.0.5",
+        "jwt-decode": "^4.0.0",
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.0",
@@ -3225,14 +3227,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -4262,9 +4264,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4905,6 +4907,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5010,6 +5021,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {
@@ -6330,10 +6350,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7213,9 +7236,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/finance-portfolio-frontend/package.json
+++ b/finance-portfolio-frontend/package.json
@@ -17,6 +17,8 @@
     "axios": "^1.13.5",
     "bootstrap": "^5.3.8",
     "ckeditor5": "^47.5.0",
+    "js-cookie": "^3.0.5",
+    "jwt-decode": "^4.0.0",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import authStore from './store/authStore';
 import './App.css';
+import Cookies from 'js-cookie';
 
 import Layout from './components/layout/Layout';
 import PostLayout from './components/layout/PostLayout';
+import PrivateRoute from './components/auth/PrivateRoute';
 
 import PostList from './pages/posts/PostList';
 import PostDetail from './pages/posts/PostDetail';
@@ -13,9 +15,9 @@ import FairValuePage from './pages/finances/FinanceFair';
 import LoginPage from './pages/members/LoginPage';
 import JoinPage from './pages/members/JoinPage';
 import ErrorPage from './pages/common/ErrorPage';
-import PrivateRoute from './components/auth/PrivateRoute';
-import { reissueMember } from './api/memberApi';
 import LoadingPage from './pages/common/LoadingPage';
+
+import { reissueMember } from './api/memberApi';
 
 function App() {
   const [authChecked, setAuthChecked] = useState(false);
@@ -25,7 +27,7 @@ function App() {
     // 1. async 로직을 별도 함수로 분리
     const initAuth = async () => {
       const pathname = globalThis.location.pathname;
-      const hasAuthCookie = document.cookie.includes('isLoggedIn=true');
+      const hasAuthCookie = Cookies.get('isLoggedIn') === 'true';
 
       // 로그인/회원가입 페이지에서는 silent refresh 시도 안 함
       // 로그인 흔적도 없으면 silent refresh 시도 안 함

--- a/finance-portfolio-frontend/src/components/auth/AdminRoute.tsx
+++ b/finance-portfolio-frontend/src/components/auth/AdminRoute.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { jwtDecode } from 'jwt-decode'; // 설치 필요: npm install jwt-decode
+
+interface TokenPayload {
+    role: string;
+    exp: number;
+}
+
+const AdminRoute = () => {
+    const token = localStorage.getItem('token');
+
+    if (!token) return <Navigate to="/login" replace />;
+
+    try {
+        const decoded: TokenPayload = jwtDecode(token);
+
+        // DB의 role이 'ADMIN'이므로 이에 맞춰 조건 확인
+        if (decoded.role !== 'ADMIN') {
+            alert('관리자만 접근 가능합니다.');
+            return <Navigate to="/" replace />;
+        }
+
+        return <Outlet />;
+    } catch {
+        return <Navigate to="/login" replace />;
+    }
+};
+
+export default AdminRoute;

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -10,7 +10,7 @@ const Navbar = () => {
 
     // 쿠키에서 실시간 닉네임 호출(메모리 상태와 무관), 디코딩 예외 대비
     const rawNickname = Cookies.get('userNickname') || '';
-    const nickname = rawNickname ? decodeURIComponent(rawNickname.replace(/\+/g, ' ')) : '사용자';
+    const nickname = rawNickname ? decodeURIComponent(rawNickname.replaceAll(/\+/g, ' ')) : '사용자';
 
     const onLogout = async () => {
         try {

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import authStore from '../../store/authStore';
 import { logoutMember } from '../../api/memberApi';
+import Cookies from 'js-cookie';
 
 
 const Navbar = () => {
     const navigate = useNavigate();
+
+    // 쿠키에서 실시간 닉네임 호출(메모리 상태와 무관), 디코딩 예외 대비
+    const rawNickname = Cookies.get('userNickname') || '';
+    const nickname = rawNickname ? decodeURIComponent(rawNickname.replace(/\+/g, ' ')) : '사용자';
 
     const onLogout = async () => {
         try {
@@ -20,6 +25,12 @@ const Navbar = () => {
         } finally {
             // 로그아웃은 에러가 나도 클라이언트 상태는 정리
             authStore.clearToken();
+
+            // 비보안 플래그 쿠키들 직접 제거 (클라이언트 사이드에서도 정리)
+            Cookies.remove('userNickname');
+            Cookies.remove('userRole');
+            Cookies.remove('isLoggedIn');
+
             navigate('/', { replace: true });
         }
     };
@@ -77,7 +88,7 @@ const Navbar = () => {
                         {authStore.isLoggedIn() ? (
                             <>
                                 <span className="badge bg-secondary px-2 py-2 fw-normal text-nowrap">
-                                    사용자님
+                                    {nickname}님
                                 </span>
                                 <button
                                     onClick={onLogout}

--- a/finance-portfolio-frontend/src/store/authStore.js
+++ b/finance-portfolio-frontend/src/store/authStore.js
@@ -1,12 +1,18 @@
 // 엑세스 토큰 저장소(메모리)
+import Cookies from 'js-cookie';
 
 let accessToken = null;
+
+const checkLoginFlag = () => {
+    const flag = Cookies.get('isLoggedIn');
+    return flag === 'true' || decodeURIComponent(flag || '') === 'true';
+};
 
 const authStore = {
     getToken: () => accessToken,
     setToken: (token) => { accessToken = token; },
     clearToken: () => { accessToken = null; },
-    isLoggedIn: () => !!accessToken,
+    isLoggedIn: () => !!accessToken || checkLoginFlag(),
 };
 
 export default authStore;


### PR DESCRIPTION
## 개요
- **관리자 기능 추가**: 관리자 페이지 추가 전 사용자 정보(`Role`)를 프론트로 전달 필요.
- **사용자 정보 전달**: `nickname`, `role`등 사용자 데이터 및 로그인 플래그 전달 과정 안정성 확보 및 프론트엔드 UI 편의성 증대를 위한 리팩토링.
- **주요 변경 사항**:
  - 사용자 데이터 전송 객체(DTO) 도입을 통한 데이터 캡슐화.
  - 사용자 편의를 위한 클라이언트 측 상태 플래그(쿠키) 관리 라이브러리 교체.

## 의사결정 명세
- **배경**: 금융 보안 표준 준수를 위해 브라우저 노출 데이터 최소화와 불필요한 인증 네트워크 비용 절감 사이의 균형을 찾는 의사결정 과정을 명세하였습니다.
- 방안1. (플래그 쿠키): 빠른 개발과 클라이언트 측 가독성은 좋으나, 민감 정보 노출(휴먼 에러) 가능성 존재.
- 방안2. (AccessToken Claim):  토큰 내 사용자 정보를 포함해 보안성은 높으나, 클레임 비대화로 인한 매 요청 시 네트워크 부하(`Payload`) 증가.
- **최종선택**. (플래그 쿠키):
  - 결정: 보안 민감도가 낮은 최소한의 플래그만 쿠키로 전달하여 불필요한 재인증 요청 방지 및 각종 사용자 정보 관리.
  - 보완: 관리자 페이지 등 민감 라우트 진입 시 `silent refresh`를 강제하여 세션 무결성 검증.

- **결론**:
  - **실무 표준**: 보다 엄밀한 보안이 필요한 프로젝트에서는 `Claim`을 선택하는 것이 최선.

  - **선택 이유**: 본 프로젝트의 특성 상 네트워크 부하, 개발 편의, 데이터 관리의 명확성 등을 종합적으로 고려하여 플래그 쿠키 방식을 최종 선택.  CSRF 취약점은 서버 단의 API 차단 로직으로 방어하며, 성능과 금융 보안 표준 사이의 합의점을 도출.

  - **보완점**: `api`의 경우 서버 단에서 차단하기 때문에 괜찮으나, 프론트에서의 라우팅을 통해 접근할 수 있는 **관리자 페이지**의 경우 서버 필터를 거치지 않으므로 노출 될 위험성이 존재.
  - 따라서 관리자 페이지 접근 라우트의 경우 `silent refresh` 과정을 필수로 수행하여 클라이언트 변조를 통한 `ADMIN`이 아닌 이용자가 관리자 페이지에 접근하는 것을 방어.
  - 또한 `SameSite: Lax`와 `Custom Header`를 통한 CSRF 방어를 위한 검증과정 병행.


## 작업내용
- ☁️**인프라**
  - **초기 데이터 생성**: EC2 DB에 직접 접근하여 ADMIN 권한 관리자 계정 생성.

- 🍃**서버**
  - **데이터 구조 개선**: MemberService에서 기존 `String[]`으로 반환하던 방식을 `MemberResponseDto` 객체 기반으로 변경하여 데이터 명확성 확보.
  - **사용자 정보 전달**: 플래그 쿠키 형태를 통해 `nickname`, `role`등 사용자 데이터 및 로그인 플래그 전달.

- ⚛️**프론트**
  - **인증 플래그 관리**: `nickname`, `role` 등 비보안 정보를 클라이언트에서 활용할 수 있도록 플래그 쿠키(Non-secure Cookie) 생성 로직 추가.
  - **라이브러리 도입**: 직접적인 `document.cookie` 조작 대신 `js-cookie` 라이브러리를 도입하여 쿠키 관리 로직의 안정성 및 가독성 향상.
  - **UI/UX 개선**: 플래그 쿠키로 전달받은 닉네임을 네비게이션 바에 {nickname}님 형태로 실시간 렌더링.

## 결과
- **유지보수성**: DTO 사용으로 인한 데이터 구조 변경 시 유연한 대응 가능 및 `js-cookie` 사용으로 인한 코드 파편화 방지.
- **UX**: 로그인 후 즉각적인 닉네임 노출을 통해 개인화된 서비스 경험 제공.

## 관련이슈
- #101