### PR TITLE
[Refactor] 🍃게시글 request Dto 입력값 검증 추가

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/finance/dto/CalculateFairRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/finance/dto/CalculateFairRequestDto.java
@@ -7,7 +7,7 @@ package com.finance.finportfolio.domain.finance.dto;
      * expectedYield: 기대수익률
      */
 public record CalculateFairRequestDto(
-        double dps,
-        double expectedYield,
-        double growthRate) {
+                double dps,
+                double expectedYield,
+                double growthRate) {
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostSaveRequestDto.java
@@ -4,15 +4,19 @@ import com.finance.finportfolio.domain.category.entity.Category;
 import com.finance.finportfolio.domain.member.entity.Member;
 import com.finance.finportfolio.domain.post.entity.Post;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 import lombok.Builder;
 
 // PostSaveRequestDto - Post 엔티티 Set 용 DTO
 @Builder
 public record PostSaveRequestDto(
-                Long categoryId,
-                String author,
-                String title,
-                String content,
+                @NotNull(message = "카테고리는 필수 선택 사항입니다.") Long categoryId,
+                @NotBlank(message = "작성자는 필수 입력 항목입니다.") String author,
+                @NotBlank(message = "제목을 입력해주세요.") @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.") String title,
+                @NotBlank(message = "본문을 입력해주세요.") String content,
                 Boolean hasImage) {
 
         public PostSaveRequestDto {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostUpdateRequestDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/post/dto/PostUpdateRequestDto.java
@@ -2,10 +2,15 @@ package com.finance.finportfolio.domain.post.dto;
 
 import lombok.Builder;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 @Builder
 public record PostUpdateRequestDto(
-        Long categoryId,
-        String title,
-        String content,
-        Boolean hasImage) {
+
+                @NotNull(message = "카테고리는 필수 선택 사항입니다.") Long categoryId,
+                @NotBlank(message = "제목을 입력해주세요.") @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.") String title,
+                @NotBlank(message = "본문을 입력해주세요.") String content,
+                Boolean hasImage) {
 }


### PR DESCRIPTION
## 개요
- **현황**: 프로젝트 초창기에 작성된 `post` 도메인의 request dto에는 입력값 검증 과정이 부재.
- **개선방안**: `validation` 어노테이션을 활용하여 입력값 검증을 `post` 도메인에도 추가하여 일관성 유지 및 런타임 에러 방지.

## 작업내용
- **입력값 검증 추가**
  - `@NotBlank`, `@Size`, `@NotNull` 등 검증 어노테이션 추가.
    - `PostSaveRequestDto`
    - `PostUpdateRequestDto`

## 결과
- **데이터 무결성 확보 및 안정성 향상**:  등의 검증 애노테이션을 통해 유효하지 않은 데이터가 도메인 및 DB 레이어까지 진입하는 것을 차단하고 불필요한 예외 발생을 방지.
- **아키텍처 일관성 유지**: 기존 `member` 등 타 도메인에 적용되어 있던 입력값 검증 패턴을 동일하게 적용하여 프로젝트 전반의 코드 일관성과 통일성을 확보.