### PR TITLE
[Security] 🍃로그인 무차별 대입 대응 방어(bucket4j+Caffeine)

### DIFF
--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	// Bucket4j & Redis Integration(로그인 무차별 대입 방어)
+    implementation 'com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.12.0'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -100,7 +100,7 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.exclusions", "**/domain/post/**, **/domain/category/**, **/*Dto*, **/*Request*, **/*Response*, **/*Entity*"
+        property "sonar.coverage.exclusions", "**/domain/post/**, **/domain/category/**, **/*Dto*, **/*Request*, **/*Response*, **/entity/**"
     }
 }
 

--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -89,7 +89,7 @@ jacocoTestReport {
                 "**/*Dto*",
                 "**/*Request*",
                 "**/*Response*",
-                "**/*Entity*",
+                "**/entity/**",
 				"**/domain/post/**",
 				"**/domain/category/**",
                 "**/FinalPortfolioApplication*" // 메인 클래스 제외

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/entity/Member.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/entity/Member.java
@@ -1,5 +1,10 @@
 package com.finance.finportfolio.domain.member.entity;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.springframework.security.authentication.LockedException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -33,11 +38,53 @@ public class Member {
     @Column(nullable = false)
     private Role role;
 
+    // [무차별대입방어]
+    @Column(nullable = false)
+    private int loginFailCount = 0; // 로그인 실패 횟수
+    private LocalDateTime lockedUntil; // 언제까지 잠글 것인가
+
     @Builder
     public Member(String loginId, String password, String nickname, Role role) {
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
         this.role = role != null ? role : Role.USER;
+        this.loginFailCount = 0;
     }
+
+    // [무차별대입방어]
+    // 잠금 상태 체크(조회)
+    public boolean isLocked() {
+        return this.lockedUntil != null && this.lockedUntil.isAfter(LocalDateTime.now());
+    }
+
+    // 잠금 상태 체크(검증 및 예외처리)
+    public void checkLockStatus() {
+        if (isLocked()) {
+            long remainingMinutes = Duration.between(LocalDateTime.now(), this.lockedUntil).toMinutes();
+            StringBuilder message = new StringBuilder("인증에 5회 이상 실패했습니다. ");
+            if (remainingMinutes > 0) {
+                message.append(remainingMinutes).append("분 후에 다시 시도해주세요.");
+            } else {
+                // 1분 미만으로 남았을 때
+                message.append("잠시 후 다시 시도해주세요.");
+            }
+            throw new LockedException(message.toString());
+        }
+    }
+
+    public void loginFailed() {
+        this.loginFailCount++;
+        // 5회 실패 시 5분 잠금
+        if (this.loginFailCount >= 5) {
+            this.lockedUntil = LocalDateTime.now().plusMinutes(5);
+        }
+    }
+
+    public void loginSuccess() {
+        // 성공시 초기화
+        this.loginFailCount = 0;
+        this.lockedUntil = null;
+    }
+
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/LoginAttemptService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/LoginAttemptService.java
@@ -1,0 +1,22 @@
+package com.finance.finportfolio.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LoginAttemptService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // 독립적인 새 트랜잭션 생성
+    public void updateFailCount(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        member.loginFailed();
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
@@ -13,10 +13,10 @@ import com.finance.finportfolio.global.error.exception.DuplicateResourceExceptio
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +31,7 @@ public class MemberService {
         private final PasswordEncoder passwordEncoder;
         private final AuthenticationManager authenticationManager;
         private final JwtTokenProvider jwtTokenProvider;
+        private final LoginAttemptService loginAttemptService;
 
         private Member findMemberByLoginId(String loginId) {
                 return memberRepository.findByLoginId(loginId)
@@ -63,42 +64,57 @@ public class MemberService {
         @Transactional
         public LoginResultDto login(MemberLoginRequestDto request) {
 
-                // 아이디/비밀번호 인증
-                Authentication authentication = authenticationManager.authenticate(
-                                new UsernamePasswordAuthenticationToken(
-                                                request.loginId(), request.password()));
+                // 아이디 있는지부터 체크
+                // 아이디 존재 여부를 숨기기 위해 findMemberByLoginId를 사용하지 않고 별도 예외처리
+                Member member = memberRepository.findByLoginId(request.loginId())
+                                .orElseThrow(() -> new BadCredentialsException("아이디 또는 비밀번호가 일치하지 않습니다."));
 
-                String loginId = authentication.getName();
+                // [무차별대입방어] 잠금 상태 체크
+                member.checkLockStatus();
 
-                // DB에서 loginId로 Member find
-                Member member = findMemberByLoginId(loginId);
+                try {
+                        // 인증시도 - 비밀번호 체크
+                        authenticationManager.authenticate(
+                                        new UsernamePasswordAuthenticationToken(
+                                                        member.getLoginId(), request.password()));
 
-                // 고객 정보 get
-                String nickName = member.getNickname();
-                Role role = member.getRole();
+                        // [무차별대입방어] 로그인 성공 초기화
+                        member.loginSuccess();
 
-                // 토큰 생성
-                String accessToken = jwtTokenProvider.createAccessToken(loginId, role.name());
-                String refreshToken = jwtTokenProvider.createRefreshToken(loginId);
+                        // 고객 정보 get
+                        String nickName = member.getNickname();
+                        Role role = member.getRole();
 
-                refreshTokenRepository.findByMember(member)
-                                .ifPresentOrElse(
-                                                existing -> existing.rotate(refreshToken), // 재로그인: 토큰 교체
-                                                () -> { // 최초 로그인: 신규 저장
-                                                        final RefreshToken newToken = RefreshToken.builder()
-                                                                        .member(member)
-                                                                        .token(refreshToken)
-                                                                        .build();
-                                                        refreshTokenRepository.save(newToken);
-                                                });
+                        // 토큰 생성
+                        String accessToken = jwtTokenProvider.createAccessToken(member.getLoginId(), role.name());
+                        String refreshToken = jwtTokenProvider.createRefreshToken(member.getLoginId());
 
-                // 토큰 및 고객정보 반환
-                MemberResponseDto memberResponseDto = new MemberResponseDto(nickName, role);
-                return LoginResultDto.builder()
-                                .accessToken(accessToken)
-                                .refreshToken(refreshToken)
-                                .memberResponseDto(memberResponseDto)
-                                .build();
+                        refreshTokenRepository.findByMember(member)
+                                        .ifPresentOrElse(
+                                                        existing -> existing.rotate(refreshToken), // 재로그인: 토큰 교체
+                                                        () -> { // 최초 로그인: 신규 저장
+                                                                final RefreshToken newToken = RefreshToken.builder()
+                                                                                .member(member)
+                                                                                .token(refreshToken)
+                                                                                .build();
+                                                                refreshTokenRepository.save(newToken);
+                                                        });
+
+                        // 토큰 및 고객정보 반환
+                        MemberResponseDto memberResponseDto = new MemberResponseDto(nickName, role);
+                        return LoginResultDto.builder()
+                                        .accessToken(accessToken)
+                                        .refreshToken(refreshToken)
+                                        .memberResponseDto(memberResponseDto)
+                                        .build();
+                } catch (BadCredentialsException e) {
+                        // [무차별 대입 방어] 로그인 실패 잠금 카운트 증가
+                        // Transactional이 예외처리 시 엔티티 변경사항도 초기화!
+                        // 트랜잭션을 별도 서비스로 분리하여 초기화 방지
+                        loginAttemptService.updateFailCount(member.getId());
+
+                        throw new BadCredentialsException("아이디 또는 비밀번호가 일치하지 않습니다.");
+                }
         }
 
         // ── 로그아웃 → Refresh Token DB에서 삭제 ──────────────────

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -27,6 +27,18 @@ spring:
   thymeleaf:
     check-template-location: false
 
+bucket4j:
+  enabled: true
+  methods:
+    - name: ip_login_limit
+      cache-name: ip_buckets # [Caffeine] 저장 공간 이름
+      rate-limit:
+        bandwidths:
+          - capacity: 10 # 1분 간 API 호출 10회 가능!(API 호출 자체라 성공해도 차감됨!)
+            time: 1
+            unit: minutes
+            refill-speed: interval
+
 server:
   error:
     include-stacktrace: never      # 스택트레이스 노출 차단 (필수)

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/LoginAttemptServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/LoginAttemptServiceTest.java
@@ -1,0 +1,190 @@
+package com.finance.finportfolio.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.entity.Role;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LoginAttemptServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private LoginAttemptService loginAttemptService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .loginId("testUser")
+                .password("encoded_password")
+                .nickname("테스터")
+                .role(Role.USER)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("updateFailCount 호출 시")
+    class UpdateFailCount {
+
+        @Test
+        @DisplayName("실패 횟수가 1 증가한다")
+        void increaseFailCountByOne() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when
+            loginAttemptService.updateFailCount(1L);
+
+            // then
+            assertThat(member.getLoginFailCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("4회 실패 시 계정이 잠기지 않는다")
+        void doesNotLockAfterFourFailures() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when: 4번 실패
+            for (int i = 0; i < 4; i++) {
+                loginAttemptService.updateFailCount(1L);
+            }
+
+            // then
+            assertThat(member.getLoginFailCount()).isEqualTo(4);
+            assertThat(member.isLocked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("5회 실패 시 계정이 5분간 잠긴다")
+        void locksAccountAfterFiveFailures() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when: 5번 실패
+            for (int i = 0; i < 5; i++) {
+                loginAttemptService.updateFailCount(1L);
+            }
+
+            // then
+            assertThat(member.getLoginFailCount()).isEqualTo(5);
+            assertThat(member.isLocked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("5회 초과 실패해도 잠금 상태가 유지된다")
+        void remainsLockedAfterMoreThanFiveFailures() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+            // when: 7번 실패
+            for (int i = 0; i < 7; i++) {
+                loginAttemptService.updateFailCount(1L);
+            }
+
+            // then
+            assertThat(member.getLoginFailCount()).isEqualTo(7);
+            assertThat(member.isLocked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 memberId이면 예외가 발생한다")
+        void throwsExceptionWhenMemberNotFound() {
+            // given
+            given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> loginAttemptService.updateFailCount(999L))
+                    .isInstanceOf(java.util.NoSuchElementException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 엔티티 잠금 상태 검증")
+    class MemberLockBehavior {
+
+        @Test
+        @DisplayName("잠금 시간이 현재보다 미래이면 isLocked()는 true를 반환한다")
+        void isLockedReturnsTrueWhenLockedUntilIsInFuture() {
+            // given
+            ReflectionTestUtils.setField(member, "lockedUntil", LocalDateTime.now().plusMinutes(5));
+
+            // then
+            assertThat(member.isLocked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("잠금 시간이 현재보다 과거이면 isLocked()는 false를 반환한다")
+        void isLockedReturnsFalseWhenLockedUntilIsInPast() {
+            // given
+            ReflectionTestUtils.setField(member, "lockedUntil", LocalDateTime.now().minusMinutes(1));
+
+            // then
+            assertThat(member.isLocked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("lockedUntil이 null이면 isLocked()는 false를 반환한다")
+        void isLockedReturnsFalseWhenLockedUntilIsNull() {
+            // then
+            assertThat(member.isLocked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("로그인 성공 시 failCount와 lockedUntil이 초기화된다")
+        void loginSuccessResetsFailCountAndLockedUntil() {
+            // given: 5회 실패 상태
+            for (int i = 0; i < 5; i++) {
+                member.loginFailed();
+            }
+            assertThat(member.isLocked()).isTrue();
+
+            // when
+            member.loginSuccess();
+
+            // then
+            assertThat(member.getLoginFailCount()).isEqualTo(0);
+            assertThat(member.isLocked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("checkLockStatus()는 잠긴 상태일 때 LockedException을 던진다")
+        void checkLockStatusThrowsLockedException() {
+            // given
+            ReflectionTestUtils.setField(member, "lockedUntil", LocalDateTime.now().plusMinutes(3));
+
+            // when & then
+            assertThatThrownBy(member::checkLockStatus)
+                    .isInstanceOf(org.springframework.security.authentication.LockedException.class)
+                    .hasMessageContaining("5회 이상 실패");
+        }
+
+        @Test
+        @DisplayName("checkLockStatus()는 잠금 해제 상태일 때 예외를 던지지 않는다")
+        void checkLockStatusDoesNotThrowWhenNotLocked() {
+            // given: 잠금 없음
+            // when & then
+            assertThatNoException().isThrownBy(member::checkLockStatus);
+        }
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -54,6 +55,9 @@ class MemberServiceTest {
 
         @Mock
         private JwtTokenProvider jwtTokenProvider;
+
+        @Mock
+        private LoginAttemptService loginAttemptService;
 
         // 테스트용 Member 생성 헬퍼
         private Member createMember(String loginId) {
@@ -165,16 +169,55 @@ class MemberServiceTest {
         }
 
         @Test
-        @DisplayName("로그인 실패 - 잘못된 비밀번호면 예외가 발생한다")
-        void login_Fail_WrongPassword() {
-                MemberLoginRequestDto request = new MemberLoginRequestDto("testId", "wrongPassword");
-                given(authenticationManager.authenticate(any()))
-                                .willThrow(new BadCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다."));
+        @DisplayName("로그인 실패 - 잘못된 비밀번호면 실패 카운트 서비스가 호출된다")
+        void login_Fail_IncreaseCount() {
+                // given
+                String loginId = "testId";
+                Long fakeMemberId = 1L;
+                MemberLoginRequestDto request = new MemberLoginRequestDto(loginId, "wrongPassword");
 
+                // Member 생성 및 Reflection을 통한 ID 주입
+                Member member = Member.builder()
+                                .loginId(loginId)
+                                .build();
+                ReflectionTestUtils.setField(member, "id", fakeMemberId);
+
+                given(memberRepository.findByLoginId(loginId)).willReturn(Optional.of(member));
+                given(authenticationManager.authenticate(any()))
+                                .willThrow(new BadCredentialsException("아이디 또는 비밀번호가 일치하지 않습니다."));
+
+                // when & then
                 assertThatThrownBy(() -> memberService.login(request))
                                 .isInstanceOf(BadCredentialsException.class);
 
+                // 검증: member.getId()로 전달된 1L이 updateFailCount의 인자로 정확히 호출되었는지 확인
+                verify(loginAttemptService, times(1)).updateFailCount(fakeMemberId);
+
+                // 검증: 성공 로직은 실행되지 않아야 함
                 verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("메인 트랜잭션이 롤백되어도 실패 카운트 서비스가 호출되어야 한다")
+        void updateFailCount_ShouldBeCalledEvenIfMainTransactionRollsBack() {
+                // given
+                Long memberId = 1L;
+
+                // when
+                try {
+                        executeMainLogicWithRollback(memberId);
+                } catch (RuntimeException e) {
+                        // 의도적 롤백 발생 처리
+                }
+
+                // then
+                // 단위 테스트에서는 실제 DB 반영을 확인할 수 없으므로, 서비스 호출 여부를 검증합니다.
+                verify(loginAttemptService, times(1)).updateFailCount(memberId);
+        }
+
+        private void executeMainLogicWithRollback(Long memberId) {
+                loginAttemptService.updateFailCount(memberId);
+                throw new RuntimeException("Main Transaction Rollback!");
         }
 
         // ── logout ─────────────────────────────────────────────────

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -196,30 +195,6 @@ class MemberServiceTest {
                 // 검증: 성공 로직은 실행되지 않아야 함
                 verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
         }
-
-        @Test
-        @DisplayName("메인 트랜잭션이 롤백되어도 실패 카운트 서비스가 호출되어야 한다")
-        void updateFailCount_ShouldBeCalledEvenIfMainTransactionRollsBack() {
-                // given
-                Long memberId = 1L;
-
-                // when
-                try {
-                        executeMainLogicWithRollback(memberId);
-                } catch (RuntimeException e) {
-                        // 의도적 롤백 발생 처리
-                }
-
-                // then
-                // 단위 테스트에서는 실제 DB 반영을 확인할 수 없으므로, 서비스 호출 여부를 검증합니다.
-                verify(loginAttemptService, times(1)).updateFailCount(memberId);
-        }
-
-        private void executeMainLogicWithRollback(Long memberId) {
-                loginAttemptService.updateFailCount(memberId);
-                throw new RuntimeException("Main Transaction Rollback!");
-        }
-
         // ── logout ─────────────────────────────────────────────────
 
         @Test

--- a/finance-portfolio-backend/src/test/resources/application-test.yml
+++ b/finance-portfolio-backend/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 개요
- **현황**: 로그인 API에 별 다른 방어 조치가 없어 **무차별 대입 공격을 통한 회원 정보 탈취 위험성이 매우 높은 상황.**
- **개선방안**:
  - `Caffeine`을 통한 인메모리 저장소에 API 호출 기록을 저장하고 `bucket4j`을 통한 API 호출 제한 조건을 설정해 반복적인 API 호출을 1차 방어.
  - 회원 관련 서비스 파트에서 로그인 시 실패 횟수를 기록하여 제한시간으로 로직 상 2차 방어.

## 변경사항
- **의존성 추가**: `build.gradle`의 의존성 파트에 `Caffeine`과 `bucket4j-redis(0.12.0)` 라이브러리 추가.
- **API 제한조건 명세**: `application.yml`에 `bucket4j` 설정 및 조건 명세
  - 1분 당 10회
  - 저장소(`Caffeine`) 이름 설정 등
- **서비스 파트 2차 방어**:
  - **회원정보 엔티티`Member`**: `loginFailCount`, `lockedUntil` 필드를 추가하고 `isLocked()`, `checkLockStatus()`, `loginFailed()`, `loginSuccess()` 메서드를 통해 로직 단계에서 로그인 잠금 기능을 구현.
  - **`MemberService`**: 
    - **login 로직 최적화**: auth 과정을 뒤로 미루고 잠금 상태를 먼저 체크하여 불필요한 인증이 일어나지 않도록 개선.
    - **로그인 시 방어 구현**: `member` 엔티티에서 추가된 무차별 대입 방어 메서드를 실제 호출.
  - `LoginAttemptService`: 예외처리 시 단일 트랜잭선 처리로 인한 롤백을 방지하기 위하여 로그인 실패 카운트 파트를 별도 트랜잭션으로 분리.

## 결과
- **보안**: 관리자 계정 및 일반 사용자 계정에 대한 자동화된 공격(`brute force`) 차단
- **효율**: 잠긴 계정에 대한 인증 요청을 조기 차단하여 서버 부하 경감.

<img width="438" height="492" alt="image" src="https://github.com/user-attachments/assets/a1377adc-92ff-4157-95a8-ddf36498d536" />


## 관련이슈
- Closes #112

## 의사결정 명세
API 호출 기록을 저장할 저장소를 선택하는데 의사결정이 필요.
### `bucket4j + Redis(외부 저장소)`
  - 장점: 서버 확장성.
  - 단점: 인프라 비용 및 관리 포인트 증가.
### `bucket4j + Caffeine(인메모리 저장소)`
  - 장점: 지연 시간 최소화.
  - 서버 재시작 시 제한 데이터 휘발.

### **최종 채택**: `bucket4j + Caffeine` - 다음과 같은 비즈니스 및 기술적 환경을 고려하여 Caffeine 기반의 인메모리 방식을 최종 선정.
  - **인프라 효율성**: 현재 서비스는 단일 EC2 인스턴스 기반의 단일 서버 환경이며, 대규모 확장이 예정되어 있지 않아 외부 저장소 구축의 실익이 낮음.
  - **성능 최적화**: 로그인 API의 빈번한 호출을 처리함에 있어 외부 저장소와의 통신 없이 로컬 메모리에서 즉각적인 방어.
  - **관리 단순화**: 수동 배포 기반의 운영 환경이므로, 잦은 재시작으로 인한 데이터 휘발 영향이 미미.