### PR TITLE
[Feat] 이미지 파일 업로드 유효성 검증 단계 추가 및 관련 예외처리 고도화

### DIFF
--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -103,6 +103,10 @@ jacocoTestReport {
 sonarqube {
     properties {
         property "sonar.coverage.exclusions", "**/domain/post/**, **/domain/category/**, **/*Dto*, **/*Request*, **/*Response*, **/entity/**"
+
+		// 소스 코드와 테스트 코드의 경로를 명확히 분리 지정
+        property "sonar.sources", "src/main/java"
+        property "sonar.tests", "src/test/java"
     }
 }
 

--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	// Bucket4j 코어(무차별 대입 공격 방어)
 	implementation 'com.bucket4j:bucket4j-core:8.10.1'
+	// 이미지 파일 유효성 검증(MIME 타입 판별, 픽셀크기 등 이미지 메타데이터 추출)
+	implementation 'org.apache.tika:tika-core:3.3.0'
+	implementation 'org.apache.commons:commons-imaging:1.0.0-alpha5'
 }
 
 tasks.named('test') {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/EditorImageController.java
@@ -3,6 +3,7 @@ package com.finance.finportfolio.domain.post.controller;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,29 +24,26 @@ public class EditorImageController {
     private final S3Properties s3Properties;
 
     @PostMapping("/api/image/upload")
-    public Map<String, Object> upload(@RequestParam("upload") MultipartFile file) {
-        Map<String, Object> response = new HashMap<>();
+    public ResponseEntity<Map<String, Object>> upload(@RequestParam("upload") MultipartFile file) {
 
         try {
-            // 1. 파일을 저장하고 저장된 파일명을 받아옴
+            // 파일을 저장하고 저장된 파일명을 받아옴
             String savedFileName = fileService.uploadFile(file);
 
+            // cdn url로
             String cdnUrl = String.format("https://%s/%s",
                     s3Properties.cloudfrontDomain(),
                     savedFileName);
 
-            // 2. CKEditor 5 전용 성공 응답 규격
-            response.put("uploaded", true);
-            response.put("url", cdnUrl);
-
-            log.info("CKEditor image uploaded successfully: {}", savedFileName);
+            return ResponseEntity.ok(Map.of(
+                    "uploaded", true,
+                    "url", cdnUrl));
         } catch (Exception e) {
             log.error("CKEditor image upload failed", e);
-
-            response.put("uploaded", false);
-            response.put("error", Map.of("message", "이미지 업로드 실패: " + e.getMessage()));
+            return ResponseEntity.badRequest().body(Map.of(
+                    "uploaded", false,
+                    "error", Map.of("message", e.getMessage()) // 백엔드 메시지 그대로 전달
+            ));
         }
-
-        return response; // 맵 객체를 최종 반환 (JSON으로 자동 변환됨)
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.safety.Safelist;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -34,27 +33,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PostService {
 
-    // jsoup 커스텀 설정 본문용(utext)
-    private static final Safelist HTML_SAFE_LIST = Safelist.relaxed()
-            .addAttributes("img", "alt", "width", "height") // 이미지 관련 속성 허용
-            .addTags("hr", "br"); // 가로줄, 줄바꿈 명시적 허용
-
     private final PostRepository postRepository;
     private final FileService fileService;
     private final CategoryRepository categoryRepository;
     private final MemberRepository memberRepository;
 
-    // Jsoup 소독 메서드
-    private String cleanHtml(String text) {
-        return (text == null || text.isEmpty()) ? "" : Jsoup.clean(text, HTML_SAFE_LIST);
-    }
-
+    // 실제 <img> 태그가 1개 이상 존재하는지 "객체" 단위로 확인
     private boolean checkImage(String htmlContent) {
         if (htmlContent == null || htmlContent.isEmpty())
             return false;
 
         Document doc = Jsoup.parseBodyFragment(htmlContent);
-        // 실제 <img> 태그가 1개 이상 존재하는지 "객체" 단위로 확인
         return !doc.select("img").isEmpty();
     }
 
@@ -114,8 +103,8 @@ public class PostService {
         Category category = categoryRepository.findById(requestDto.categoryId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. ID: " + requestDto.categoryId()));
 
-        // jsoup 살균과 Cdn삭제(키 추출)
-        String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
+        // Cdn삭제(키 추출)
+        String cleanedContent = fileService.removeCdnUrls(requestDto.content());
         boolean hasImage = checkImage(cleanedContent);
 
         Post post = requestDto.toEntity(category, member, cleanedContent, hasImage);
@@ -130,8 +119,8 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
 
-        // jsoup 살균과 Cdn삭제(키 추출)
-        String cleanedContent = fileService.removeCdnUrls(cleanHtml(requestDto.content()));
+        // Cdn삭제(키 추출)
+        String cleanedContent = fileService.removeCdnUrls(requestDto.content());
         boolean hasImage = checkImage(cleanedContent);
 
         Category category = categoryRepository.findById(requestDto.categoryId())

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/S3Config.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/S3Config.java
@@ -1,5 +1,7 @@
 package com.finance.finportfolio.global.config;
 
+import org.apache.tika.Tika;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
@@ -9,4 +11,10 @@ public class S3Config {
     // AWS 인증 정보 처리 - Access key, Secret Key
     // S3Client 빈 생성 - 실제 파일 업로드/삭제
     // 보안 및 권한 부여 방식 결정
+
+    // 이미지 파일 유효성 검증 ApacheTika 빈 등록
+    @Bean
+    public Tika tika() {
+        return new Tika();
+    }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.finance.finportfolio.global.error;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
@@ -73,6 +75,15 @@ public class GlobalExceptionHandler {
                 .orElse("🛠입력값이 올바르지 않습니다.");
 
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
+    }
+
+    // 400 BAD_REQUEST
+    // CKEditor 전용 포맷으로 처리해야함(Map<String, Object>)
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        return ResponseEntity.badRequest().body(Map.of(
+                "uploaded", false,
+                "error", Map.of("message", "파일 용량이 너무 큽니다. (최대 1MB)")));
     }
 
     // 401 UNAUTHORIZED

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -84,6 +84,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         return ResponseEntity.badRequest().body(Map.of(
                 "uploaded", false,
+                "status", HttpStatus.BAD_REQUEST.value(),
+                "code", "FILE_SIZE_LIMIT_EXCEEDED",
                 "error", Map.of("message", "파일 용량이 너무 큽니다. (최대 1MB)")));
     }
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
+import com.finance.finportfolio.global.error.exception.FileStorageException;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -160,6 +161,15 @@ public class GlobalExceptionHandler {
         log.error("CloudFront 설정 에러 발생!", e.getMessage(), e);
         String message = resolveMessage(e.getMessage(), "시스템 보안 설정에 문제가 발생했습니다.");
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "CLOUDFRONT_CONFIG_ERROR", message);
+    }
+
+    // 500 INTERNAL_SERVER_ERROR
+    // STORAGE_ERROR: S3 파일 업로드 쪽 런타임 에러
+    @ExceptionHandler(FileStorageException.class)
+    public ResponseEntity<ErrorResponse> handleFileStorageException(FileStorageException e) {
+        log.error("S3 파일 업로드 장애", e);
+        String message = resolveMessage(e.getMessage(), "파일 업로드 간 시스템 오류가 발생했습니다. 관리자에게 문의하세요.");
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "STORAGE_ERROR", message);
     }
 
     // 500 INTERNAL_SERVER_ERROR

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/FileStorageException.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/error/exception/FileStorageException.java
@@ -1,0 +1,17 @@
+package com.finance.finportfolio.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+// S3 파일 업로드 실패(저장소 측 문제 발생)
+// 500 INTERNAL_SERVER_ERROR
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class FileStorageException extends RuntimeException {
+    public FileStorageException(String message) {
+        super(message);
+    }
+
+    public FileStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -23,11 +23,11 @@ public class S3FileHandler {
     private final S3Template s3Template;
     private final S3Properties s3Properties;
 
-    public String uploadFile(MultipartFile file, String savedFileName) {
+    public String uploadFile(MultipartFile file, String savedFileName, String mimeType) {
         try {
             // 1. 메타데이터 객체 생성 및 설정 (빌더 패턴 활용)
             ObjectMetadata metadata = ObjectMetadata.builder()
-                    .contentType(file.getContentType())
+                    .contentType(mimeType)
                     .contentLength(file.getSize())
                     .build();
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.finance.finportfolio.global.error.exception.FileStorageException;
+
 import io.awspring.cloud.s3.S3Template;
 import io.awspring.cloud.s3.ObjectMetadata;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -45,10 +47,10 @@ public class S3FileHandler {
 
         } catch (IOException e) {
             log.error("S3 파일 읽기 에러: {}", e.getMessage());
-            throw new RuntimeException("S3 파일 업로드 중 오류 발생", e);
+            throw new FileStorageException("S3 파일 업로드 중 오류 발생", e);
         } catch (S3Exception e) {
             log.error("AWS S3 서비스 에러: {}", e.awsErrorDetails().errorMessage());
-            throw new RuntimeException("AWS S3 서비스 오류", e);
+            throw new FileStorageException("AWS S3 서비스 오류", e);
         }
     }
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -45,7 +45,7 @@ public class S3FileServiceImpl implements FileService {
             .addTags("hr", "br"); // 가로줄, 줄바꿈 명시적 허용
 
     // 용량, 해상도 제한
-    private static final long MAX_FILE_SIZE = 1 * 1024 * 1024;
+    private static final long MAX_FILE_SIZE = 1L * 1024 * 1024;
     private static final int MAX_PIXEL_SIZE = 1920;
 
     // 1차 이미지 유효성 체크

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -1,5 +1,7 @@
 package com.finance.finportfolio.infrastructure.file;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -11,9 +13,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.imaging.ImageInfo;
+import org.apache.commons.imaging.Imaging;
+import org.apache.tika.Tika;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.safety.Safelist;
 import org.jsoup.select.Elements;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -31,16 +37,59 @@ import lombok.extern.slf4j.Slf4j;
 public class S3FileServiceImpl implements FileService {
 
     private final S3FileHandler s3FileHandler;
+    private final Tika tika;
+
+    // jsoup 커스텀 설정 본문용(utext)
+    private static final Safelist HTML_SAFE_LIST = Safelist.relaxed()
+            .addAttributes("img", "alt", "width", "height") // 이미지 관련 속성 허용
+            .addTags("hr", "br"); // 가로줄, 줄바꿈 명시적 허용
+
+    // 용량, 해상도 제한
+    private static final long MAX_FILE_SIZE = 1 * 1024 * 1024;
+    private static final int MAX_PIXEL_SIZE = 1920;
+
+    // 1차 이미지 유효성 체크
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("파일 용량이 너무 큽니다.");
+        }
+    }
 
     @Override
     public String uploadFile(MultipartFile file) {
-        if (file == null || file.isEmpty() || file.getOriginalFilename() == null) {
-            return null;
+
+        validateFile(file);
+
+        // 2차 이미지 유효성 체크
+        try {
+            // MIME 타입 검증
+            String mimeType;
+            try (InputStream inputStream = file.getInputStream()) {
+                // S3Config의 tika 빈
+                mimeType = tika.detect(inputStream);
+            }
+            if (!mimeType.startsWith("image/")) {
+                throw new IllegalArgumentException("허용되지 않는 파일 형식입니다.");
+            }
+
+            // 3. 해상도 검증(메모리 부하 방지)
+            try (InputStream inputStream = file.getInputStream()) {
+                ImageInfo imageInfo = Imaging.getImageInfo(inputStream, file.getOriginalFilename());
+                if (imageInfo.getWidth() > MAX_PIXEL_SIZE || imageInfo.getHeight() > MAX_PIXEL_SIZE) {
+                    throw new IllegalArgumentException("이미지 해상도가 너무 높습니다.");
+                }
+            }
+
+            String savedFileName = createFileName(file.getOriginalFilename());
+            return s3FileHandler.uploadFile(file, savedFileName, mimeType);
+
+        } catch (IOException e) {
+            log.error("이미지 분석 또는 파일 읽기 실패: {}", e.getMessage());
+            throw new IllegalArgumentException("올바르지 않은 이미지 형식 및 읽기 오류입니다.");
         }
-
-        String savedFileName = createFileName(file.getOriginalFilename());
-        return s3FileHandler.uploadFile(file, savedFileName);
-
     }
 
     private String createFileName(String originalFileName) {
@@ -83,6 +132,7 @@ public class S3FileServiceImpl implements FileService {
                 img.attr("src", cdnUrl);
             }
         }
+
         return doc.body().html();
     }
 
@@ -93,7 +143,9 @@ public class S3FileServiceImpl implements FileService {
             return "";
         }
 
-        Document doc = Jsoup.parseBodyFragment(content);
+        String cleanedHtml = Jsoup.clean(content, HTML_SAFE_LIST);
+
+        Document doc = Jsoup.parseBodyFragment(cleanedHtml);
         Elements imgs = doc.select("img[src]");
 
         for (Element img : imgs) {
@@ -103,9 +155,11 @@ public class S3FileServiceImpl implements FileService {
                 img.attr("src", pureKey);
             }
         }
-        log.info("살균된 content: {}", doc.body().html());
 
-        return doc.body().html();
+        String finalContent = doc.body().html();
+        log.info("살균된 content: {}", finalContent);
+
+        return finalContent;
     }
 
     // http:, CDN url 등 경로 쳐내고 키 값 추출

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
         static: ap-northeast-2
         instance-profile: false
 
+  servlet:
+    multipart:
+      max-file-size: 1MB
+      max-request-size: 2MB
+
   thymeleaf:
     check-template-location: false
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/S3ConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/S3ConfigTest.java
@@ -1,0 +1,53 @@
+package com.finance.finportfolio.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.apache.tika.Tika;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = S3Config.class)
+@ActiveProfiles("local")
+class S3ConfigTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private Tika tika;
+
+    @Test
+    @DisplayName("S3Config를 통해 Tika 빈이 스프링 컨테이너에 정상 등록된다")
+    void tikaBeanRegistrationTest() {
+        // when
+        Tika registeredBean = applicationContext.getBean(Tika.class);
+
+        // then
+        assertThat(registeredBean).isNotNull();
+        assertThat(registeredBean).isSameAs(tika);
+    }
+
+    @Test
+    @DisplayName("Tika 빈이 파일의 MIME 타입을 올바르게 식별한다")
+    void tikaMimeTypeDetectionTest() throws IOException {
+        // given
+        MockMultipartFile mockPngFile = new MockMultipartFile(
+                "file",
+                "test-image.png",
+                "image/png",
+                new byte[] { (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' } // PNG Magic Number
+        );
+
+        // when
+        String detectedType = tika.detect(mockPngFile.getBytes());
+
+        // then
+        assertThat(detectedType).isEqualTo("image/png");
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/S3ConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/S3ConfigTest.java
@@ -29,8 +29,9 @@ class S3ConfigTest {
         Tika registeredBean = applicationContext.getBean(Tika.class);
 
         // then
-        assertThat(registeredBean).isNotNull();
-        assertThat(registeredBean).isSameAs(tika);
+        assertThat(registeredBean)
+                .isNotNull()
+                .isSameAs(tika);
     }
 
     @Test

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/GlobalExceptionHandlerTest.java
@@ -71,6 +71,18 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("메시지 없이 MaxUploadSizeExceededException 발생 시 🛠 기본 메시지를 반환한다")
+    void handleMaxUploadSizeExceededExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/file-size-limit-exceeded"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.uploaded").value(false))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("FILE_SIZE_LIMIT_EXCEEDED"))
+                .andExpect(jsonPath("$.error.message").value("파일 용량이 너무 큽니다. (최대 1MB)"))
+                .andDo(print());
+    }
+
+    @Test
     @DisplayName("UsernameNotFoundException 발생 시 401 에러와 전용 코드를 반환한다")
     void handleUsernameNotFoundExceptionTest() throws Exception {
         mockMvc.perform(get("/test/user-not-found"))
@@ -155,6 +167,17 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.status").value(500))
                 .andExpect(jsonPath("$.code").value("CLOUDFRONT_CONFIG_ERROR"))
                 .andExpect(jsonPath("$.message").value("시스템 보안 설정에 문제가 발생했습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("S3 파일 업로드 에러 발생 시 500 에러를 반환한다")
+    void handleFileStorageExceptionTest() throws Exception {
+        mockMvc.perform(get("/test/storage-error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.code").value("STORAGE_ERROR"))
+                .andExpect(jsonPath("$.message").value("파일 업로드 간 시스템 오류가 발생했습니다. 관리자에게 문의하세요."))
                 .andDo(print());
     }
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/TestExceptionController.java
@@ -2,12 +2,14 @@ package com.finance.finportfolio.global.error;
 
 import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 import com.finance.finportfolio.global.error.exception.DuplicateResourceException;
+import com.finance.finportfolio.global.error.exception.FileStorageException;
 import com.finance.finportfolio.global.error.exception.RefreshTokenNotFoundException;
 
 import io.jsonwebtoken.ExpiredJwtException;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.LockedException;
@@ -24,6 +26,11 @@ public class TestExceptionController {
     @GetMapping("/test/illegal-state-default")
     public void throwIllegalStateDefault() {
         throw new IllegalStateException(""); // 메시지 비움 -> 🛠 기본 메시지 작동 확인
+    }
+
+    @GetMapping("/test/file-size-limit-exceeded")
+    public void throwMaxUploadSizeExceeded() {
+        throw new MaxUploadSizeExceededException(-1L); // 메시지 비움 -> 🛠 기본 메시지 작동 확인
     }
 
     @GetMapping("/test/user-not-found")
@@ -64,6 +71,11 @@ public class TestExceptionController {
     @GetMapping("/test/cloudfront-config-error")
     public void throwCloudFrontConfiguration() {
         throw new CloudFrontConfigurationException("");
+    }
+
+    @GetMapping("/test/storage-error")
+    public void throwFileStorage() {
+        throw new FileStorageException("");
     }
 
     @GetMapping("/test/runtime")

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/FileStorageExceptionTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/error/exception/FileStorageExceptionTest.java
@@ -1,0 +1,33 @@
+package com.finance.finportfolio.global.error.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FileStorageExceptionTest {
+
+    @Test
+    @DisplayName("메시지를 담은 예외가 정상적으로 생성되고 던져진다")
+    void exceptionMessageTest() {
+        String message = "Refresh Token이 없습니다.";
+
+        assertThatThrownBy(() -> {
+            throw new FileStorageException(message);
+        }).isInstanceOf(FileStorageException.class)
+                .hasMessage(message);
+    }
+
+    @Test
+    @DisplayName("원인 예외(Cause)를 포함하여 던질 수 있다")
+    void exceptionWithCauseTest() {
+        Throwable cause = new IllegalArgumentException("원본 에러");
+        String message = "래핑된 에러 메시지";
+
+        FileStorageException ex = new FileStorageException(message, cause);
+
+        assertThat(ex.getMessage()).isEqualTo(message);
+        assertThat(ex.getCause()).isEqualTo(cause);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
@@ -30,8 +30,8 @@ class S3FileHandlerTest {
     private S3FileHandler s3FileHandler;
 
     // 테스트 데이터 상수
-    private final String BUCKET_NAME = "test-bucket";
-    private final String CLOUDFRONT_DOMAIN = "https://cdn.example.com";
+    private static final String BUCKET_NAME = "test-bucket";
+    private static final String CLOUDFRONT_DOMAIN = "https://cdn.example.com";
 
     @BeforeEach
     void setUp() {
@@ -43,7 +43,7 @@ class S3FileHandlerTest {
 
     @Test
     @DisplayName("파일 업로드 시 S3Template의 upload 메서드가 호출되고 저장 파일명을 반환한다")
-    void uploadFileSuccessTest() throws IOException {
+    void uploadFileSuccessTest() {
         // given
         String savedFileName = "uuid-test.png";
         String contentType = "image/png";

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
@@ -1,0 +1,87 @@
+package com.finance.finportfolio.infrastructure.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Template;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileHandlerTest {
+
+    @Mock
+    private S3Template s3Template;
+
+    private S3FileHandler s3FileHandler;
+
+    // 테스트 데이터 상수
+    private final String BUCKET_NAME = "test-bucket";
+    private final String CLOUDFRONT_DOMAIN = "https://cdn.example.com";
+
+    @BeforeEach
+    void setUp() {
+        // S3Properties가 record이거나 final일 경우 Mocking 대신 실제 객체 사용
+        // 생성자나 빌더를 통해 테스트용 데이터를 직접 주입
+        S3Properties s3Properties = new S3Properties(BUCKET_NAME, CLOUDFRONT_DOMAIN);
+        s3FileHandler = new S3FileHandler(s3Template, s3Properties);
+    }
+
+    @Test
+    @DisplayName("파일 업로드 시 S3Template의 upload 메서드가 호출되고 저장 파일명을 반환한다")
+    void uploadFileSuccessTest() throws IOException {
+        // given
+        String savedFileName = "uuid-test.png";
+        String contentType = "image/png";
+        MockMultipartFile file = new MockMultipartFile("file", "test.png", contentType, "content".getBytes());
+
+        // when
+        String result = s3FileHandler.uploadFile(file, savedFileName, contentType);
+
+        // then
+        assertThat(result).isEqualTo(savedFileName);
+        verify(s3Template, times(1)).upload(
+                eq(BUCKET_NAME),
+                eq(savedFileName),
+                any(InputStream.class),
+                any(ObjectMetadata.class));
+    }
+
+    @Test
+    @DisplayName("다중 파일 삭제 시 리스트 크기만큼 deleteObject가 호출된다")
+    void deleteFilesTest() {
+        // given
+        List<String> keys = List.of("key1.png", "key2.png");
+
+        // when
+        s3FileHandler.deleteFiles(keys);
+
+        // then
+        verify(s3Template, times(1)).deleteObject(BUCKET_NAME, "key1.png");
+        verify(s3Template, times(1)).deleteObject(BUCKET_NAME, "key2.png");
+    }
+
+    @Test
+    @DisplayName("클라우드프론트 도메인 정보를 정상적으로 가져온다")
+    void getCloudfrontDomainTest() {
+        // when
+        String result = s3FileHandler.getCloudfrontDomain();
+
+        // then
+        assertThat(result).isEqualTo(CLOUDFRONT_DOMAIN);
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
@@ -1,0 +1,197 @@
+package com.finance.finportfolio.infrastructure.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.tika.Tika;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileServiceImplTest {
+
+    @Mock
+    private S3FileHandler s3FileHandler;
+
+    @Mock
+    private Tika tika;
+
+    @InjectMocks
+    private S3FileServiceImpl s3FileService;
+
+    @Nested
+    @DisplayName("파일 업로드 테스트")
+    class UploadFile {
+
+        @Test
+        @DisplayName("정상적인 이미지 파일일 경우 업로드에 성공한다")
+        void uploadFileSuccessTest() throws IOException {
+            // given
+            // java.awt를 사용하여 Imaging 라이브러리가 완벽히 인식하는 가상의 1x1 PNG 바이트 배열 동적 생성
+            java.awt.image.BufferedImage bufferedImage = new java.awt.image.BufferedImage(1, 1,
+                    java.awt.image.BufferedImage.TYPE_INT_ARGB);
+            java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+            javax.imageio.ImageIO.write(bufferedImage, "png", baos);
+            byte[] validPngBytes = baos.toByteArray();
+
+            MockMultipartFile file = new MockMultipartFile(
+                    "file", "test.png", "image/png", validPngBytes);
+
+            given(tika.detect(any(InputStream.class))).willReturn("image/png");
+            given(s3FileHandler.uploadFile(eq(file), anyString(), eq("image/png")))
+                    .willReturn("uuid-test.png");
+
+            // when
+            String result = s3FileService.uploadFile(file);
+
+            // then
+            assertThat(result).isEqualTo("uuid-test.png");
+            verify(s3FileHandler, times(1)).uploadFile(eq(file), anyString(), eq("image/png"));
+        }
+
+        @Test
+        @DisplayName("파일이 없거나 비어있는 경우 예외를 발생시킨다")
+        void uploadFileEmptyExceptionTest() {
+            // given
+            MockMultipartFile emptyFile = new MockMultipartFile("file", "", "image/png", new byte[0]);
+
+            // when & then
+            assertThatThrownBy(() -> s3FileService.uploadFile(emptyFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("업로드할 파일이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("용량이 제한(1MB)을 초과하는 경우 예외를 발생시킨다")
+        void uploadFileLargeSizeExceptionTest() {
+            // given
+            byte[] largeBytes = new byte[1024 * 1024 + 1]; // 1MB + 1Byte
+            MockMultipartFile largeFile = new MockMultipartFile("file", "large.png", "image/png", largeBytes);
+
+            // when & then
+            assertThatThrownBy(() -> s3FileService.uploadFile(largeFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("파일 용량이 너무 큽니다.");
+        }
+
+        @Test
+        @DisplayName("MIME 타입이 이미지가 아닐 경우 예외를 발생시킨다")
+        void uploadFileInvalidMimeTypeExceptionTest() throws IOException {
+            // given
+            MockMultipartFile textFile = new MockMultipartFile("file", "test.txt", "text/plain", "hello".getBytes());
+            given(tika.detect(any(InputStream.class))).willReturn("text/plain");
+
+            // when & then
+            assertThatThrownBy(() -> s3FileService.uploadFile(textFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("허용되지 않는 파일 형식입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("HTML 본문 파일 처리 테스트")
+    class ContentFileProcessing {
+
+        @Test
+        @DisplayName("본문 데이터 삭제 시 포함된 이미지 파일의 키만 추출하여 S3Handler 다중삭제를 호출한다")
+        void deleteFilesTest() {
+            // given
+            String uuid1 = "12345678-1234-1234-1234-123456781234";
+            String uuid2 = "abcdefab-abcd-abcd-abcd-abcdefabcdef";
+            String content = "<p>본문내용</p><img src=\"" + uuid1 + "-img1.png\"><img src=\"https://cdn.example.com/"
+                    + uuid2 + "-img2.png\">";
+
+            // when
+            s3FileService.deleteFiles(content);
+
+            // then
+            verify(s3FileHandler, times(1)).deleteFiles(List.of(uuid1 + "-img1.png", uuid2 + "-img2.png"));
+        }
+
+        @Test
+        @DisplayName("본문을 조회용으로 전환 시 도메인이 없는 파일명에 CDN 주소를 붙여준다")
+        void convertToCdnUrlsTest() {
+            // given
+            String pureKey = "12345678-1234-1234-1234-123456781234-image.png";
+            String content = "<img src=\"" + pureKey + "\">";
+            given(s3FileHandler.getCloudfrontDomain()).willReturn("cdn.financeportfolio.com");
+
+            // when
+            String result = s3FileService.convertToCdnUrls(content);
+
+            // then
+            assertThat(result).contains("https://cdn.financeportfolio.com/" + pureKey);
+        }
+
+        @Test
+        @DisplayName("본문을 저장용으로 전환 시 CDN 주소를 떼고 HTML 살균(Jsoup.clean)을 수행한다")
+        void removeCdnUrlsTest() {
+            // given
+            String pureKey = "12345678-1234-1234-1234-123456781234-image.png";
+            String inputHtml = "<p>안전한 본문</p><img src=\"https://cdn.example.com/" + pureKey
+                    + "\"><script>alert('xss');</script>";
+
+            // when
+            String result = s3FileService.removeCdnUrls(inputHtml);
+
+            // then
+            assertThat(result).contains("img src=\"" + pureKey + "\"");
+            assertThat(result).doesNotContain("<script>"); // XSS 방어 살균 검증
+        }
+    }
+
+    @Nested
+    @DisplayName("미참조 파일(Orphan Files) 정리 테스트")
+    class CleanUpOrphanFiles {
+
+        @Test
+        @DisplayName("S3 버킷 키 목록 중 DB 본문에 존재하지 않는 파일만 선별하여 삭제한다")
+        void cleanUpOrphanFilesSuccessTest() {
+            // given
+            String usedKey = "12345678-1234-1234-1234-123456781234-used.png";
+            String orphanKey = "abcdefab-abcd-abcd-abcd-abcdefabcdef-orphan.png";
+
+            List<String> allPostContents = List.of("<img src=\"" + usedKey + "\">");
+            List<String> s3BucketKeys = List.of(usedKey, orphanKey);
+
+            given(s3FileHandler.getS3ObjectKeys()).willReturn(s3BucketKeys);
+
+            // when
+            s3FileService.cleanUpOrphanFiles(allPostContents);
+
+            // then
+            verify(s3FileHandler, times(1)).deleteFiles(List.of(orphanKey));
+        }
+
+        @Test
+        @DisplayName("DB 데이터가 하나도 비어있을 경우 오작동 방지를 위해 삭제 처리를 중단한다")
+        void cleanUpOrphanFilesEmptyPostContentsTest() {
+            // given
+            List<String> emptyContents = List.of();
+
+            // when
+            s3FileService.cleanUpOrphanFiles(emptyContents);
+
+            // then
+            verify(s3FileHandler, never()).getS3ObjectKeys();
+            verify(s3FileHandler, never()).deleteFiles(any());
+        }
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
@@ -152,8 +152,9 @@ class S3FileServiceImplTest {
             String result = s3FileService.removeCdnUrls(inputHtml);
 
             // then
-            assertThat(result).contains("img src=\"" + pureKey + "\"");
-            assertThat(result).doesNotContain("<script>"); // XSS 방어 살균 검증
+            assertThat(result)
+                    .contains("img src=\"" + pureKey + "\"")
+                    .doesNotContain("<script>"); // XSS 방어 살균 검증
         }
     }
 

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -70,6 +70,9 @@ const handleGlobalError = (error) => {
 
     if (isLoginRequest(error.config)) return;
 
+    // 이미지 업로드 실패는 호출한 쪽(어댑터)에서 처리
+    if (error.config?.url?.includes('/image/upload')) return;
+
     switch (status) {
         case 403:
             alert("권한이 없습니다.");

--- a/finance-portfolio-frontend/src/api/postApi.js
+++ b/finance-portfolio-frontend/src/api/postApi.js
@@ -42,28 +42,34 @@ export const imageUploadAdapter = (loader) => {
     return {
         upload: async () => {
             try {
-                // 1. 파일 로드 (await로 뎁스 제거)
+                // 파일 로드
                 const file = await loader.file;
 
-                // 2. FormData 준비
+                // 프론트 사전 검증 (CKEditor 기본 제한 우회, 서버 제한과 맞춰야함)
+                if (file.size > 1 * 1024 * 1024) {
+                    throw new Error('파일 용량이 너무 큽니다. (최대 1MB)');
+                }
+
+                // FormData 준비
                 const formData = new FormData();
                 formData.append('upload', file);
 
-                // 3. API 호출
+                // API 호출
                 const response = await axiosInstance.post('/image/upload', formData, {
-                    headers: {
-                        'Content-Type': 'multipart/form-data',
-                    },
+                    headers: { 'Content-Type': 'multipart/form-data' },
                 });
 
-                // 4. 성공 시 결과 반환
-                return {
-                    default: response.data.url
-                };
+                // 파일 업로드 실패시 예외처리
+                if (!response.data.uploaded) {
+                    throw new Error(response.data.error?.message || '업로드 실패');
+                }
+
+                // 성공 시 결과 반환
+                return { default: response.data.url };
+
             } catch (err) {
-                // 5. 에러 핸들링
-                const errorMessage = err.response?.data?.message || '업로드 실패';
-                throw errorMessage; // async 함수에서 에러는 throw하면 reject와 동일합니다.
+                const raw = err.response?.data?.error?.message || err.message || '이미지 업로드에 실패했습니다.';
+                throw new Error(raw.replace(/^Error:\s*/, ''));
             }
         }
     };


### PR DESCRIPTION
## 개요
- **현황**: `S3FileServiceImpl`에서 메타데이터 기반의 형식 체크만 수행하고 있어, 확장자 위조를 통한 악의적인 스크립트 파일(예: .jsp, .php를 .jpg로 위조) 업로드 위험이 존재.
- **해결방안**:
  - 악의적 스크립트 파일 업로드를 방지하기 위해 기존 Jsoup 살균에 앞서 파일 본문을 직접 분석하는 검증 로직을 추가.
  - 다층 방어 체계 구축(프론트, 멀티파트 파싱, 서비스 코드).
  - 업로드 실패 시 프론트엔드와 백엔드 간의 데이터 정합성 문제를 해결.

## 작업내용
- 🍃서버
  - **의존성 및 설정 관리**
    - `build.gradle`: `Apache Tika(3.3.0)` 및 `Apache Commons Imaging(1.0.0)` 라이브러리 추가.
    - `S3Config`: 멀티파트 파일의 MIME 타입 체크를 위한 `Tika` 인스턴스를 `Bean`으로 등록.
    - `application.yml`: `multipart` 설정(`max-file-size`, `max-request-size`)을 통해 **네트워크 진입 단계**에서 대용량 파일 **1차 차단**.
  - **비지니스 로직 및 구조 개선**
    - **`S3FileServiceImpl` (핵심)**: 파일 업로드 시 파일 크기, 해상도(픽셀), MIME 타입(`Magic Byte`) 등 이미지 파일 유효성을 전방위적으로 검증하는 로직 구현.
    - `PostService`: 기존에 포함되어 있던 Jsoup HTML 살균 로직을 `FileService`로 이관하여 서비스 간 **관심사 분리** 및 데이터 영속화 역할 집중.
  - **예외 처리 및 컨트롤러**
    - `EditorImageController`: 이미지 업로드 실패 시 클라이언트가 상태를 명확히 인지할 수 있도록 응답 코드를 `200`에서 `400 BadRequest`로 교정.
    - `GlobalExceptionHandler`: 설정된 파일 크기 초과 시 발생하는 `MaxUploadSizeExceededException`에 대한 공통 예외 핸들러 추가.

- ⚛️프론트
  - **네트워크 통신 최적화**
    - **`axios` 인스턴스**: `/image/upload` 엔드포인트 호출 시, 전역 에러 핸들러(`handleGlobalError`)가 간섭하지 않고 어댑터에서 직접 에러를 제어할 수 있도록 예외 분기 처리.
  - **에디터 인터페이스 고도화**
    - `postApi`: `imageUploadAdapter` 내부에 업로드 전 파일 유효성을 프론트 사이드에서 먼저 검증.
    - **예외 핸들링**: 서버 업로드 실패 시 `Promise.reject` 등을 통해 에디터 내부에 임시 저장된 Base64 이미지가 유지되지 않도록 예외 처리 강화.

## 결과
- **보안 및 아키텍처 고도화**: Apache Tika 기반 매직 바이트 검증으로 우회 업로드를 차단하고, HTML 살균 로직을 `FileService`로 이관하여 관심사를 분리.
- **API 및 예외 처리 규격화**: 이미지 업로드 실패 시 상태 코드를 `400 BadRequest`로 교정하고, `MaxUploadSizeExceededException` 공통 핸들러를 통해 예외 응답을 일관화.
- **클라이언트 데이터 정합성 확보**: Axios 인터셉터 분기 및 프론트 어댑터 예외 처리를 통해, 업로드 실패 시 에디터 내에 Base64 임시 이미지가 잔존하는 이슈를 완벽히 해결. - [추가2 참고]

<img width="1065" height="691" alt="image" src="https://github.com/user-attachments/assets/3cb4b31b-517c-4ed3-9e69-8fbcc0a8b1ae" />

## 관련이슈
- Closes #121

## 추가1) 의사결정 명세
- 이미지 파일 유효성 체크에는 다음과 같은 방법들이 있었으며 의사결정 과정을 다음과 같이 명세함.

|보안 전략|핵심 메커니즘|장점|단점 및 한계점|
|---|---|---|---|
|방법1(매직 바이트 검증)|바이너리 헤더(Magic Bytes) 및 MIME 타입 검증|추가 비용 없음, 구현이 빠르고 가벼움|내부 악성 스크립트(Polyglot) 및 스테가노그래피 탐지 불가|
|방법2(리사이징/재인코딩)|`Graphics2D` 등을 통한 픽셀 재구성 및 포맷 변환|구조적 데이터 변환으로 내장 악성코드 완전 파괴|높은 CPU 자원 소모, 고화질 원본 유지 불가|
|방법3(안티바이러스 스캔)|ClamAV 또는 AWS GuardDuty 연동 스캐닝|알려진 패턴의 멀웨어/바이러스에 대한 높은 신뢰도|추가 인프라 비용 발생 및 시스템 복잡도 증가|

- **최종 결정 및 채택 근거**
  - 선택 전략: **[방법1]** Apache Tika 기반 Deep Check + 인프라 레벨 방어 체계 구축.
  - 한정된 인프라 자원 (`t3.micro`)
    - **방법3**의 경우 소규모 프로젝트 단계에서 별도 스캔 서버 운영 및 유료 보안 서비스 도입은 비용 및 인프라 오버헤드가 과도.
    - **방법2**의 경우 `t3.micro` 환경의 제한된 CPU/메모리 자원에서 실시간 이미지 재인코딩 처리는 자원 고갈 위험이 높음.
- **향후 확장 가능성**
  - AWS Lambda 기반 방법 2 연계
    - Lambda를 사용하면 메인 EC2 서버의 CPU 자원을 소모하지 않으면서도, 구조적 변환을 통해 이미지 내 악성코드를 완전히 제거하는 강력한 보안 계층 확보 가능.

## 추가2) **트러블슈팅**: 이미지 업로드 실패 시 에디터 내 잔존 현상
- **문제 상황**
  - 서버의 해상도 제한 정책으로 인해 이미지의 **S3 업로드가 실패**했음에도, **CKEditor 본문 내에서는 이미지가 정상적으로 표시**되는 현상 발생.
  - S3 버킷을 직접 확인해본 결과 파일이 확실히 저장되지 않았으나, 에디터 상에서는 미리보기가 유지되어 데이터 정합성 불일치 문제 인지.
- **원인분석**
  - **Base64 임시 렌더링**:
    - 미리보기 이미지를 확인해보니 `data:image/png;base64,iVBOR...` 와 같은 주소가 확인 됨.
    - 확인 결과 CKeditor의 경우 이미지 저장이 실패하는 경우 **임시 데이터 URL(base64)**를 통해 이미지를 임시 보관하는 방어 로직이 기본 설정되어있음을 인지.
  - **예외처리 누락**: CKeditor용 업로드 어댑터에서 파일 업로드 실패 상황 예외처리를 명시하지 않아. CKeditor가 알아서 임시 데이터로 저장한 상황.
- **해결방안**
  - **어댑터 예외 처리**: `imageUploadAdapter` 내에 서버 에러 발생 시 `Promise`를 `reject` 처리하는 로직을 추가하여 에디터가 업로드 실패를 즉각 인지하도록 수정.
  - **공통 인터셉터 예외 처리**: Axios 전역 응답 인터셉터가 이미지 업로드 에러까지 일괄 처리하는 비효율을 방지하기 위해, `/image/upload` API는 인터셉터를 거치지 않고 에러를 직접 반환하도록 분기 처리하여 응답 프로세스 최적화.