### PR TITLE
[Feat] ⚛️DOMPurify를 통한 XSS 방어 강화 및 🍃Jsoup 살균 조건 완화

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -47,6 +47,7 @@ public class S3FileServiceImpl implements FileService {
             .addAttributes("img", "alt", "width", "height", "src")
             // 링크(a) 태그의 target 속성 허용 (새창 열기용)
             .addAttributes("a", "target", "rel")
+            .addProtocols("a", "href", "http", "https", "mailto")
             // 모든 허용된 태그에 대해 인라인 스타일(style) 속성 허용
             // (텍스트 정렬, 글자 색상, 배경색 유지)
             .addAttributes(":all", "style")

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -41,8 +41,19 @@ public class S3FileServiceImpl implements FileService {
 
     // jsoup 커스텀 설정 본문용(utext)
     private static final Safelist HTML_SAFE_LIST = Safelist.relaxed()
-            .addAttributes("img", "alt", "width", "height") // 이미지 관련 속성 허용
-            .addTags("hr", "br"); // 가로줄, 줄바꿈 명시적 허용
+            // CKEditor 필수 기본 태그 및 가로줄/줄바꿈 추가 허용
+            .addTags("hr", "br", "span", "div")
+            // 이미지 태그의 필수 속성 확장
+            .addAttributes("img", "alt", "width", "height", "src")
+            // 링크(a) 태그의 target 속성 허용 (새창 열기용)
+            .addAttributes("a", "target", "rel")
+            // 모든 허용된 태그에 대해 인라인 스타일(style) 속성 허용
+            // (텍스트 정렬, 글자 색상, 배경색 유지)
+            .addAttributes(":all", "style")
+            // 테이블(표) 서식 보존을 위한 속성 추가 허용
+            .addAttributes("table", "border", "cellspacing", "cellpadding")
+            .addAttributes("td", "colspan", "rowspan")
+            .addAttributes("th", "colspan", "rowspan");
 
     // 용량, 해상도 제한
     private static final long MAX_FILE_SIZE = 1L * 1024 * 1024;

--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.13.5",
         "bootstrap": "^5.3.8",
         "ckeditor5": "^47.5.0",
+        "dompurify": "^3.4.5",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
         "react": "^19.2.0",
@@ -2894,6 +2895,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3793,6 +3801,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/finance-portfolio-frontend/package.json
+++ b/finance-portfolio-frontend/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.13.5",
     "bootstrap": "^5.3.8",
     "ckeditor5": "^47.5.0",
+    "dompurify": "^3.4.5",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^4.0.0",
     "react": "^19.2.0",

--- a/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import DOMPurify from 'dompurify';
 
 import LoadingPage from '../common/LoadingPage';
 import { getPostById, deletePost } from '../../api/postApi';
@@ -69,10 +70,11 @@ const PostDetail = () => {
                     </tr>
                     <tr>
                         <th className="table-light">내용</th>
-                        {/* dangerouslySetInnerHTML: 타임리프의 utext와 같은 기능 */}
+                        {/* dangerouslySetInnerHTML: 타임리프의 utext와 같은 기능
+                        dompurify를 통해 XSS 이중방어 */}
                         <td
                             className="post-content"
-                            dangerouslySetInnerHTML={{ __html: post.content }}
+                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}
                             style={{ minHeight: '200px' }}
                         />
                     </tr>


### PR DESCRIPTION
## 개요
- **XSS 이중방어**
  - **현황**: 서버측은 Jsoup을 통해 XSS 방어가 이루어지지만 프론트의 출력부에선 방어 로직이 부재하여 우회 공격에 취약.
  - **개선방안**: 프론트 사이드에서 `DOMPurify` 라이브러리를 통해 출력과정에서의 취약점 또한 이중방어.
- **Jsoup 조건 완화**
  - **현황**: Jsoup `Safelist.relaxed()`의 커스텀 설정이 과도하게 엄격하여 CKEditor의 설정이 변경 될 시 사용자가 지정한 설정이 삭제될 위험 존재.
  - **개선방안**: 커스텀 설정에 보안취약점에 영향을 미치지 않되 필수적인 태그, 속성을 명시적으로 허가.

## 작업내용
- 🍃서버
  - Jsoup 커스텀 설정 완화.
    - 기본 태그 및 가로줄/줄바꿈.
    - 링크(a) 태그의 target 속성.
    - 모든 허용된 태그에 대해 인라인 스타일(style) 속성
    - 테이블(표) 서식 보존을 위한 속성.

- ⚛️프론트
  - `DOMPurify` 라이브러리 추가.
  - 게시글 상세 페이지(`PostDetail`)의 속성 `DOMPurify` 살균 과정 추가.
    - `dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}`

## 결과
- **출력부 보안 강화(XSS 이중방어)**: 프론트엔드 출력부(`PostDetail`)에 DOMPurify 살균 로직을 도입하여, 혹시 모를 **백엔드 살균 우회 공격**이나 가공되지 않은 악성 스크립트의 실행 가능성을 차단.
- **CKEditor 서식 깨짐 대비**: Jsoup의 `Safelist` 규제를 합리적으로 완화하여 테이블 구조, 인라인 스타일(글자 색상, 정렬 등), 링크 속성 등 CKEditor의 개선 작업 시 작성된 서식 있는 텍스트가 깨지지 않고 의도한 대로 정상 렌더링되도록 보완.