### PR TITLE
[Feat] Scheduler 도입을 통한 미참조 이미지 정기 정리 구현

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/controller/PostController.java
@@ -75,12 +75,4 @@ public class PostController {
         postService.deletePost(id);
         return ResponseEntity.noContent().build();
     }
-
-    @DeleteMapping("/cleanup")
-    public ResponseEntity<Void> cleanUpOrphanFiles() {
-        log.info("미참조 이미지 정리 시작");
-        postService.cleanUpOrphanFiles();
-        return ResponseEntity.noContent().build();
-    }
-
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/FileService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/FileService.java
@@ -15,4 +15,6 @@ public interface FileService {
     String convertToCdnUrls(String content);
 
     String removeCdnUrls(String content);
+
+    int s3ObjectCount();
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -63,6 +63,14 @@ public class PostService {
                 .orElse(false);
     }
 
+    @Transactional(readOnly = true)
+    public List<String> getAllPostContents() {
+        return postRepository.findAll().stream()
+                .map(Post::getContent)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
     // 게시글 페이지 조회(페이징), return: 게시글 목록
     @Transactional(readOnly = true)
     public Page<PostResponseDto> getPostList(int page, int size, Long categoryId) {
@@ -145,16 +153,9 @@ public class PostService {
         postRepository.delete(post);
     }
 
-    // 미참조 이미지 파일 삭제 - 버튼 식(차후 정기 실행으로 변경)
     @Transactional(readOnly = true)
-    public void cleanUpOrphanFiles() {
-        // DB에서 post의 모든 content 넘김
-        List<String> allPostContents = postRepository.findAll().stream()
-                .map(Post::getContent)
-                .filter(Objects::nonNull)
-                .toList();
-
-        fileService.cleanUpOrphanFiles(allPostContents);
+    public int s3ObjectCount() {
+        return fileService.s3ObjectCount();
     }
 
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SchedulerConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.finance.finportfolio.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig implements SchedulingConfigurer {
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+
+        // 동시 실행 가능한 스케줄러 스레드 수
+        threadPoolTaskScheduler.setPoolSize(1);
+        threadPoolTaskScheduler.setThreadNamePrefix("s3-cleanup-cron-");
+        threadPoolTaskScheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/scheduler/S3ImageCleanupScheduler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/scheduler/S3ImageCleanupScheduler.java
@@ -1,0 +1,40 @@
+package com.finance.finportfolio.global.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.finance.finportfolio.domain.post.service.FileService;
+import com.finance.finportfolio.domain.post.service.PostService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3ImageCleanupScheduler {
+    private final PostService postService;
+    private final FileService fileService;
+
+    // 매일 3시
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanUpOrphanImages() {
+        log.info("S3 미참조 이미지 정기 정리 시작(0 0 3 * * *)");
+        try {
+            List<String> allPostContents = postService.getAllPostContents();
+
+            if (allPostContents.isEmpty()) {
+                log.info("S3 미참조 이미지 정기 정리 조기 종료(게시글 없음)");
+                return;
+            }
+
+            fileService.cleanUpOrphanFiles(allPostContents);
+            log.info("S3 미참조 이미지 정기 정리 종료(성공)");
+
+        } catch (Exception e) {
+            log.info("S3 미참조 이미지 정기 정리 조기 종료(예외 발생): ", e);
+        }
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileHandler.java
@@ -2,6 +2,7 @@ package com.finance.finportfolio.infrastructure.file;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -85,7 +86,8 @@ public class S3FileHandler {
     public List<String> getS3ObjectKeys() {
         return s3Template.listObjects(s3Properties.bucketName(), "").stream()
                 .map(resource -> resource.getLocation().getObject())
-                .filter(filename -> filename != null && !filename.isEmpty())
+                .filter(Objects::nonNull)
+                .filter(filename -> !filename.isEmpty())
                 .toList();
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -214,6 +214,12 @@ public class S3FileServiceImpl implements FileService {
         }
     }
 
+    @Override
+    public int s3ObjectCount() {
+        List<String> s3Keys = s3FileHandler.getS3ObjectKeys();
+        return s3Keys.size();
+    }
+
     // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직
     private List<String> extractFileNamesFromContent(String content) {
         List<String> imageKeys = new ArrayList<>();

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SchedulerConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SchedulerConfigTest.java
@@ -1,0 +1,47 @@
+package com.finance.finportfolio.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.*;
+
+class SchedulerConfigTest {
+
+    private final SchedulerConfig schedulerConfig = new SchedulerConfig();
+
+    @Test
+    @DisplayName("TaskScheduler가 ScheduledTaskRegistrar에 등록된다")
+    void configureTasks_registersTaskScheduler() {
+        // given
+        ScheduledTaskRegistrar taskRegistrar = mock(ScheduledTaskRegistrar.class);
+
+        // when
+        schedulerConfig.configureTasks(taskRegistrar);
+
+        // then
+        var captor = forClass(ThreadPoolTaskScheduler.class);
+        verify(taskRegistrar, times(1)).setTaskScheduler(captor.capture());
+
+        ThreadPoolTaskScheduler scheduler = captor.getValue();
+        // getPoolSize() → 실제 풀 크기 (initialize() 후 executor 기준)
+        // getCorePoolSize() → initialize() 이후 실제 설정된 코어 스레드 수
+        assertThat(scheduler.getScheduledThreadPoolExecutor().getCorePoolSize()).isEqualTo(1);
+        assertThat(scheduler.getThreadNamePrefix()).isEqualTo("s3-cleanup-cron-");
+    }
+
+    @Test
+    @DisplayName("configureTasks 호출 시 예외가 발생하지 않는다")
+    void configureTasks_doesNotThrow() {
+        // given
+        ScheduledTaskRegistrar taskRegistrar = new ScheduledTaskRegistrar();
+
+        // when & then
+        assertThatCode(() -> schedulerConfig.configureTasks(taskRegistrar))
+                .doesNotThrowAnyException();
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/scheduler/S3ImageCleanupSchedulerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/scheduler/S3ImageCleanupSchedulerTest.java
@@ -1,0 +1,82 @@
+package com.finance.finportfolio.global.scheduler;
+
+import com.finance.finportfolio.domain.post.service.FileService;
+import com.finance.finportfolio.domain.post.service.PostService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class S3ImageCleanupSchedulerTest {
+
+    @Mock
+    private PostService postService;
+
+    @Mock
+    private FileService fileService;
+
+    @InjectMocks
+    private S3ImageCleanupScheduler scheduler;
+
+    @Test
+    @DisplayName("게시글이 존재하면 cleanUpOrphanFiles를 호출한다")
+    void cleanUpOrphanImages_withPosts_callsCleanUp() {
+        // given
+        List<String> contents = List.of("<img src='https://s3.../image1.png'>", "내용2");
+        when(postService.getAllPostContents()).thenReturn(contents);
+
+        // when
+        scheduler.cleanUpOrphanImages();
+
+        // then
+        verify(postService, times(1)).getAllPostContents();
+        verify(fileService, times(1)).cleanUpOrphanFiles(contents);
+    }
+
+    @Test
+    @DisplayName("게시글이 없으면 cleanUpOrphanFiles를 호출하지 않는다")
+    void cleanUpOrphanImages_noPosts_skipsCleanUp() {
+        // given
+        when(postService.getAllPostContents()).thenReturn(Collections.emptyList());
+
+        // when
+        scheduler.cleanUpOrphanImages();
+
+        // then
+        verify(postService, times(1)).getAllPostContents();
+        verify(fileService, never()).cleanUpOrphanFiles(any());
+    }
+
+    @Test
+    @DisplayName("PostService에서 예외 발생 시 cleanUpOrphanFiles를 호출하지 않는다")
+    void cleanUpOrphanImages_postServiceThrows_doesNotPropagateException() {
+        // given
+        when(postService.getAllPostContents()).thenThrow(new RuntimeException("DB 오류"));
+
+        // when & then (예외가 외부로 전파되지 않아야 함)
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+                () -> scheduler.cleanUpOrphanImages());
+        verify(fileService, never()).cleanUpOrphanFiles(any());
+    }
+
+    @Test
+    @DisplayName("FileService에서 예외 발생 시 예외가 외부로 전파되지 않는다")
+    void cleanUpOrphanImages_fileServiceThrows_doesNotPropagateException() {
+        // given
+        List<String> contents = List.of("내용1");
+        when(postService.getAllPostContents()).thenReturn(contents);
+        doThrow(new RuntimeException("S3 오류")).when(fileService).cleanUpOrphanFiles(any());
+
+        // when & then
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+                () -> scheduler.cleanUpOrphanImages());
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileHandlerTest.java
@@ -1,11 +1,15 @@
 package com.finance.finportfolio.infrastructure.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -17,7 +21,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
+import com.finance.finportfolio.global.error.exception.FileStorageException;
+
+import io.awspring.cloud.s3.Location;
 import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +69,30 @@ class S3FileHandlerTest {
     }
 
     @Test
+    @DisplayName("파일 업로드 중 IOException 발생 시 FileStorageException을 던진다")
+    void uploadFileIOExceptionTest() {
+        // given
+        String savedFileName = "uuid-test.png";
+        String contentType = "image/png";
+
+        // MockMultipartFile의 getInputStream() 호출 시 IOException을 유도하기 위해 스파이 또는 익명 클래스
+        // 활용 가능
+        // 혹은 S3Template.upload에서 내부적으로 스트림 읽다 터지는 상황 모킹
+        MockMultipartFile file = new MockMultipartFile("file", "test.png", contentType, "content".getBytes()) {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                throw new IOException("인위적 파일 읽기 실패");
+            }
+        };
+
+        // when & then
+        assertThatThrownBy(() -> s3FileHandler.uploadFile(file, savedFileName, contentType))
+                .isInstanceOf(FileStorageException.class)
+                .hasMessageContaining("S3 파일 업로드 중 오류 발생")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
     @DisplayName("다중 파일 삭제 시 리스트 크기만큼 deleteObject가 호출된다")
     void deleteFilesTest() {
         // given
@@ -82,5 +114,48 @@ class S3FileHandlerTest {
 
         // then
         assertThat(result).isEqualTo(CLOUDFRONT_DOMAIN);
+    }
+
+    @Test
+    @DisplayName("S3 오브젝트 키 목록을 정상적으로 조회하고 null이나 빈 값은 필터링한다")
+    void getS3ObjectKeysSuccessTest() {
+        // given
+        S3Resource resource1 = mock(S3Resource.class);
+        S3Resource resource2 = mock(S3Resource.class);
+        S3Resource resource3 = mock(S3Resource.class); // null 필터링 테스트용
+        S3Resource resource4 = mock(S3Resource.class); // 빈 문자열 필터링 테스트용
+
+        Location location1 = mock(Location.class);
+        Location location2 = mock(Location.class);
+        Location location3 = mock(Location.class);
+        Location location4 = mock(Location.class);
+
+        // 각 가짜 리소스가 가짜 Location 객체를 반환하도록 설정
+        when(resource1.getLocation()).thenReturn(location1);
+        when(location1.getObject()).thenReturn("images/photo1.png");
+
+        when(resource2.getLocation()).thenReturn(location2);
+        when(location2.getObject()).thenReturn("images/photo2.png");
+
+        // Objects::nonNull 검증용 가짜 스텁 설정
+        when(resource3.getLocation()).thenReturn(location3);
+        when(location3.getObject()).thenReturn(null);
+
+        // !filename.isEmpty() 검증용 가짜 스텁 설정
+        when(resource4.getLocation()).thenReturn(location4);
+        when(location4.getObject()).thenReturn("");
+
+        // S3Template Mock이 위에서 가공된 4개의 리소스를 반환하도록 리스트 지정
+        List<S3Resource> mockResources = List.of(resource1, resource2, resource3, resource4);
+        when(s3Template.listObjects(BUCKET_NAME, "")).thenReturn(mockResources);
+
+        // when
+        List<String> result = s3FileHandler.getS3ObjectKeys();
+
+        // then
+        assertThat(result)
+                .hasSize(2)
+                .containsExactly("images/photo1.png", "images/photo2.png");
+        verify(s3Template, times(1)).listObjects(BUCKET_NAME, "");
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -193,6 +194,21 @@ class S3FileServiceImplTest {
             // then
             verify(s3FileHandler, never()).getS3ObjectKeys();
             verify(s3FileHandler, never()).deleteFiles(any());
+        }
+
+        @Test
+        @DisplayName("S3 오브젝트 키 목록의 크기를 정상적으로 반환한다")
+        void s3ObjectCountSuccessTest() {
+            // given
+            List<String> mockKeys = List.of("images/file1.png", "images/file2.png", "images/file3.png");
+            when(s3FileHandler.getS3ObjectKeys()).thenReturn(mockKeys);
+
+            // when
+            int count = s3FileService.s3ObjectCount();
+
+            // then
+            assertThat(count).isEqualTo(3);
+            verify(s3FileHandler, times(1)).getS3ObjectKeys();
         }
     }
 }


### PR DESCRIPTION
## 개요
- **현황**: 과거 수동으로 작동하던 미참조 이미지 삭제 메서드가 프론트 UI 개편 과정에서 버튼이 삭제되어 데드 코드화.
- **목적**: 데드 코드화 되었던 미참조 이미지 삭제 메서드를 Spring Scheduler를 통해 정기적으로 자동 삭제하여 인프라 저장소 비용을 절감하고 데이터의 정전성을 유지.
- **배경**: 사용자가 게시글 작성 중 이미지를 업로드한 후 글 저장을 취소하거나, 이미지를 본문에서 지운 경우 S3에 무의미한 파일이 남아 자원이 낭비되는 문제를 해결하는 것이 목적.

## 작업 내용
- **정기처리 구현**
  - `PostService`: `cleanUpOrphanFiles` 메서드에 분리되어있던 전체게시글 조회 기능을 표준 방식에 걸맞게 `getAllPostContents`으로 회귀하여 후 스케줄러에서 사용 가능하게 변경.
  - `SchedulerConfig`: Spring Scheduler를 사용하기 위한 세부 설정 Config 파일.
  - `S3ImageCleanupScheduler`: S3 미참조 이미지 정기 정리 기능 구현. (`cron = "0 0 3 * * *"`)
- 데드코드 정리
  - `PostController`의 수동 작동 메서드 `cleanUpOrphanFiles` 삭제.
- 가독성 향상
  - `S3FileHandler` `filter`의 논리 연산자 처리를 각 필터로 분리하여 명확화.

- 후속 작업 대비 선행작업
  - `FileService`, , `S3FileServiceImpl`: 관리자 대시보드에 총 이미지 수를 보여주기 위한 `s3ObjectCount` 메서드 추가.

## 결과
- **비용 최적화**: 웹 서버(EC2)가 사용되지 않는 새벽 시간대의 유휴 자원을 활용하여 인프라 비용을 최소화하는 동시에 S3 버킷 용량을 상시 최적화.
- **유지보수성 향상**: 백그라운드 스레드에 명확한 접두사를 지정하여 에러 발생 시 로그 추적 및 디버깅 편의성을 극대화.

<img width="567" height="40" alt="image" src="https://github.com/user-attachments/assets/f0dc1314-bfbd-4c91-85b7-9c22d59f19e3" />
