### PR TITLE
[Feat] 관리자 API 송수신 부 구성을 통한 대시보드 실 데이터 전송

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/controller/AdminController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.finance.finportfolio.domain.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
+import com.finance.finportfolio.domain.admin.service.AdminService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+    private final AdminService adminService;
+
+    @GetMapping("/summary")
+    public ResponseEntity<AdminResponseDto> getCounts() {
+        AdminResponseDto summary = adminService.getDashboardSummary();
+        return ResponseEntity.ok(summary);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/dto/AdminResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/dto/AdminResponseDto.java
@@ -1,0 +1,11 @@
+package com.finance.finportfolio.domain.admin.dto;
+
+public record AdminResponseDto(
+        long totalPostCount,
+        long totalImageCount,
+        long totalMemberCount) {
+    public static AdminResponseDto from(long totalPostCount, long totalImageCount, long totalMemberCount) {
+        return new AdminResponseDto(
+                totalPostCount, totalImageCount, totalMemberCount);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/service/AdminService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/service/AdminService.java
@@ -1,0 +1,24 @@
+package com.finance.finportfolio.domain.admin.service;
+
+import org.springframework.stereotype.Service;
+
+import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
+import com.finance.finportfolio.domain.member.service.MemberService;
+import com.finance.finportfolio.domain.post.service.PostService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final PostService postService;
+    private final MemberService memberService;
+
+    public AdminResponseDto getDashboardSummary() {
+        long totalPostCount = postService.getTotalPostCount();
+        long totalImageCount = postService.s3ObjectCount();
+        long totalMemberCount = memberService.getTotalMemberCount();
+
+        return new AdminResponseDto(totalPostCount, totalImageCount, totalMemberCount);
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
@@ -33,6 +33,11 @@ public class MemberService {
         private final JwtTokenProvider jwtTokenProvider;
         private final LoginAttemptService loginAttemptService;
 
+        @Transactional(readOnly = true)
+        public long getTotalMemberCount() {
+                return memberRepository.count();
+        }
+
         private Member findMemberByLoginId(String loginId) {
                 return memberRepository.findByLoginId(loginId)
                                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/service/PostService.java
@@ -71,6 +71,16 @@ public class PostService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public long getTotalPostCount() {
+        return postRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public long s3ObjectCount() {
+        return fileService.s3ObjectCount();
+    }
+
     // 게시글 페이지 조회(페이징), return: 게시글 목록
     @Transactional(readOnly = true)
     public Page<PostResponseDto> getPostList(int page, int size, Long categoryId) {
@@ -151,11 +161,6 @@ public class PostService {
 
         // DB 게시글 삭제
         postRepository.delete(post);
-    }
-
-    @Transactional(readOnly = true)
-    public int s3ObjectCount() {
-        return fileService.s3ObjectCount();
     }
 
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -88,9 +88,10 @@ public class SecurityConfig {
                                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                                 // 에러페이지
                                                 .requestMatchers("/error").permitAll()
+                                                // 관리자 기능
+                                                .requestMatchers("/api/admin/**").hasRole(ADMIN)
                                                 // 게시판
                                                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
-                                                .requestMatchers("/api/posts/cleanup").hasRole(ADMIN)
                                                 .requestMatchers("/api/posts/**").hasAnyRole(USER, ADMIN)
                                                 .requestMatchers(HttpMethod.POST, "/api/image/upload")
                                                 .hasAnyRole(USER, ADMIN)
@@ -104,8 +105,6 @@ public class SecurityConfig {
                                                 .requestMatchers("/api/member/logout").hasAnyRole(USER, ADMIN)
                                                 // 금융 계산기 등
                                                 .requestMatchers("/api/finance/**").permitAll()
-                                                // 관리자 기능
-                                                .requestMatchers("/api/admin/**").hasRole(ADMIN)
                                                 // 명시되지 않은 경로 모두 차단
                                                 .anyRequest().denyAll())
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/ApiRateLimitGroup.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/ApiRateLimitGroup.java
@@ -10,8 +10,7 @@ public enum ApiRateLimitGroup {
             "/api/member/join")),
     // 이미지 S3 업로드, 미참조 이미지 삭제
     HIGH("고부하 리소스", 2, 15, Duration.ofMinutes(1), List.of(
-            "/api/image/upload",
-            "/api/posts/cleanup")),
+            "/api/image/upload")),
     // 게시글 조회, 금융 계산기
     MEDIUM("DB/UX 보호", 3, 30, Duration.ofMinutes(1), List.of(
             "/api/posts",

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -59,6 +59,12 @@ public class S3FileServiceImpl implements FileService {
     }
 
     @Override
+    public int s3ObjectCount() {
+        List<String> s3Keys = s3FileHandler.getS3ObjectKeys();
+        return s3Keys.size();
+    }
+
+    @Override
     public String uploadFile(MultipartFile file) {
 
         validateFile(file);
@@ -212,12 +218,6 @@ public class S3FileServiceImpl implements FileService {
             log.info("미참조 파일 삭제 실행: {} 건", orphanKeys.size());
             s3FileHandler.deleteFiles(orphanKeys);
         }
-    }
-
-    @Override
-    public int s3ObjectCount() {
-        List<String> s3Keys = s3FileHandler.getS3ObjectKeys();
-        return s3Keys.size();
     }
 
     // HTML 본문에서 URL/파일명 리스트를 추출하는 정규식 로직

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/controller/AdminControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,91 @@
+package com.finance.finportfolio.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.FilterType;
+
+import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
+import com.finance.finportfolio.domain.admin.service.AdminService;
+import com.finance.finportfolio.global.security.filter.JwtAuthenticationFilter;
+
+@WebMvcTest(value = AdminController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+})
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminService adminService;
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth
+                            // 실제 운영 환경의 인가 규칙과 동일하게 매핑
+                            .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                            .anyRequest().permitAll());
+            return http.build();
+        }
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 대시보드 통계 조회 성공")
+    @WithMockUser(roles = "ADMIN") // ROLE_ADMIN 권한을 가진 가상의 사용자 생성
+    void getCounts_Success_WhenAdmin() throws Exception {
+        // given
+        AdminResponseDto mockResponse = new AdminResponseDto(128L, 45L, 12L);
+        given(adminService.getDashboardSummary()).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/summary")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalPostCount").value(128))
+                .andExpect(jsonPath("$.totalImageCount").value(45))
+                .andExpect(jsonPath("$.totalMemberCount").value(12));
+    }
+
+    @Test
+    @DisplayName("권한이 없는 일반 사용자가 대시보드 조회 시 403 Forbidden 반환")
+    @WithMockUser(roles = "USER") // ROLE_USER 권한을 가진 가상의 사용자 생성
+    void getCounts_Forbidden_WhenUser() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/summary")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden()); // SecurityConfig 설정에 의해 차단됨
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 비회원이 대시보드 조회 시 401 Unauthorized 또는 403 Forbidden 반환")
+    void getCounts_Unauthorized_WhenAnonymous() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/summary")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden()); // Spring Security 기본 익명 사용자 차단 정책
+    }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/service/AdminServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/service/AdminServiceTest.java
@@ -1,0 +1,57 @@
+package com.finance.finportfolio.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
+import com.finance.finportfolio.domain.member.service.MemberService;
+import com.finance.finportfolio.domain.post.service.PostService;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private PostService postService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("대시보드 요약 정보 조회 성공")
+    void getDashboardSummary_Success() {
+        // given
+        long expectedPostCount = 15L;
+        long expectedImageCount = 30L;
+        long expectedMemberCount = 5L;
+
+        given(postService.getTotalPostCount()).willReturn(expectedPostCount);
+        given(postService.s3ObjectCount()).willReturn(expectedImageCount);
+        given(memberService.getTotalMemberCount()).willReturn(expectedMemberCount);
+
+        // when
+        AdminResponseDto result = adminService.getDashboardSummary();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.totalPostCount()).isEqualTo(expectedPostCount);
+        assertThat(result.totalImageCount()).isEqualTo(expectedImageCount);
+        assertThat(result.totalMemberCount()).isEqualTo(expectedMemberCount);
+
+        // verify (의존 객체 메서드 호출 여부 검증)
+        then(postService).should(times(1)).getTotalPostCount();
+        then(postService).should(times(1)).s3ObjectCount();
+        then(memberService).should(times(1)).getTotalMemberCount();
+    }
+}

--- a/finance-portfolio-frontend/src/api/adminApi.js
+++ b/finance-portfolio-frontend/src/api/adminApi.js
@@ -1,0 +1,7 @@
+import axiosInstance from './axios';
+
+// 대시보드 일람
+export const getDashboardSummary = async () => {
+    const response = await axiosInstance.get('/admin/summary');
+    return response.data; // AdminResponseDto 가 들어옴
+};

--- a/finance-portfolio-frontend/src/api/postApi.js
+++ b/finance-portfolio-frontend/src/api/postApi.js
@@ -32,12 +32,7 @@ export const deletePost = async (id) => {
     await axiosInstance.delete(`/posts/${id}`);
 };
 
-// 6. 미참조 파일 정리 (DELETE /api/posts/cleanup)
-export const cleanUpFiles = async () => {
-    await axiosInstance.delete('/posts/cleanup');
-};
-
-// 7. CKeditor 전용 업로드 어댑터
+// 6. CKeditor 전용 업로드 어댑터
 export const imageUploadAdapter = (loader) => {
     return {
         upload: async () => {

--- a/finance-portfolio-frontend/src/pages/admins/AdminDashboard.jsx
+++ b/finance-portfolio-frontend/src/pages/admins/AdminDashboard.jsx
@@ -1,16 +1,35 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getDashboardSummary } from '../../api/adminApi';
+import LoadingPage from '../common/LoadingPage';
 
 const AdminDashboard = () => {
     const navigate = useNavigate();
 
-    // 임시 통계 데이터 (실제로는 API에서 호출)
+    const [dashboardData, setDashboardData] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        getDashboardSummary()
+            .then((data) => {
+                setDashboardData(data);
+                setLoading(false);
+            })
+            .catch((err) => {
+                console.error('대시보드 데이터 로드 실패:', err);
+                setError('데이터를 불러오는 중 오류가 발생했습니다.');
+                setLoading(false);
+            });
+    }, []);
+
     const stats = [
-        { title: '총 게시글', count: '128', unit: '개', color: 'text-primary' },
-        { title: '신규 회원', count: '12', unit: '명', color: 'text-success' },
-        { title: '오늘 방문자', count: '1,024', unit: '명', color: 'text-info' },
-        { title: '시스템 상태', count: '정상', unit: '', color: 'text-warning' },
+        { title: '총 게시글', count: dashboardData?.totalPostCount ?? 0, unit: '개', color: 'text-primary' },
+        { title: 'S3 오브젝트', count: dashboardData?.totalImageCount ?? 0, unit: '개', color: 'text-warning' },
+        { title: '총 회원 수', count: dashboardData?.totalMemberCount ?? 0, unit: '명', color: 'text-success' },
     ];
+
+    if (loading) return <LoadingPage />;
 
     return (
         <div className="container py-4">
@@ -33,7 +52,9 @@ const AdminDashboard = () => {
                             <div className="card-body">
                                 <h6 className="card-subtitle mb-2 text-muted fw-bold">{item.title}</h6>
                                 <div className={`h3 mb-0 fw-bold ${item.color}`}>
-                                    {item.count}<small className="fs-6 text-muted ms-1">{item.unit}</small>
+                                    {/* 1,000 단위 콤마 포맷팅 */}
+                                    {Number(item.count).toLocaleString()}
+                                    <small className="fs-6 text-muted ms-1">{item.unit}</small>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## 개요
- **현황**: 관리자 대시보드의 통계 데이터가 하드코딩된 상태.
- **개선방안**: 백엔드 DB 집계 및 S3 객체 수 연동 API를 프론트엔드와 연결하여 대시보드 데이터 동적화 및 관리자 제어 기능 확립.

## 작업 내용
- 🍃서버
  - **관리자 도메인 및 통계 API 구현** (`GET` `/api/admin/summary`)
    - 각 서비스 및 컴포넌트로부터 데이터를 취합하여 관리자용 대시보드 데이터 반환.
    - `AdminController`, `AdminResponseDto` 구현.
    - `AdminService` 내 데이터 수집 로직 구현:
      - `MemberService`: 전체 회원 수 집계 (`getTotalMemberCount`)
      - `PostService`: 전체 게시글 수 집계 (`getTotalPostCount`)
      - `S3FileServiceImpl`: S3 버킷 내 객체 수 집계 (`s3ObjectCount`)
  - **보안 및 접근 제어 설정**
    - `SecurityConfig`: 관리자 전용 API 경로(`requestMatchers("/api/admin/")`)의 인가 처리 우선순위 상향 조정.
  - **데드코드 제거**
    - `ApiRateLimitGroup`의 고부하 리소스 제한 그룹에서 제거된 엔드포인트(`"/api/image/upload"`) 관련 설정 삭제.

- ⚛️프론트
  - **관리자 API 송수신부 구현**
    - 백엔드 관리자 API와 통신하는 `adminApi` 모듈 추가.
  - **대시보드 컴포넌트 수정**
    - `AdminDashboard` 내 하드코딩되어 있던 summary 파트에 API 실데이터 바인딩.
  - **데드코드 제거**
    - `postApi` 내에서 사용되지 않는 미참조 이미지 수동 삭제 메서드(`cleanUpFiles`) 제거.

## 결과
- **동적 관리**: 하드코딩을 제거하고 실제 DB 및 외부 스토리지(S3) 지표를 연동하여 실시간 운영 지표 모니터링.
- **유지보수성**: 미사용 엔드포인트 및 데드코드 정리를 통한 시스템 복잡도 감소.

<img width="1060" height="436" alt="image" src="https://github.com/user-attachments/assets/1f2c2199-4cbb-406d-ae3a-6b99a8e8d13a" />

## 관련이슈
- Closes #131