### PR TITLE
[Refactor] 🍃DTO 생성자 위임 구조 정적 팩토리 메서드 패턴으로 변경

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/dto/CategoryResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/dto/CategoryResponseDto.java
@@ -7,8 +7,8 @@ public record CategoryResponseDto(
         String name,
         int sortOrder) {
     // Entity -> DTO 변환 생성자
-    public CategoryResponseDto(Category category) {
-        this(
+    public static CategoryResponseDto from(Category category) {
+        return new CategoryResponseDto(
                 category.getId(),
                 category.getName(),
                 category.getSortOrder());

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/service/CategoryService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/category/service/CategoryService.java
@@ -45,7 +45,7 @@ public class CategoryService {
     // 목록 조회
     public List<CategoryResponseDto> findAllOrderByOrder() {
         return categoryRepository.findAllByOrderBySortOrderAsc().stream()
-                .map(CategoryResponseDto::new)
+                .map(CategoryResponseDto::from)
                 .toList();
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostResponseDto.java
@@ -8,29 +8,30 @@ import com.finance.finportfolio.domain.post.entity.Post;
 
 // PostResponseDto - Post 엔티티 Get용 DTO
 public record PostResponseDto(
-        Long id,
-        String categoryName,
-        String author,
-        String title,
-        String content,
-        boolean hasImage,
-        LocalDateTime createdAt) {
-    // Entity -> DTO 변환을 위한 생성자
-    public PostResponseDto(Post post) {
-        this(post, post.getContent());
-    }
+                Long id,
+                String categoryName,
+                String author,
+                String title,
+                String content,
+                boolean hasImage,
+                LocalDateTime createdAt) {
+        // 원본 호출용
+        public static PostResponseDto from(Post post) {
+                return PostResponseDto.ofForJsoup(post, post.getContent());
+        }
 
-    public PostResponseDto(Post post, String processedContent) {
-        this(
-                post.getId(),
-                Optional.ofNullable(post.getCategory())
-                        .map(Category::getName)
-                        .orElse("미분류"),
-                Optional.ofNullable(post.getAuthor())
-                        .orElse("익명"),
-                post.getTitle(),
-                processedContent,
-                post.isHasImage(),
-                post.getCreatedAt());
-    }
+        // 살균 Content 호출용
+        public static PostResponseDto ofForJsoup(Post post, String processedContent) {
+                return new PostResponseDto(
+                                post.getId(),
+                                Optional.ofNullable(post.getCategory())
+                                                .map(Category::getName)
+                                                .orElse("미분류"),
+                                Optional.ofNullable(post.getAuthor())
+                                                .orElse("익명"),
+                                post.getTitle(),
+                                processedContent,
+                                post.isHasImage(),
+                                post.getCreatedAt());
+        }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -73,7 +73,7 @@ public class PostService {
         }
 
         // Entity를 DTO로 변환하여 반환
-        return postPage.map(PostResponseDto::new);
+        return postPage.map(PostResponseDto::from);
     }
 
     // ID로 게시글 조회, return: 게시글
@@ -84,7 +84,7 @@ public class PostService {
 
         String processedContent = fileService.convertToCdnUrls(post.getContent());
 
-        return new PostResponseDto(post, processedContent);
+        return PostResponseDto.ofForJsoup(post, processedContent);
     }
 
     // 게시글 저장, return: 저장된 게시글 ID


### PR DESCRIPTION
## 개요
- **현황**: 생성자 위임 방식을 사용함에 따라 `new` 키워드만으로는 데이터 생성의 목적(원본 데이터 반환, Jsoup 살균 처리 등)을 직관적으로 파악하기 어려움.
- **문제상황**: 서비스 계층에서 DTO의 구조와 역할을 확인하기 위해 내부 코드를 반복적으로 확인해야 하는 번거로움이 발생하여 개발 생산성이 저하.

## 작업내용
- **DTO 구조 변경(`CategoryResponseDto`, `PostResponseDto`)**: 생정자 방식을 폐기 후 정적 팩토리 메서드 패턴을 도입.
  - `from()`: 원본 및 표준 DTO 생성.
  - `ofForJsoup()`: 살균 처리 비지니스 로직이 포함된 메서드명.
- **서비스 로직 개선(`Categoryservice`, `PostService`)**: `new`를 통한 생성자 방식에서 `from`을 통한 메서드 방식으로 DTO 호출하도록 변경.

## 결과
- **유지보수성**: 게시글 수정/삭제 권한 작업 전 전달 데이터를 리펙토링 하는 과정에서 DTO 호출의 가독성을 향상하여 작업 효율 개선.