### PR TITLE
[Feat] ⚛️DOMPurify를 통한 XSS 이중방어

### DIFF
--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.13.5",
         "bootstrap": "^5.3.8",
         "ckeditor5": "^47.5.0",
+        "dompurify": "^3.4.5",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
         "react": "^19.2.0",
@@ -2894,6 +2895,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3793,6 +3801,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/finance-portfolio-frontend/package.json
+++ b/finance-portfolio-frontend/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.13.5",
     "bootstrap": "^5.3.8",
     "ckeditor5": "^47.5.0",
+    "dompurify": "^3.4.5",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^4.0.0",
     "react": "^19.2.0",

--- a/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import DOMPurify from 'dompurify';
 
 import LoadingPage from '../common/LoadingPage';
 import { getPostById, deletePost } from '../../api/postApi';
@@ -69,10 +70,11 @@ const PostDetail = () => {
                     </tr>
                     <tr>
                         <th className="table-light">내용</th>
-                        {/* dangerouslySetInnerHTML: 타임리프의 utext와 같은 기능 */}
+                        {/* dangerouslySetInnerHTML: 타임리프의 utext와 같은 기능
+                        dompurify를 통해 XSS 이중방어 */}
                         <td
                             className="post-content"
-                            dangerouslySetInnerHTML={{ __html: post.content }}
+                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}
                             style={{ minHeight: '200px' }}
                         />
                     </tr>


### PR DESCRIPTION
## 개요
- **현황**: 서버측은 `Jsoup`을 통해 XSS 방어가 이루어지지만 프론트의 출력부에선 방어 로직이 부재하여 우회 공격에 취약.
- **개선방안**: 프론트 사이드에서 `DOMPurify` 라이브러리를 통해 출력과정에서의 취약점 또한 이중방어.

## 작업내용
- `DOMPurify` 라이브러리 추가.
- 게시글 상세 페이지(`PostDetail`)의 속성 `DOMPurify` 살균 과정 추가.
  - `dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}`

## 결과