### PR TITLE
[Refactor] CloudFront 필터 예외처리 개선 및 health엔드포인트 허가

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/SecurityConfig.java
@@ -86,6 +86,8 @@ public class SecurityConfig {
                                 .authorizeHttpRequests(auth -> auth
                                                 // 예비요청(OPTIONS)
                                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                                                // 헬스체크(로드밸런서)
+                                                .requestMatchers("/api/health").permitAll()
                                                 // 에러페이지
                                                 .requestMatchers("/error").permitAll()
                                                 // 관리자 기능

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilter.java
@@ -4,17 +4,22 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 
 import java.io.IOException;
+import java.util.Map;
 
+@Slf4j
 @Component // 빈 등록은 하되
 @ConditionalOnProperty( // dev/prod 프로파일에서만 활성화
         name = "cloudfront.enabled", havingValue = "true")
@@ -22,12 +27,21 @@ public class CloudFrontHeaderFilter extends OncePerRequestFilter {
 
     private final String cfHeaderName;
     private final String cfHeaderValue;
+    private final ObjectMapper objectMapper;
 
     public CloudFrontHeaderFilter(
             @Value("${cloudfront.custom.header.name}") String cfHeaderName,
-            @Value("${cloudfront.custom.header.value}") String cfHeaderValue) {
+            @Value("${cloudfront.custom.header.value}") String cfHeaderValue,
+            ObjectMapper objectMapper) {
+
+        // 서버 실행시점 필수 값 체크
+        if (!StringUtils.hasText(cfHeaderName) || !StringUtils.hasText(cfHeaderValue)) {
+            throw new CloudFrontConfigurationException("CloudFront 필터 초기화 실패: 필수 헤더 설정값이 누락되었습니다.");
+        }
+
         this.cfHeaderName = cfHeaderName;
         this.cfHeaderValue = cfHeaderValue;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -52,17 +66,25 @@ public class CloudFrontHeaderFilter extends OncePerRequestFilter {
             String headerValue = request.getHeader(cfHeaderName);
 
             if (headerValue == null || !headerValue.equals(cfHeaderValue)) {
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                response.setContentType("application/json;charset=UTF-8");
-                response.getWriter().write(
-                        "{\"status\": 403, \"message\": \"Direct access is not allowed. Please access through CloudFront.\"}");
+                sendErrorResponse(response, HttpServletResponse.SC_FORBIDDEN,
+                        "CloudFront를 통하지 않은 직접 접근은 허가되지 않습니다.");
                 return;
             }
 
             filterChain.doFilter(request, response);
         } catch (Exception e) {
-            throw new CloudFrontConfigurationException("CloudFront Header Filter 초기화 실패: " + e.getMessage());
-        }
+            log.error("CloudFront 헤더 검증 실패: {}", e.getMessage());
 
+            sendErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+        }
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json;charset=UTF-8");
+        Map<String, Object> errorBody = Map.of(
+                "status", status,
+                "message", message);
+        response.getWriter().write(objectMapper.writeValueAsString(errorBody));
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/CloudFrontHeaderFilterTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.finance.finportfolio.global.error.exception.CloudFrontConfigurationException;
 
 import java.io.IOException;
@@ -21,11 +23,12 @@ class CloudFrontHeaderFilterTest {
     private CloudFrontHeaderFilter filter;
     private static final String HEADER_NAME = "X-Custom-CF-Header";
     private static final String HEADER_VALUE = "secret-value-123";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
         // 테스트용 필터 인스턴스 생성
-        filter = new CloudFrontHeaderFilter(HEADER_NAME, HEADER_VALUE);
+        filter = new CloudFrontHeaderFilter(HEADER_NAME, HEADER_VALUE, objectMapper);
     }
 
     @Test
@@ -60,7 +63,8 @@ class CloudFrontHeaderFilterTest {
         // then
         verify(filterChain, never()).doFilter(request, response);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
-        assertThat(response.getContentAsString()).contains("Direct access is not allowed");
+        assertThat(response.getContentType()).contains("application/json");
+        assertThat(response.getContentAsString()).contains("CloudFront를 통하지 않은 직접 접근은 허가되지 않습니다.");
     }
 
     @Test
@@ -96,32 +100,37 @@ class CloudFrontHeaderFilterTest {
     }
 
     @Test
-    @DisplayName("예외 발생 시 지정된 메시지가 포함된 CloudFrontConfigurationException을 던진다")
-    void throwCloudFrontConfigurationException() {
-        // given
-        String originalErrorMessage = "Access Key is missing";
-        String expectedMessage = "CloudFront Header Filter 초기화 실패: " + originalErrorMessage;
-
+    @DisplayName("필터 생성 시 필수 설정값이 누락되면 CloudFrontConfigurationException이 발생한다")
+    void shouldThrowExceptionWhenConfigurationIsMissing() {
         // when & then
-        // 람다 내부 로직을 예외를 직접 던지는 단일 호출로 리팩토링
-        assertThatThrownBy(() -> {
-            throw new CloudFrontConfigurationException("CloudFront Header Filter 초기화 실패: " + originalErrorMessage);
-        })
+        assertThatThrownBy(() -> new CloudFrontHeaderFilter("", HEADER_VALUE, objectMapper))
                 .isInstanceOf(CloudFrontConfigurationException.class)
-                .hasMessage(expectedMessage);
+                .hasMessageContaining("CloudFront 필터 초기화 실패: 필수 헤더 설정값이 누락되었습니다.");
+
+        assertThatThrownBy(() -> new CloudFrontHeaderFilter(HEADER_NAME, null, objectMapper))
+                .isInstanceOf(CloudFrontConfigurationException.class)
+                .hasMessageContaining("CloudFront 필터 초기화 실패: 필수 헤더 설정값이 누락되었습니다.");
     }
 
     @Test
-    @DisplayName("예외가 발생해도 원인(Cause)이 유지되는지 확인")
-    void exceptionCausePersistence() {
+    @DisplayName("필터 체인 동작 중 예기치 않은 예외가 발생하면 500 Internal Server Error를 직접 반환한다")
+    void shouldReturn500WhenUnexpectedExceptionOccurs() throws ServletException, IOException {
         // given
-        RuntimeException cause = new RuntimeException("Original Cause");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HEADER_NAME, HEADER_VALUE); // 일단 헤더 검증은 통과하도록 유도
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // 다음 필터로 넘어갈 때 강제로 예외를 발생시키도록 모킹
+        FilterChain filterChain = mock(FilterChain.class);
+        doThrow(new RuntimeException("DB Connection Failed")).when(filterChain).doFilter(request, response);
 
         // when
-        CloudFrontConfigurationException exception = new CloudFrontConfigurationException("Test Message", cause);
+        filter.doFilter(request, response, filterChain);
 
         // then
-        assertThat(exception.getMessage()).isEqualTo("Test Message");
-        assertThat(exception.getCause()).isEqualTo(cause);
+        // 예외가 밖으로 던져지지 않고 내부 catch 블록에서 처리되어 500 코드가 나가야 함
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        assertThat(response.getContentType()).contains("application/json");
+        assertThat(response.getContentAsString()).contains("서버 내부 오류가 발생했습니다.");
     }
 }


### PR DESCRIPTION
## 개요
- `CloudFrontHeaderFilter`의 예외 처리 방식을 개선하여 구동 안정성 확립.
- 인프라 모니터링 확장 시 발생할 수 있는 헬스체크 실패 리스크를 사전 방지.


## 작업 내용
- `CloudFrontHeaderFilter`:
  - **구동 안정성 확보**: 서버 실행 단계에서 CloudFront 설정값을 미리 체크하여 런타임 에러를 방지하며 초기 안정성을 향상.
  - **에러 메시지 정제**: 실제 상황과 어긋나던 "초기화 실패" 메시지를 서버 내부 결함에 걸맞은 명확한 `500` 에러 메시지로 정상화.
  - **필터 예외 제어권 획득**: 필터 체인단에서 `throw`된 예외가 컨트롤러로 반환되지 못하던 문제를 컴포넌트 안에선 에러 로그 기록만 하고 `ObjectMapper` 직접 응답 방식으로 전달.
- `SecurityConfig`:
  - **인가 정책 정합성 통일**: 차후 로드밸런서 확장성을 고려하여, CloudFront 필터가 우회한 `/api/health` 경로를 `SecurityConfig`에서도 동일하게 허가하여 정책 충돌 방지.

##. 결과 및 기대 효과
- **예외 핸들링** 필터 레이어에서 발생하던 예외를 스프링 컨텍스트 밖에서 제어하여 클라이언트에게 규격화된 에러 응답을 보장.
* **인프라 정합성 및 확장성:** 초기 설정 검증 도입으로 배포 사고 리스크를 예방, 필터 우회 정책과 시큐리티 인가 정책의 일관성을 확보하여 향후 로드밸런서 연결 시 헬스체크 오작동을 사전 차단.