### PR TITLE
[Feat] 🍃작성자 식별 도입 및 ⚛️작성자 UI 추가

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -49,9 +50,10 @@ public class PostController {
     }
 
     @PostMapping // 새 post - portfolio_db에 저장
-    public ResponseEntity<Long> createPost(@RequestBody PostSaveRequestDto requestDto) {
+    public ResponseEntity<Long> createPost(@RequestBody PostSaveRequestDto requestDto,
+            @AuthenticationPrincipal String loginId) {
         log.info("게시글 저장 시도 - 제목: {}", requestDto.title());
-        Long postId = postService.savePost(requestDto);
+        Long postId = postService.savePost(requestDto, loginId);
         return ResponseEntity.status(201).body(postId);
     }
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
@@ -26,7 +26,8 @@ public record PostResponseDto(
                 Optional.ofNullable(post.getCategory())
                         .map(Category::getName)
                         .orElse("미분류"),
-                post.getAuthor(),
+                Optional.ofNullable(post.getAuthor())
+                        .orElse("익명"),
                 post.getTitle(),
                 processedContent,
                 post.isHasImage(),

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
@@ -22,7 +22,7 @@ public record PostSaveRequestDto(
         }
 
         // DTO -> Entity 변환 (DB 저장용 builder)
-        public Post toEntity(Category category, String cleanedContent, Boolean hasImage) {
+        public Post toEntity(Category category, String author, String cleanedContent, Boolean hasImage) {
                 return Post.builder()
                                 .category(category)
                                 .author(author)

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -15,13 +15,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.finance.finportfolio.domain.category.entity.Category;
 import com.finance.finportfolio.domain.category.repository.CategoryRepository;
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
 import com.finance.finportfolio.domain.post.dto.PostResponseDto;
 import com.finance.finportfolio.domain.post.dto.PostSaveRequestDto;
 import com.finance.finportfolio.domain.post.dto.PostUpdateRequestDto;
 import com.finance.finportfolio.domain.post.entity.Post;
 import com.finance.finportfolio.domain.post.repository.PostRepository;
 
-import lombok.NonNull;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +42,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final FileService fileService;
     private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
 
     // Jsoup 소독 메서드
     private String cleanHtml(String text) {
@@ -86,7 +89,13 @@ public class PostService {
 
     // 게시글 저장, return: 저장된 게시글 ID
     @Transactional
-    public Long savePost(PostSaveRequestDto requestDto, String author) {
+    public Long savePost(PostSaveRequestDto requestDto, String loginId) {
+
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        String nickname = member.getNickname(); // 유저의 실제 닉네임
+
         // jsoup 살균과 Cdn삭제(키 추출)
         String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
@@ -95,7 +104,7 @@ public class PostService {
         Category category = categoryRepository.findById(requestDto.categoryId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. ID: " + requestDto.categoryId()));
 
-        Post post = requestDto.toEntity(category, author, cleanedContent, hasImage);
+        Post post = requestDto.toEntity(category, nickname, cleanedContent, hasImage);
 
         return postRepository.save(post).getId();
     }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -86,7 +86,7 @@ public class PostService {
 
     // 게시글 저장, return: 저장된 게시글 ID
     @Transactional
-    public Long savePost(PostSaveRequestDto requestDto) {
+    public Long savePost(PostSaveRequestDto requestDto, String author) {
         // jsoup 살균과 Cdn삭제(키 추출)
         String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
         boolean hasImage = checkImage(cleanedContent);
@@ -95,7 +95,7 @@ public class PostService {
         Category category = categoryRepository.findById(requestDto.categoryId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. ID: " + requestDto.categoryId()));
 
-        Post post = requestDto.toEntity(category, cleanedContent, hasImage);
+        Post post = requestDto.toEntity(category, author, cleanedContent, hasImage);
 
         return postRepository.save(post).getId();
     }

--- a/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
@@ -56,6 +56,10 @@ const PostDetail = () => {
                         <td>{post.categoryName}</td>
                     </tr>
                     <tr>
+                        <th className="table-light" style={{ width: '20%' }}>작성자</th>
+                        <td>{post.author}</td>
+                    </tr>
+                    <tr>
                         <th className="table-light" style={{ width: '20%' }}>제목</th>
                         <td>{post.title}</td>
                     </tr>

--- a/finance-portfolio-frontend/src/pages/posts/PostList.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostList.jsx
@@ -63,6 +63,7 @@ const PostList = () => {
                     <tr>
                         <th>ID</th>
                         <th>제목</th>
+                        <th>작성자</th>
                         <th>시간</th>
                     </tr>
                 </thead>
@@ -76,10 +77,10 @@ const PostList = () => {
                                     {post.hasImage && <span className="badge bg-info me-1">📷</span>}
                                     {post.title}
                                 </td>
+                                <td>{post.author}</td>
                                 <td>
                                     {new Intl.DateTimeFormat('ko-KR', {
                                         year: 'numeric', month: '2-digit', day: '2-digit',
-                                        hour: '2-digit', minute: '2-digit', hour12: false,
                                     }).format(new Date(post.createdAt))}
                                 </td>
                             </tr>


### PR DESCRIPTION
## 개요
- **현황**: `PostResponseDto`에 `author`가 있음에도 게시글 목록과 게시글 상세 페이지에서 작성자를 화면에 표시하지 않아 불편함을 야기.
- **개선사항**: 게시글 목록, 게시글 상세 페이지에서 작성자(`nickname`)을 표시하여 `UX` 개선.
- **추가 개선사항**: #111 에서 서술된 추가 보안취약점 - DTO를 프론트사이드에서 전달하는 문제를 서버에서 작성자를 식별하는 방식으로 개선.

## 변경사항
- 🍃서버
  - `PostContoller`: `@AuthenticationPrincipal`을 통하여 `loginId`를 서비스로 전달.
  - `PostService`: 전달받은 `loginId`를 통하여 `nickname`을 호출하여 `author`를 DTO로 전달하여 빌드.
  - `PostSaveRequestDto`: `author` 를 매개변수를 전달받아 엔티티 빌드.

- ⚛️프론트
  - `PostList.jsx`, `PostDetail.jsx`: 테이블에 작성자 표시 항목 추가.

## 결과
- UI에 작성자를 추가하여 **사용자 경험**과 **개발 편의성**을 향상.
- **보안강화**: 프론트 사이드에서 JSON을 변조하여 작성자를 변경하는 보안 취약점 방지.

## 관련이슈
- Fixes #111

<img width="1069" height="561" alt="image" src="https://github.com/user-attachments/assets/3e8a8ebe-5b7b-4ba1-a998-25390881502c" />

<img width="979" height="262" alt="image" src="https://github.com/user-attachments/assets/b0076e8d-ef54-4728-8863-d960ce07c0df" />
