### PR TITLE
[Feat] IP 기반 Rate Limit 필터 고도화(그룹 중요도별 차등 제한)

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/ApiRateLimitGroup.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/ApiRateLimitGroup.java
@@ -1,0 +1,53 @@
+package com.finance.finportfolio.global.security.filter;
+
+import java.time.Duration;
+import java.util.List;
+
+public enum ApiRateLimitGroup {
+    // 로그인, 회원가입
+    CRITICAL("보안/비용 위험", 1, 5, Duration.ofMinutes(1), List.of(
+            "/api/member/login",
+            "/api/member/join")),
+    // 이미지 S3 업로드, 미참조 이미지 삭제
+    HIGH("고부하 리소스", 2, 15, Duration.ofMinutes(1), List.of(
+            "/api/image/upload",
+            "/api/posts/cleanup")),
+    // 게시글 조회, 금융 계산기
+    MEDIUM("DB/UX 보호", 3, 30, Duration.ofMinutes(1), List.of(
+            "/api/posts",
+            "/api/posts/list",
+            "/api/finance/fair")),
+    LOW("일반 조회", 4, 150, Duration.ofMinutes(1), List.of(
+            "/**"// 나머지 모든 경로
+    ));
+
+    private final String description;
+    private final int priority;
+    private final int limit;
+    private final Duration duration;
+    private final List<String> patterns;
+
+    ApiRateLimitGroup(String description, int priority, int limit, Duration duration, List<String> patterns) {
+        this.description = description;
+        this.priority = priority;
+        this.limit = limit;
+        this.duration = duration;
+        this.patterns = patterns;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public List<String> getPatterns() {
+        return patterns;
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/IpRateLimitFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/IpRateLimitFilter.java
@@ -8,47 +8,85 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class IpRateLimitFilter extends OncePerRequestFilter {
 
     private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
-
-    private Bucket newBucket() {
-        return Bucket.builder()
-                .addLimit(Bandwidth.builder()
-                        .capacity(5)
-                        .refillIntervally(5, Duration.ofMinutes(1))
-                        .build())
-                .build();
-    }
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain) throws ServletException, IOException {
 
-        // /api/member/login 경로만 적용
-        if (!request.getRequestURI().equals("/api/member/login")) {
+        String uri = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 요청에 맞는 그룹 식별
+        ApiRateLimitGroup group = resolveGroup(uri, method);
+
+        // 예외 경로 처리
+        if (isExcludedPath(uri)) {
             filterChain.doFilter(request, response);
             return;
         }
 
+        // 버킷 키 생성(Group + IP)
         String ip = request.getRemoteAddr();
-        Bucket bucket = buckets.computeIfAbsent(ip, k -> newBucket());
+        String key = group.name() + ":" + ip;
+        Bucket bucket = buckets.computeIfAbsent(key, k -> createNewBucket(group));
 
         if (bucket.tryConsume(1)) {
             filterChain.doFilter(request, response);
         } else {
-            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
-            response.setContentType("application/json;charset=UTF-8");
-            response.getWriter().write(
-                    "{\"status\": 429, \"message\": \"요청이 너무 많습니다. 잠시 후 다시 시도해주세요.\"}");
+            sendLimitExceededResponse(response, group);
         }
+    }
+
+    private ApiRateLimitGroup resolveGroup(String uri, String method) {
+        // 우선순위가 높은 그룹부터 매칭 확인
+        for (ApiRateLimitGroup group : ApiRateLimitGroup.values()) {
+            for (String pattern : group.getPatterns()) {
+                if (pathMatcher.match(pattern, uri)) {
+                    // /api/posts 의 경우 POST일 때만 MEDIUM 그룹으로 적용하는 등의 세부 제어
+                    if (uri.equals("/api/posts") && !method.equalsIgnoreCase("POST")) {
+                        continue;
+                    }
+                    return group;
+                }
+            }
+        }
+        return ApiRateLimitGroup.LOW;
+    }
+
+    private boolean isExcludedPath(String uri) {
+        return uri.startsWith("/api/member/logout") ||
+                uri.startsWith("/api/member/reissue") ||
+                uri.equals("/error");
+    }
+
+    private Bucket createNewBucket(ApiRateLimitGroup group) {
+        return Bucket.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(group.getLimit())
+                        .refillIntervally(group.getLimit(), group.getDuration())
+                        .build())
+                .build();
+    }
+
+    private void sendLimitExceededResponse(HttpServletResponse response, ApiRateLimitGroup group) throws IOException {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        String json = String.format(
+                "{\"status\": 429, \"group\": \"%s\", \"message\": \"요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.\"}",
+                group.getDescription());
+        response.getWriter().write(json);
     }
 }

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -27,10 +27,6 @@ spring:
   thymeleaf:
     check-template-location: false
 
-  main:
-    allow-bean-definition-overriding: true
-
-
 server:
   error:
     include-stacktrace: never      # 스택트레이스 노출 차단 (필수)

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -8,6 +8,7 @@ import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
 import com.finance.finportfolio.domain.member.entity.Role;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
+import com.finance.finportfolio.global.security.filter.IpRateLimitFilter;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import org.junit.jupiter.api.DisplayName;
@@ -24,9 +25,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -56,8 +62,23 @@ class MemberControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
+    @MockitoBean
+    private IpRateLimitFilter ipRateLimitFilter;
+
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    // IpRateLimitFilter Mock 설정: 항상 체인을 통과시킴
+    @org.junit.jupiter.api.BeforeEach
+    void bypassRateLimitFilter() throws Exception {
+        doAnswer(invocation -> {
+            HttpServletRequest req = invocation.getArgument(0);
+            HttpServletResponse res = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(req, res);
+            return null;
+        }).when(ipRateLimitFilter).doFilter(any(), any(), any());
+    }
 
     @Test
     @DisplayName("SecurityConfig 빈 정상 로드 확인")

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/IpRateLimitFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/IpRateLimitFilterTest.java
@@ -25,15 +25,17 @@ class IpRateLimitFilterTest {
         filterChain = mock(FilterChain.class);
     }
 
+    // ──────────────────────────────────────────────
+    // 1. CRITICAL 그룹 - 로그인 한도 초과 (limit=5)
+    // ──────────────────────────────────────────────
     @Test
-    @DisplayName("허용량(5회) 초과 요청 시 429 에러와 메시지를 반환한다")
-    void exceedsRateLimitReturns429() throws ServletException, IOException {
-        // given: 동일한 IP로 요청 설정
+    @DisplayName("CRITICAL 그룹: 허용량(5회) 초과 시 429와 올바른 메시지를 반환한다")
+    void critical_exceedsRateLimitReturns429() throws ServletException, IOException {
         String clientIp = "127.0.0.1";
 
-        // 5회까지는 성공해야 함
+        // 5회까지는 성공
         for (int i = 0; i < 5; i++) {
-            MockHttpServletRequest request = createLoginRequest(clientIp);
+            MockHttpServletRequest request = createRequest("/api/member/login", "POST", clientIp);
             MockHttpServletResponse response = new MockHttpServletResponse();
 
             filter.doFilter(request, response, filterChain);
@@ -41,39 +43,173 @@ class IpRateLimitFilterTest {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
         }
 
-        // when: 6번째 요청
-        MockHttpServletRequest exceedRequest = createLoginRequest(clientIp);
+        // 6번째 요청: 한도 초과
+        MockHttpServletRequest exceedRequest = createRequest("/api/member/login", "POST", clientIp);
         MockHttpServletResponse exceedResponse = new MockHttpServletResponse();
 
         filter.doFilter(exceedRequest, exceedResponse, filterChain);
 
-        // then: 429 Too Many Requests 확인
         assertThat(exceedResponse.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
         assertThat(exceedResponse.getContentType()).isEqualTo("application/json;charset=UTF-8");
-        assertThat(exceedResponse.getContentAsString()).contains("요청이 너무 많습니다.");
+        // 변경된 에러 메시지 검증
+        assertThat(exceedResponse.getContentAsString())
+                .contains("요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.");
+        // 응답 JSON에 그룹 설명 포함 여부
+        assertThat(exceedResponse.getContentAsString())
+                .contains(ApiRateLimitGroup.CRITICAL.getDescription());
 
-        // 6번째 요청은 filterChain.doFilter가 호출되지 않았어야 함
+        // 6번째 요청에서는 filterChain이 호출되지 않아야 함
         verify(filterChain, times(5)).doFilter(any(), any());
     }
 
+    // ──────────────────────────────────────────────
+    // 2. HIGH 그룹 - 이미지 업로드 한도 초과 (limit=15)
+    // ──────────────────────────────────────────────
     @Test
-    @DisplayName("로그인 경로가 아닌 경우 필터를 통과한다")
-    void skipFilterForNonLoginPath() throws ServletException, IOException {
-        // given
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/api/member/profiles");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    @DisplayName("HIGH 그룹: 허용량(15회) 초과 시 429를 반환한다")
+    void high_exceedsRateLimitReturns429() throws ServletException, IOException {
+        String clientIp = "10.0.0.1";
 
-        // when
-        filter.doFilter(request, response, filterChain);
+        // 15회까지는 성공
+        for (int i = 0; i < 15; i++) {
+            MockHttpServletRequest request = createRequest("/api/image/upload", "POST", clientIp);
+            MockHttpServletResponse response = new MockHttpServletResponse();
 
-        // then
-        verify(filterChain, times(1)).doFilter(request, response);
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        // 16번째 요청: 한도 초과
+        MockHttpServletRequest exceedRequest = createRequest("/api/image/upload", "POST", clientIp);
+        MockHttpServletResponse exceedResponse = new MockHttpServletResponse();
+
+        filter.doFilter(exceedRequest, exceedResponse, filterChain);
+
+        assertThat(exceedResponse.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        assertThat(exceedResponse.getContentAsString())
+                .contains(ApiRateLimitGroup.HIGH.getDescription());
+        verify(filterChain, times(15)).doFilter(any(), any());
     }
 
-    private MockHttpServletRequest createLoginRequest(String ip) {
+    // ──────────────────────────────────────────────
+    // 3. 제외 경로 - filterChain을 그대로 통과해야 함
+    // ──────────────────────────────────────────────
+    @Test
+    @DisplayName("제외 경로(/api/member/logout)는 rate limit 없이 통과한다")
+    void excludedPath_logout_passesThrough() throws ServletException, IOException {
+        MockHttpServletRequest request = createRequest("/api/member/logout", "POST", "127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("제외 경로(/api/member/reissue)는 rate limit 없이 통과한다")
+    void excludedPath_reissue_passesThrough() throws ServletException, IOException {
+        MockHttpServletRequest request = createRequest("/api/member/reissue", "POST", "127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("제외 경로(/error)는 rate limit 없이 통과한다")
+    void excludedPath_error_passesThrough() throws ServletException, IOException {
+        MockHttpServletRequest request = createRequest("/error", "GET", "127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    // ──────────────────────────────────────────────
+    // 4. /api/posts 메서드 분기 - POST만 MEDIUM 그룹
+    // ──────────────────────────────────────────────
+    @Test
+    @DisplayName("/api/posts POST 요청은 MEDIUM 그룹(limit=30)으로 처리된다")
+    void posts_postMethod_appliesMediumGroup() throws ServletException, IOException {
+        String clientIp = "192.168.0.1";
+
+        // MEDIUM limit(30)까지 성공
+        for (int i = 0; i < 30; i++) {
+            MockHttpServletRequest request = createRequest("/api/posts", "POST", clientIp);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        // 31번째 요청: MEDIUM 한도 초과
+        MockHttpServletRequest exceedRequest = createRequest("/api/posts", "POST", clientIp);
+        MockHttpServletResponse exceedResponse = new MockHttpServletResponse();
+
+        filter.doFilter(exceedRequest, exceedResponse, filterChain);
+
+        assertThat(exceedResponse.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        assertThat(exceedResponse.getContentAsString())
+                .contains(ApiRateLimitGroup.MEDIUM.getDescription());
+    }
+
+    @Test
+    @DisplayName("/api/posts GET 요청은 MEDIUM이 아닌 LOW 그룹(limit=150)으로 처리된다")
+    void posts_getMethod_appliesLowGroup() throws ServletException, IOException {
+        String clientIp = "192.168.0.2";
+
+        // LOW limit(150)까지 성공해야 함 (MEDIUM limit=30을 넘어도 통과)
+        for (int i = 0; i < 31; i++) {
+            MockHttpServletRequest request = createRequest("/api/posts", "GET", clientIp);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilter(request, response, filterChain);
+
+            // MEDIUM(30)을 초과해도 LOW 그룹이므로 429가 아님
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // 5. IP 독립성 - 다른 IP는 별도 버킷을 사용
+    // ──────────────────────────────────────────────
+    @Test
+    @DisplayName("IP가 다르면 버킷이 독립적으로 관리된다")
+    void differentIps_haveSeparateBuckets() throws ServletException, IOException {
+        String ipA = "1.1.1.1";
+        String ipB = "2.2.2.2";
+
+        // IP-A: CRITICAL 한도(5회) 소진
+        for (int i = 0; i < 5; i++) {
+            filter.doFilter(createRequest("/api/member/login", "POST", ipA),
+                    new MockHttpServletResponse(), filterChain);
+        }
+
+        // IP-A 6번째: 429 반환
+        MockHttpServletResponse responseA = new MockHttpServletResponse();
+        filter.doFilter(createRequest("/api/member/login", "POST", ipA), responseA, filterChain);
+        assertThat(responseA.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+
+        // IP-B: 아직 버킷이 가득 차지 않았으므로 통과
+        MockHttpServletResponse responseB = new MockHttpServletResponse();
+        filter.doFilter(createRequest("/api/member/login", "POST", ipB), responseB, filterChain);
+        assertThat(responseB.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    // ──────────────────────────────────────────────
+    // Helper
+    // ──────────────────────────────────────────────
+    private MockHttpServletRequest createRequest(String uri, String method, String ip) {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/api/member/login");
+        request.setRequestURI(uri);
+        request.setMethod(method);
         request.setRemoteAddr(ip);
         return request;
     }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/IpRateLimitFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/IpRateLimitFilterTest.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -95,38 +97,22 @@ class IpRateLimitFilterTest {
     // ──────────────────────────────────────────────
     // 3. 제외 경로 - filterChain을 그대로 통과해야 함
     // ──────────────────────────────────────────────
-    @Test
-    @DisplayName("제외 경로(/api/member/logout)는 rate limit 없이 통과한다")
-    void excludedPath_logout_passesThrough() throws ServletException, IOException {
-        MockHttpServletRequest request = createRequest("/api/member/logout", "POST", "127.0.0.1");
+    @ParameterizedTest
+    @CsvSource({
+            "/api/member/logout, POST",
+            "/api/member/reissue, POST",
+            "/error, GET"
+    })
+    @DisplayName("제외 경로는 Rate Limit 없이 통과한다")
+    void excludedPaths_passThrough(String path, String method) throws ServletException, IOException {
+        // Given
+        MockHttpServletRequest request = createRequest(path, method, "127.0.0.1");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
+        // When
         filter.doFilter(request, response, filterChain);
 
-        verify(filterChain, times(1)).doFilter(request, response);
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
-    @DisplayName("제외 경로(/api/member/reissue)는 rate limit 없이 통과한다")
-    void excludedPath_reissue_passesThrough() throws ServletException, IOException {
-        MockHttpServletRequest request = createRequest("/api/member/reissue", "POST", "127.0.0.1");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        filter.doFilter(request, response, filterChain);
-
-        verify(filterChain, times(1)).doFilter(request, response);
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
-    @DisplayName("제외 경로(/error)는 rate limit 없이 통과한다")
-    void excludedPath_error_passesThrough() throws ServletException, IOException {
-        MockHttpServletRequest request = createRequest("/error", "GET", "127.0.0.1");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        filter.doFilter(request, response, filterChain);
-
+        // Then
         verify(filterChain, times(1)).doFilter(request, response);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
     }

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -55,6 +55,10 @@ axiosInstance.interceptors.response.use(
     async (error) => {
         const originalRequest = error.config;
 
+        const status = error.response?.status;
+        // 비지니스 로직상 실패: 에러 페이지로 보내지 않음
+        const isLoginRequest = originalRequest.url.includes('/member/login');
+
         // reissue 요청 자체가 실패했을 때
         if (originalRequest.url === '/member/reissue') {
             authStore.clearToken();
@@ -66,7 +70,7 @@ axiosInstance.interceptors.response.use(
             throw error;
         }
 
-        // 일반 API 에러
+        // 토큰 만료 여부
         // ACCESS_TOKEN_EXPIRED 에러이고 재시도 안 한 요청이면 재발급 시도
         const isExpired =
             error.response?.status === 401 &&
@@ -75,7 +79,6 @@ axiosInstance.interceptors.response.use(
 
         // 토큰 만료 이외 에러 
         if (!isExpired) {
-            const status = error.response?.status || 500;
             const message = error.response?.data?.message || '알 수 없는 오류가 발생했습니다.';
 
             // 개발 환경에서만 에러 상세 출력
@@ -83,12 +86,30 @@ axiosInstance.interceptors.response.use(
                 console.error(`[API Error] Status: ${status}, Message: ${message}`);
             }
 
-            // 로그인 요청(`/member/login`)에서 발생한 에러는 비지니스 로직상 실패: 에러 페이지로 보내지 않음!
-            const isLoginRequest = originalRequest.url.includes('/member/login');
+            // Brute force 방어
+            if (status === 429) {
+                // 로그인 요청에서 발생한 429는 에러 페이지로 보내지 않음
+                if (isLoginRequest) {
+                    throw error;
+                }
+
+                // 일반 API 요청 중 발생한 429는 에러 페이지로 이동
+                const retryAfterHeader = error.response.headers['retry-after'];
+                const retryAfter = retryAfterHeader ? Number.parseInt(retryAfterHeader, 10) : 60;
+
+                history.push('/error?status=429', {
+                    message: "요청 한도를 초과했습니다.",
+                    subMessage: `${retryAfter}초 후에 다시 시도할 수 있습니다.`,
+                    retryAfter: retryAfter
+                });
+                throw error;
+            }
 
             if (!isLoginRequest && (status === 404 || status >= 500)) {
                 // 쿼리 스트링으로 데이터 전달
-                history.push(`/error?status=${status}&message=${encodeURIComponent(message)}`);
+                history.push(`/error?status=${status}`, {
+                    message: message
+                });
             }
 
             throw error;

--- a/finance-portfolio-frontend/src/pages/common/ErrorPage.jsx
+++ b/finance-portfolio-frontend/src/pages/common/ErrorPage.jsx
@@ -10,12 +10,24 @@ const ErrorPage = ({ status: propStatus, message: propMessage }) => {
     // 메모리로 값 수신
     const location = useLocation();
 
-    // 엔드포인트(인터셉터) || props(라우트) || 메모리(네비게이트) || 기본 문구
-    const status = searchParams.get('status') || location.state?.status || propStatus || '오류';
-    const message = searchParams.get('message') || location.state?.message || propMessage || '알 수 없는 오류가 발생했습니다.';
+    console.log('Current Location Object:', location);
+    console.log('State Message:', location.state?.message);
 
-    console.log(searchParams.get('status'));
-    console.log(location.state?.status);
+    // 엔드포인트(인터셉터) || 메모리(네비게이트) || props(라우트) || 기본 문구
+    const status = searchParams.get('status') || location.state?.status || propStatus || 'Error';
+
+    let rawMessage = location.state?.message || searchParams.get('message') || propMessage;
+
+    let message = '알 수 없는 오류가 발생했습니다.';
+    if (rawMessage) {
+        try {
+            message = decodeURIComponent(rawMessage);
+        } catch {
+            message = rawMessage;
+        }
+    }
+
+    const subMessage = location.state?.subMessage;
 
     return (
         <div className="d-flex align-items-center justify-content-center"
@@ -23,6 +35,7 @@ const ErrorPage = ({ status: propStatus, message: propMessage }) => {
             <div className="text-center">
                 <h1 className="display-1 fw-bold text-muted">{status}</h1>
                 <p className="fs-5 mb-4">{message}</p>
+                {subMessage && <p className="text-muted small mb-4">{subMessage}</p>}
                 <button onClick={() => navigate('/')} className="btn btn-primary">
                     홈으로
                 </button>

--- a/finance-portfolio-frontend/src/utils/history.js
+++ b/finance-portfolio-frontend/src/utils/history.js
@@ -3,12 +3,10 @@ export const navRef = {
 };
 
 export const history = {
-    push(url) {
+    push(url, state = null) {
         if (navRef.navigate) {
-            // 리액트 엔진이 로드된 상태라면 SPA 라우팅 실행 (깜빡임 X)
-            navRef.navigate(url);
+            navRef.navigate(url, state ? { state } : undefined);
         } else {
-            // 만약 앱 로딩 전이나 특수 상황이라면 브라우저 강제 이동 (Fallback)
             console.warn("Navigation 호출 시점에 리액트 엔진이 준비되지 않았습니다.");
             globalThis.location.href = url;
         }
@@ -16,15 +14,15 @@ export const history = {
 
     goBack() {
         if (navRef.navigate) {
-            navRef.navigate(-1); // 리액트 라우터의 뒤로 가기 방식
+            navRef.navigate(-1);
         } else {
-            globalThis.history.back(); // 브라우저 네이티브 뒤로 가기
+            globalThis.history.back();
         }
     },
 
-    replace(url) {
+    replace(url, state = null) {
         if (navRef.navigate) {
-            navRef.navigate(url, { replace: true });
+            navRef.navigate(url, { replace: true, ...(state && { state }) });
         } else {
             globalThis.location.replace(url);
         }


### PR DESCRIPTION
## 개요
- **현황**: Brute force 차단 필터는 보안 취약점이 가장 시급했던 로그인 영역(`/api/member/login`)에만 선제적으로 적용된 상태. (#122)

- 최초 계획된 API의 중요도와 부하를 고려하여 상세 API 그룹별 차등 제한 정책을 수립.
- 차단 시 사용자 경험(UX)을 개선하기 위한 프론트엔드 연동을 진행.

## 작업내용
- 🍃서버
  - **필터 고도화**
    - **`ApiRateLimitGroup` (`Enum`)**: 보안 중요도 및 트래픽 특성에 따라 엔드포인트를 그룹화하고, 그룹별 최대 호출 횟수(Threshold)와 차단 지속 시간을 관리.
    - **`IpRateLimitFilter`**: 하드코딩된 로직을 제거하고, `ApiRateLimitGroup`에서 정의된 정책에 따라 동적으로 Rate 한도를 판별하도록 개선.

- ⚛️프론트
  - **에러 처리 고도화**
    - **`axios` 인터셉터**: `429 Too Many Requests` 응답 수신 시, 사용자에게 명확한 안내를 위해 에러 페이지로 이동하는 로직을 추가
    - `history.js`, `ErrorPage.jsx`: 보안 및 가독성을 위해 URL 파라미터(`searchParams`) 방식 외에도 메모리 기반의 `location.state`를 통한 메시지 수신 방식을 병행 적용하고, 이에 따른 방어 로직을 소폭 강화.

## 결과
- **보안 강화**: 로그인 외에도 게시판 작성, 관리자 기능 등 주요 API에 대해 개별적인 방어선 구축을 통해 비용 공격에 대한 저항성 향상.
- **UX 개선**: API 차단 발생 시 단순 알림이 아닌, 정돈된 에러 페이지(`ErrorPage`)를 통해 차단 사유를 명확히 안내.
- **유지보수성**: 신규 API 추가 시 `ApiRateLimitGroup`에 상수를 추가하는 것만으로 간단히 제한 정책 적용 가능.

## 관련이슈/PR
- Closes #120 (상세 API 그룹별 차등 제한 정책 명세.)
- #122