### PR TITLE
[Security] 🍃쿠키 Samesite 정책 단일화

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenCookieManager.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/controller/TokenCookieManager.java
@@ -86,7 +86,7 @@ public class TokenCookieManager {
                 .secure(isSecure) // HTTPS 필수
                 .path("/")
                 .maxAge(maxAge) // maxAge가 0이면 삭제용, 그 외에는 생성용
-                .sameSite(isSecure ? "Lax" : "Strict") // CSRF 방지(Lax: 링크 타고 온 건 허용)
+                .sameSite("Strict") // CSRF 방지
                 .build();
     }
 

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -170,7 +170,7 @@ class MemberControllerTest {
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(cookie().secure("refreshToken", true))
-                .andExpect(cookie().attribute("refreshToken", "SameSite", "Lax"));
+                .andExpect(cookie().attribute("refreshToken", "SameSite", "Strict"));
     }
 
     @Test


### PR DESCRIPTION
## 개요
- **현황**: 쿠키의 Samesite 가변 정책이 배포환경에서 `Lax`, 로컬 환경에서 `Strict`로  반대로 설정되어 있어 CSRF 공격에 노출 위험이 있는 상황.
- **개선방안**: 정책 적용 조건을 반대로 돌리기보다 통합하여 관리에 용이하도록 변경.

## 작업내용
- `TokenCookieManager`: 로컬환경 여부를 판명하는 `isSecure` 변수와 무관하게 `Strict`로 로컬/배포환경 정책 단일화.

## 결과
- **CSRF 방어**: `SameSite` 정책을 `Strict`로 상향함으로써, 외부 사이트에서 발생하는 서드 파티 요청 시 인증 쿠키가 전송되는 것을 원천 차단.
- **유지보수성**: 로컬 개발 환경과 배포 운영 환경의 정책을 하나로 통합 관리, 환경 차이로 인해 발생할  수 있는 잠재적 버그 가능성 차단.