### PR TITLE
[Security] 🍃Refresh Token 만료 예외 처리

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationEx
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -105,6 +106,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleRefreshTokenNotFoundException(RefreshTokenNotFoundException e) {
         String message = resolveMessage(e.getMessage(), "🛠Refresh Token이 없습니다.");
         return buildErrorResponse(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", message);
+    }
+
+    // 401 UNAUTHORIZED
+    // EXPIRED_JWT: 리프레쉬 토큰 없음
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ErrorResponse> handleExpiredJwtException(ExpiredJwtException e) {
+        String message = resolveMessage(e.getMessage(), "🛠토큰이 만료되었습니다.");
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", message);
     }
 
     // 409 CONFLICT

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
@@ -75,6 +75,17 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("BadCredentialsException 발생 시 401 에러와 전용 코드를 반환한다")
+    void ExpiredJwtExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/expired-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("EXPIRED_TOKEN"))
+                .andExpect(jsonPath("$.message").value("🛠토큰이 만료되었습니다."))
+                .andDo(print());
+    }
+
+    @Test
     @DisplayName("DuplicateResourceException 발생 시 409 에러를 반환한다")
     void handleDuplicateExceptionTest() throws Exception {
         mockMvc.perform(get("/test/duplicate"))

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
@@ -4,6 +4,8 @@ import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationEx
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
+import io.jsonwebtoken.ExpiredJwtException;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -35,6 +37,11 @@ public class TestExceptionController {
     @GetMapping("/test/refresh-token-not-found")
     public void throwRefreshTokenNotFound() {
         throw new RefreshTokenNotFoundException("");
+    }
+
+    @GetMapping("/test/expired-token")
+    public void throwExpiredJWT() {
+        throw new ExpiredJwtException(null, null, "");
     }
 
     @GetMapping("/test/duplicate")


### PR DESCRIPTION
## 개요
- **현황**: `MemberService.reissue()` 메서드에서 `Refresh Token`의 만료 여부를 검증하는 로직이 불완전.
- **문제상황**:` jwtTokenProvider.validateToken()` 호출 시 만료된 토큰일 경우 내부적으로 `ExpiredJwtException`을 던지지만, 서비스 계층에서 이를 적절히 캐치하지 못해 서버 내부 오류(`500`)가 발생.
- **해결방안**: 전역 예외 핸들러를 통해 `401 Unauthorized`로 적절히 응답하도록 수정.

## 변경사항
- **`GlobalExceptionHandler` 수정**:
  - `ExpiredJwtException` 핸들러를 통해 리프레쉬 토큰 만료 시 `401 Unauthorized`를 반환하여 사용자가 재로그인할 수 있도록 명확한 비즈니스 예외 처리.

## 기대효과
- **시스템 안정성 향상**: 예상치 못한 `500` 에러를 방지하여 서버 로그의 노이즈를 줄이고 시스템 신뢰도 구축.
- **사용자 경험(UX) 개선**: 토큰 만료 시 서버 에러가 아닌 "세션 만료" 등의 명확한 안내를 통해 자연스러운 재로그인 유도.
- **예외 처리 표준화**: JWT 관련 예외 발생 시 일관된 응답 규격을 유지하여 프론트엔드와의 통신 효율화.

## 관련이슈
- Fixes #114