### PR TITLE
[Security] API 및 헤더 인가설정 명세화를 통한 보안 조건 고도화

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/finance/controller/FinanceController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/finance/controller/FinanceController.java
@@ -17,32 +17,32 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/fin")
+@RequestMapping("/api/finance")
 public class FinanceController {
 
-    private final FinanceService financeService;
+        private final FinanceService financeService;
 
-    /*
-     * 고든 성장 모델 계산
-     * dps: 현재 배당금
-     * growthRate: 배당 성장률
-     * expectedYield: 기대수익률
-     */
-    @PostMapping("/fair") // POST 방식으로 변경
-    public ResponseEntity<CalculateFairResponseDto> calculateFairValue(
-            @RequestBody CalculateFairRequestDto requestDto) {
-        log.info("적정주가 계산 요청 - DPS: {}, Yield: {}, Growth: {}",
-                requestDto.dps(), requestDto.expectedYield(), requestDto.growthRate());
+        /*
+         * 고든 성장 모델 계산
+         * dps: 현재 배당금
+         * growthRate: 배당 성장률
+         * expectedYield: 기대수익률
+         */
+        @PostMapping("/fair") // POST 방식으로 변경
+        public ResponseEntity<CalculateFairResponseDto> calculateFairValue(
+                        @RequestBody CalculateFairRequestDto requestDto) {
+                log.info("적정주가 계산 요청 - DPS: {}, Yield: {}, Growth: {}",
+                                requestDto.dps(), requestDto.expectedYield(), requestDto.growthRate());
 
-        // 비즈니스 로직 수행
-        double value = financeService.calculateFairValue(
-                requestDto.dps(),
-                requestDto.expectedYield(),
-                requestDto.growthRate());
+                // 비즈니스 로직 수행
+                double value = financeService.calculateFairValue(
+                                requestDto.dps(),
+                                requestDto.expectedYield(),
+                                requestDto.growthRate());
 
-        // 응답 객체 생성
-        CalculateFairResponseDto responseDto = new CalculateFairResponseDto(value, "계산이 완료되었습니다.");
+                // 응답 객체 생성
+                CalculateFairResponseDto responseDto = new CalculateFairResponseDto(value, "계산이 완료되었습니다.");
 
-        return ResponseEntity.ok(responseDto);
-    }
+                return ResponseEntity.ok(responseDto);
+        }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenReissueController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/api/member")
 public class TokenReissueController {
 
     private final MemberService memberService;

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
@@ -78,10 +78,4 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/showLog")
-    public ResponseEntity<Void> showLog() {
-        log.info("서버에서 응답!");
-        return ResponseEntity.noContent().build();
-    }
-
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -38,6 +38,10 @@ public class SecurityConfig {
 
         private final JwtTokenProvider jwtTokenProvider;
 
+        // 중복방지용 상수처리
+        public static final String USER = "USER";
+        public static final String ADMIN = "ADMIN";
+
         // 기본 Rounds 10(실무 표준은 10~12, 복잡도는 1상승 시 2배 씩 증가)
         @Bean
         public PasswordEncoder passwordEncoder() {
@@ -86,21 +90,21 @@ public class SecurityConfig {
                                                 .requestMatchers("/error").permitAll()
                                                 // 게시판
                                                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
-                                                .requestMatchers("/api/posts/**").hasAnyRole("USER", "ADMIN")
+                                                .requestMatchers("/api/posts/**").hasAnyRole(USER, ADMIN)
                                                 .requestMatchers(HttpMethod.POST, "/api/image/upload")
-                                                .hasAnyRole("USER", "ADMIN")
+                                                .hasAnyRole(USER, ADMIN)
                                                 // 게시판 카테고리(관리는 ADMIN 제한)
                                                 .requestMatchers(HttpMethod.GET, "/api/category/**").permitAll()
-                                                .requestMatchers("/api/category/**").hasRole("ADMIN")
+                                                .requestMatchers("/api/category/**").hasRole(ADMIN)
                                                 // 회원관리
                                                 .requestMatchers("/api/member/join", "/api/member/login",
                                                                 "/api/member/reissue")
                                                 .permitAll()
-                                                .requestMatchers("/api/member/logout").hasAnyRole("USER", "ADMIN")
+                                                .requestMatchers("/api/member/logout").hasAnyRole(USER, ADMIN)
                                                 // 금융 계산기 등
                                                 .requestMatchers("/api/finance/**").permitAll()
                                                 // 관리자 기능
-                                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                                .requestMatchers("/api/admin/**").hasRole(ADMIN)
                                                 // 명시되지 않은 경로 모두 차단
                                                 .anyRequest().denyAll())
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.finance.finportfolio.global.config;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -30,6 +32,9 @@ import java.util.List;
 @RequiredArgsConstructor
 @SuppressWarnings("java:S4502")
 public class SecurityConfig {
+
+        @Value("${cloudfront.custom.header.name}")
+        private String cfHeaderName;
 
         private final JwtTokenProvider jwtTokenProvider;
 
@@ -75,14 +80,29 @@ public class SecurityConfig {
 
                                 // ── 인가 설정 ────────────────────────────────────────────
                                 .authorizeHttpRequests(auth -> auth
+                                                // 예비요청(OPTIONS)
+                                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                                                // 에러페이지
                                                 .requestMatchers("/error").permitAll()
+                                                // 게시판
                                                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                                                .requestMatchers("/api/posts/**").hasAnyRole("USER", "ADMIN")
+                                                .requestMatchers(HttpMethod.POST, "/api/image/upload")
+                                                .hasAnyRole("USER", "ADMIN")
+                                                // 게시판 카테고리(관리는 ADMIN 제한)
                                                 .requestMatchers(HttpMethod.GET, "/api/category/**").permitAll()
                                                 .requestMatchers("/api/category/**").hasRole("ADMIN")
-                                                .requestMatchers("/api/member/join", "/api/member/login").permitAll()
-                                                .requestMatchers("/api/auth/reissue").permitAll()
+                                                // 회원관리
+                                                .requestMatchers("/api/member/join", "/api/member/login",
+                                                                "/api/member/reissue")
+                                                .permitAll()
+                                                .requestMatchers("/api/member/logout").hasAnyRole("USER", "ADMIN")
+                                                // 금융 계산기 등
+                                                .requestMatchers("/api/finance/**").permitAll()
+                                                // 관리자 기능
                                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                                                .anyRequest().authenticated())
+                                                // 명시되지 않은 경로 모두 차단
+                                                .anyRequest().denyAll())
 
                                 // 인증되지 않은 사용자가 보호된 리소스에 접근 시 응답 설정
                                 .exceptionHandling(ex -> ex
@@ -90,6 +110,11 @@ public class SecurityConfig {
                                                         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                                                         response.setContentType("application/json;charset=UTF-8");
                                                         response.getWriter().write("{\"error\": \"UNAUTHORIZED\"}");
+                                                })
+                                                .accessDeniedHandler((request, response, authException) -> {
+                                                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                                                        response.setContentType("application/json;charset=UTF-8");
+                                                        response.getWriter().write("{\"error\": \"FORBIDDEN\"}");
                                                 }))
 
                                 // ── JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록 ──
@@ -109,7 +134,12 @@ public class SecurityConfig {
                                 "https://www.ljh-finance.com",
                                 "https://dev.ljh-finance.com"));
                 configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-                configuration.setAllowedHeaders(List.of("*"));
+                configuration.setAllowedHeaders(List.of(
+                                "Authorization", // JWT 토큰용
+                                "Content-Type", // JSON 데이터 전송용
+                                "X-Requested-With", // AJAX 요청 식별용
+                                cfHeaderName // CloudFront 커스텀헤더 (EC2 접근용)
+                ));
                 configuration.setAllowCredentials(true);
                 configuration.setExposedHeaders(List.of("Authorization"));
                 configuration.setMaxAge(3600L);

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -102,7 +102,7 @@ class TokenReissueControllerTest {
                 }).when(tokenCookieManager).setAuthCookies(any(), any(), any());
 
                 // when & then
-                mockMvc.perform(post("/api/auth/reissue") // 엔드포인트 경로 확인 필요
+                mockMvc.perform(post("/api/member/reissue") // 엔드포인트 경로 확인 필요
                                 .cookie(new Cookie("refreshToken", oldRefreshToken)))
                                 .andExpect(status().isOk())
                                 // Access Token 헤더 검증
@@ -126,7 +126,7 @@ class TokenReissueControllerTest {
                                 .when(tokenCookieManager).extractRefreshTokenFromCookie(any());
 
                 // when & then
-                mockMvc.perform(post("/api/auth/reissue"))
+                mockMvc.perform(post("/api/member/reissue"))
                                 .andExpect(status().isUnauthorized())
                                 .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_NOT_FOUND"))
                                 .andExpect(jsonPath("$.message", Matchers.containsString("Refresh Token이 없습니다.")));
@@ -146,7 +146,7 @@ class TokenReissueControllerTest {
                 given(memberService.reissue(any()))
                                 .willThrow(new IllegalStateException("유효하지 않은 Refresh Token입니다."));
 
-                mockMvc.perform(post("/api/auth/reissue")
+                mockMvc.perform(post("/api/member/reissue")
                                 .cookie(new Cookie("refreshToken", "invalidToken")))
                                 .andExpect(status().isBadRequest());
         }
@@ -163,7 +163,7 @@ class TokenReissueControllerTest {
                 given(memberService.reissue(any()))
                                 .willThrow(new IllegalStateException("Refresh Token이 일치하지 않습니다."));
 
-                mockMvc.perform(post("/api/auth/reissue")
+                mockMvc.perform(post("/api/member/reissue")
                                 .cookie(new Cookie("refreshToken", "stolenToken")))
                                 .andExpect(status().isBadRequest());
         }

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -19,7 +19,7 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
     (config) => {
         // reissue 요청일 때는 기존 토큰을 첨부하지 않음
-        if (config.url?.includes('/auth/reissue')) {
+        if (config.url?.includes('/member/reissue')) {
             return config;
         }
 
@@ -56,7 +56,7 @@ axiosInstance.interceptors.response.use(
         const originalRequest = error.config;
 
         // reissue 요청 자체가 실패했을 때
-        if (originalRequest.url === '/auth/reissue') {
+        if (originalRequest.url === '/member/reissue') {
             authStore.clearToken();
             isRefreshing = false;
             processPendingQueue(error); // 대기 중인 다른 요청들 종료
@@ -110,13 +110,13 @@ axiosInstance.interceptors.response.use(
         // 실제 엑세스 토큰 재발급 파트
         try {
             // Refresh Token은 HttpOnly 쿠키로 자동 전송(서버가 직접 쏨)
-            // 엑세스 토큰 재발급 `axiosInstance.post('/auth/reissue')`
+            // 엑세스 토큰 재발급 `axiosInstance.post('/member/reissue')`
             // status: 200, data: "토큰이 재발급되었습니다."
             // status: 400, data: "유효하지 않은 Refresh Token입니다."
             // status: 400, data: "존재하지 않는 회원입니다."
             // status: 400, data: "로그인 상태가 아닙니다."
             // status: 400, data: "Refresh Token이 일치하지 않습니다."
-            const response = await axiosInstance.post('/auth/reissue');
+            const response = await axiosInstance.post('/member/reissue');
             const authHeader = response.headers['authorization'] || response.headers['Authorization'];
             const newToken = authHeader?.replace('Bearer ', '');
 

--- a/finance-portfolio-frontend/src/api/memberApi.js
+++ b/finance-portfolio-frontend/src/api/memberApi.js
@@ -47,7 +47,7 @@ export const loginMember = async (form) => {
 // status: 400, data: "로그인 상태가 아닙니다."
 // status: 400, data: "Refresh Token이 일치하지 않습니다."
 export const reissueMember = async () => {
-    const response = await axiosInstance.post('/auth/reissue');
+    const response = await axiosInstance.post('/member/reissue');
     // 토큰 필요!
     return parseAuthResponse(response);
 };

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -20,8 +20,14 @@ const Navbar = () => {
                 alert(message);
             }
         } catch (error) {
-            const message = error.response?.data || "로그아웃 중 오류가 발생했습니다."
-            alert(message);
+            const status = error.response?.status;
+            const errorMessage = error.response?.data || "로그아웃 중 오류가 발생했습니다.";
+
+            // 401 에러(이미 토큰 만료)인 경우 alert 생략
+            // 그 외의 에러(500 등)인 경우에만 사용자에게 알림
+            if (status !== 401) {
+                alert(errorMessage);
+            }
         } finally {
             // 로그아웃은 에러가 나도 클라이언트 상태는 정리
             authStore.clearToken();


### PR DESCRIPTION
## 개요
- **현황**: 현재 이미지 업로드, 게시글 작성 등 모든 민감한 작업에 관한 API인가가`anyRequest().authenticated()`의 포괄적 설정에 의존.
- **문제상황**: 현재는 기능상 문제가 없으나, 차후 RBAC(역할 기반 권한 제어) 도입 시 일반 유저가 관리자 기능을 호출하는 권한 상승 공격에 노출될 수 있으며, 의도치 않은 엔드포인트가 '로그인'만으로 접근 가능해지는 보안 홀 발생 가능성 존재.
- **해결방안**: **화이트리스트** 전략을 채택하여, 모든 API 경로와 HTTP 메서드에 대해 명시적으로 인가 로직을 작성.

## 변경사항
- 🍃**서버**
  - **인가 설정 명세화(`SecurityConfig`)**:
    - `anyRequest().authenticated`를 `anyRequest().denyAll`로 변경하여 명시되지 않은 경로 차단.
    - `/api/image/upload").hasAnyRole("USER", "ADMIN")` 등 모든 API에 대한 명시적 인가 추가.
    - **헤더 명세화**: 기존 `*`로 모든 헤더를 포괄적 허용하는 방식에서 `Authorization`, `Content-Type`, `X-Requested-With`, CDN용 커스텀 헤더를 명시적으로 허용하도록 조건 강화.
  - **매핑 엔드포인트 개선**:
    - **분기 매핑 통합**: 회원가입, 로그인, 로그아웃은 `/api/member`에 매핑되어있으나
재인증 절차는 `/api/auth`에 매핑 되어있어 api 명칭이 일관적이지 않아 혼란을 가중.
      - `/api/member`로 엔드포인트를 통합하여 관리.
    - **명칭 구체화**: 기능이 불명확했던 `/api/fin`를 `/api/finance`로 엔드포인트가 기능을 정확히 나타내도록 수정.
  - **레거시 코드 삭제**: `PostController`의 레거시 테스트 `showLog()` 메서드 삭제.

- ⚛️**프론트**
  - **분기 매핑 통합**: 서버의 변경된 매핑 포인트에 따라 프론트 사이드의 엔드포인트 `/auth/reissue`를 `/member/reissue`로 변경.
  - **추가 변경점-로그아웃 UX 개선**: 로그아웃 시 토큰 만료(`401`)일 경우 `alert` 생략

## 의사결정 명세
- **DoS의 위협**
  - **문제상황**: 로그아웃 API의 인가 설정을 어느정도로 조일 것이냐에 대한 의사결정이 필요했습니다.
  - **방안1**: `permitAll()`로 변경
    - 장점: 쉽고 빠른 구현
    - 단점: **DoS 공격** 노출 - 특정 ID를 타겟팅하여 로그아웃 API를 무차별 호출하는 보안 취약점 존재!
  - **방안2(채택)**: 권한은 잠가두고 프론트엔드에서 처리
    - 장점: **DoS 공격** 방어
    - 단점: 프론트엔드 로직 부담
  - **요약**: 프론트 로그아웃의 토큰 만료 시 예외처리가 이미 대비되어 있어, `alert` 조건을 소폭 개선하고 **방안2**를 최종 선택.

## 기대효과
- **세밀한 접근 제어**: 사용자 역할(Role)에 따른 리소스 접근 권한을 명확히 분리하여 **보안 사고 예방**.
- **유지보수성 향상**: `SecurityConfig`만으로 전체 서비스의 출입 통제 명세를 한눈에 파악 가능
- **최소 권한 원칙 준수**: 의도치 않은 API 노출을 원천 차단함으로써 시스템의 전체적인 공격 표면 축소.

## 관련이슈
- Fixes #113