### PR TITLE
[Feat] AWS 연결 상태 대시보드 모니터링

### DIFF
--- a/finance-portfolio-backend/build.gradle
+++ b/finance-portfolio-backend/build.gradle
@@ -56,6 +56,13 @@ dependencies {
 	// 이미지 파일 유효성 검증(MIME 타입 판별, 픽셀크기 등 이미지 메타데이터 추출)
 	implementation 'org.apache.tika:tika-core:3.3.0'
 	implementation 'org.apache.commons:commons-imaging:1.0.0-alpha5'
+
+	// AWS SDK v2
+    implementation platform('software.amazon.awssdk:bom:2.44.12')
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:ec2'
+    // Spring Web & Validation (기존 구성 선언 가정)
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 tasks.named('test') {

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/controller/AdminController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/controller/AdminController.java
@@ -1,5 +1,7 @@
 package com.finance.finportfolio.domain.admin.controller;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
 import com.finance.finportfolio.domain.admin.service.AdminService;
+import com.finance.finportfolio.domain.admin.service.AwsHealthCheckService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,10 +20,20 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/admin")
 public class AdminController {
     private final AdminService adminService;
+    private final AwsHealthCheckService awsHealthCheckService;
 
+    // 총 게시글, s3오브젝트, 총 회원 수 종합 전달
     @GetMapping("/summary")
     public ResponseEntity<AdminResponseDto> getCounts() {
         AdminResponseDto summary = adminService.getDashboardSummary();
         return ResponseEntity.ok(summary);
+    }
+
+    // AWS S3, EC2 상태 전달
+    @GetMapping("/awsHealth")
+    public ResponseEntity<Map<String, Object>> getAwsStatus() {
+        Map<String, Object> response = awsHealthCheckService.checkAwsStatus();
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckService.java
@@ -1,0 +1,89 @@
+package com.finance.finportfolio.domain.admin.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class AwsHealthCheckService {
+
+    private final S3Client s3Client;
+    private final Ec2Client ec2Client;
+
+    @Value("${spring.cloud.aws.s3.bucket-name}")
+    private String bucketName;
+
+    @Value("${spring.cloud.aws.ec2.instance-id}")
+    private String instanceId;
+
+    public AwsHealthCheckService(S3Client s3Client, Ec2Client ec2Client) {
+        this.s3Client = s3Client;
+        this.ec2Client = ec2Client;
+    }
+
+    public Map<String, Object> checkAwsStatus() {
+        Map<String, Object> statusMap = new HashMap<>();
+
+        statusMap.put("s3", checkS3Status());
+        statusMap.put("ec2", checkEc2Status());
+
+        return statusMap;
+    }
+
+    private Map<String, Object> checkS3Status() {
+        Map<String, Object> s3Result = new HashMap<>();
+        try {
+            HeadBucketRequest headBucketRequest = HeadBucketRequest.builder()
+                    .bucket(bucketName)
+                    .build();
+
+            s3Client.headBucket(headBucketRequest);
+            s3Result.put("status", "UP");
+            s3Result.put("message", "S3 Bucket access successful.");
+        } catch (S3Exception e) {
+            s3Result.put("status", "DOWN");
+            s3Result.put("message", "S3 Error: " + e.awsErrorDetails().errorMessage());
+        } catch (Exception e) {
+            s3Result.put("status", "DOWN");
+            s3Result.put("message", "Unexpected Error: " + e.getMessage());
+        }
+        return s3Result;
+    }
+
+    private Map<String, Object> checkEc2Status() {
+        Map<String, Object> ec2Result = new HashMap<>();
+        try {
+            DescribeInstancesRequest request = DescribeInstancesRequest.builder()
+                    .instanceIds(instanceId)
+                    .build();
+
+            DescribeInstancesResponse response = ec2Client.describeInstances(request);
+
+            // 인스턴스의 현재 상태 추출 (e.g., running, stopped)
+            String state = response.reservations().get(0)
+                    .instances().get(0)
+                    .state()
+                    .name()
+                    .toString();
+
+            ec2Result.put("status", "UP");
+            ec2Result.put("instanceState", state);
+        } catch (Ec2Exception e) {
+            ec2Result.put("status", "DOWN");
+            ec2Result.put("message", "EC2 Error: " + e.awsErrorDetails().errorMessage());
+        } catch (Exception e) {
+            ec2Result.put("status", "DOWN");
+            ec2Result.put("message", "Unexpected Error: " + e.getMessage());
+        }
+        return ec2Result;
+    }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckService.java
@@ -19,6 +19,9 @@ public class AwsHealthCheckService {
     private final S3Client s3Client;
     private final Ec2Client ec2Client;
 
+    private static final String STATUS = "status";
+    private static final String MESSAGE = "message";
+
     @Value("${spring.cloud.aws.s3.bucket-name}")
     private String bucketName;
 
@@ -47,14 +50,14 @@ public class AwsHealthCheckService {
                     .build();
 
             s3Client.headBucket(headBucketRequest);
-            s3Result.put("status", "UP");
-            s3Result.put("message", "S3 Bucket access successful.");
+            s3Result.put(STATUS, "UP");
+            s3Result.put(MESSAGE, "S3 Bucket access successful.");
         } catch (S3Exception e) {
-            s3Result.put("status", "DOWN");
-            s3Result.put("message", "S3 Error: " + e.awsErrorDetails().errorMessage());
+            s3Result.put(STATUS, "DOWN");
+            s3Result.put(MESSAGE, "S3 Error: " + e.awsErrorDetails().errorMessage());
         } catch (Exception e) {
-            s3Result.put("status", "DOWN");
-            s3Result.put("message", "Unexpected Error: " + e.getMessage());
+            s3Result.put(STATUS, "DOWN");
+            s3Result.put(MESSAGE, "Unexpected Error: " + e.getMessage());
         }
         return s3Result;
     }
@@ -75,14 +78,14 @@ public class AwsHealthCheckService {
                     .name()
                     .toString();
 
-            ec2Result.put("status", "UP");
+            ec2Result.put(STATUS, "UP");
             ec2Result.put("instanceState", state);
         } catch (Ec2Exception e) {
-            ec2Result.put("status", "DOWN");
-            ec2Result.put("message", "EC2 Error: " + e.awsErrorDetails().errorMessage());
+            ec2Result.put(STATUS, "DOWN");
+            ec2Result.put(MESSAGE, "EC2 Error: " + e.awsErrorDetails().errorMessage());
         } catch (Exception e) {
-            ec2Result.put("status", "DOWN");
-            ec2Result.put("message", "Unexpected Error: " + e.getMessage());
+            ec2Result.put(STATUS, "DOWN");
+            ec2Result.put(MESSAGE, "Unexpected Error: " + e.getMessage());
         }
         return ec2Result;
     }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/AwsConfig.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/config/AwsConfig.java
@@ -1,0 +1,44 @@
+package com.finance.finportfolio.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String regionStr;
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public StaticCredentialsProvider credentialsProvider() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey));
+    }
+
+    @Bean
+    public S3Client s3Client(StaticCredentialsProvider credentialsProvider) {
+        return S3Client.builder()
+                .region(Region.of(regionStr))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    @Bean
+    public Ec2Client ec2Client(StaticCredentialsProvider credentialsProvider) {
+        return Ec2Client.builder()
+                .region(Region.of(regionStr))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+}

--- a/finance-portfolio-backend/src/main/resources/application.yml
+++ b/finance-portfolio-backend/src/main/resources/application.yml
@@ -18,12 +18,6 @@ spring:
       filter:
         enabled: true
 
-  cloud:
-    aws:
-      region:
-        static: ap-northeast-2
-        instance-profile: false
-
   servlet:
     multipart:
       max-file-size: 1MB
@@ -68,12 +62,16 @@ spring:
 
   cloud:
     aws:
+      region:
+        static: ap-northeast-2
       credentials:
         access-key: ${AWS_ACCESS_KEY_ID} 
         secret-key: ${AWS_SECRET_ACCESS_KEY}
       s3:
         bucket-name: finportfolio-s3-bucket-local-9806
         cloudfront-domain: dt08rm0613jz4.cloudfront.net
+      ec2:
+        instance-id: i-0ad52267191315154
 ---
 spring:
   config:
@@ -87,12 +85,16 @@ spring:
 
   cloud:
     aws:
+      region:
+        static: ap-northeast-2
       credentials:
         access-key: ${AWS_ACCESS_KEY_ID} 
         secret-key: ${AWS_SECRET_ACCESS_KEY}
       s3:
         bucket-name: finportfolio-s3-bucket-dev-9806
         cloudfront-domain: d24842uv7pd3qd.cloudfront.net
+      ec2:
+        instance-id: i-0ad52267191315154
 
 cloudfront:
   enabled: true
@@ -117,12 +119,16 @@ spring:
 
   cloud:
     aws:
+      region:
+        static: ap-northeast-2
       credentials:
         access-key: ${AWS_ACCESS_KEY_ID} 
         secret-key: ${AWS_SECRET_ACCESS_KEY}
       s3:
         bucket-name: finportfolio-s3-bucket-prod-9806
         cloudfront-domain: d2m4qtzslhorm2.cloudfront.net
+      ec2:
+        instance-id: i-0ad52267191315154
 
 cloudfront:
   enabled: true

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/controller/AdminControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/controller/AdminControllerTest.java
@@ -6,6 +6,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,7 @@ import org.springframework.context.annotation.FilterType;
 
 import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
 import com.finance.finportfolio.domain.admin.service.AdminService;
+import com.finance.finportfolio.domain.admin.service.AwsHealthCheckService;
 import com.finance.finportfolio.global.security.filter.JwtAuthenticationFilter;
 
 @WebMvcTest(value = AdminController.class, excludeFilters = {
@@ -35,6 +39,9 @@ class AdminControllerTest {
 
     @MockitoBean
     private AdminService adminService;
+
+    @MockitoBean
+    private AwsHealthCheckService awsHealthCheckService;
 
     @TestConfiguration
     static class TestSecurityConfig {
@@ -87,5 +94,46 @@ class AdminControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isForbidden()); // Spring Security 기본 익명 사용자 차단 정책
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 AWS 헬스체크 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void getAwsStatus_Success_WhenAdmin() throws Exception {
+        // given
+        Map<String, Object> mockResponse = new HashMap<>();
+        mockResponse.put("s3Status", "UP");
+        mockResponse.put("ec2Status", "RUNNING");
+
+        given(awsHealthCheckService.checkAwsStatus()).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/awsHealth")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.s3Status").value("UP"))
+                .andExpect(jsonPath("$.ec2Status").value("RUNNING"));
+    }
+
+    @Test
+    @DisplayName("권한이 없는 일반 사용자가 AWS 헬스체크 조회 시 403 Forbidden 반환")
+    @WithMockUser(roles = "USER")
+    void getAwsStatus_Forbidden_WhenUser() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/awsHealth")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 비회원이 AWS 헬스체크 조회 시 403 Forbidden 반환")
+    void getAwsStatus_Unauthorized_WhenAnonymous() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/admin/awsHealth")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckServiceTest.java
@@ -88,13 +88,15 @@ class AwsHealthCheckServiceTest {
 
                 @SuppressWarnings("unchecked")
                 Map<String, Object> s3Result = (Map<String, Object>) result.get("s3");
-                assertThat(s3Result.get("status")).isEqualTo("UP");
-                assertThat(s3Result.get("message")).isEqualTo("S3 Bucket access successful.");
+                assertThat(s3Result)
+                                .containsEntry("status", "UP")
+                                .containsEntry("message", "S3 Bucket access successful.");
 
                 @SuppressWarnings("unchecked")
                 Map<String, Object> ec2Result = (Map<String, Object>) result.get("ec2");
-                assertThat(ec2Result.get("status")).isEqualTo("UP");
-                assertThat(ec2Result.get("instanceState")).isEqualTo("running");
+                assertThat(ec2Result)
+                                .containsEntry("status", "UP")
+                                .containsEntry("instanceState", "running");
         }
 
         @Test
@@ -125,12 +127,12 @@ class AwsHealthCheckServiceTest {
                 // then
                 @SuppressWarnings("unchecked")
                 Map<String, Object> s3Result = (Map<String, Object>) result.get("s3");
-                assertThat(s3Result.get("status")).isEqualTo("DOWN");
+                assertThat(s3Result).containsEntry("status", "DOWN");
                 assertThat(s3Result.get("message").toString()).contains("S3 Error: Access Denied");
 
                 @SuppressWarnings("unchecked")
                 Map<String, Object> ec2Result = (Map<String, Object>) result.get("ec2");
-                assertThat(ec2Result.get("status")).isEqualTo("DOWN");
+                assertThat(ec2Result).containsEntry("status", "DOWN");
                 assertThat(ec2Result.get("message").toString()).contains("EC2 Error: The instance ID does not exist");
         }
 
@@ -149,12 +151,12 @@ class AwsHealthCheckServiceTest {
                 // then
                 @SuppressWarnings("unchecked")
                 Map<String, Object> s3Result = (Map<String, Object>) result.get("s3");
-                assertThat(s3Result.get("status")).isEqualTo("DOWN");
+                assertThat(s3Result).containsEntry("status", "DOWN");
                 assertThat(s3Result.get("message").toString()).contains("Unexpected Error: Connection Timeout");
 
                 @SuppressWarnings("unchecked")
                 Map<String, Object> ec2Result = (Map<String, Object>) result.get("ec2");
-                assertThat(ec2Result.get("status")).isEqualTo("DOWN");
+                assertThat(ec2Result).containsEntry("status", "DOWN");
                 assertThat(ec2Result.get("message").toString()).contains("Unexpected Error: Internal Service Error");
         }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/service/AwsHealthCheckServiceTest.java
@@ -1,0 +1,160 @@
+package com.finance.finportfolio.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.InstanceState;
+import software.amazon.awssdk.services.ec2.model.InstanceStateName;
+import software.amazon.awssdk.services.ec2.model.Reservation;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@ExtendWith(MockitoExtension.class)
+class AwsHealthCheckServiceTest {
+
+        @Mock
+        private S3Client s3Client;
+
+        @Mock
+        private Ec2Client ec2Client;
+
+        @InjectMocks
+        private AwsHealthCheckService awsHealthCheckService;
+
+        private static final String TEST_BUCKET = "test-s3-bucket";
+        private static final String TEST_INSTANCE_ID = "i-0123456789abcdef0";
+
+        @BeforeEach
+        void setUp() {
+                // @Value 어노테이션으로 주입되는 필드 값 설정
+                ReflectionTestUtils.setField(awsHealthCheckService, "bucketName", TEST_BUCKET);
+                ReflectionTestUtils.setField(awsHealthCheckService, "instanceId", TEST_INSTANCE_ID);
+        }
+
+        @Test
+        @DisplayName("S3 및 EC2 상태가 정상일 때 전체 헬스체크 성공")
+        void checkAwsStatus_Success() {
+                // given
+                // 1. S3 Mocking: headBucket 호출 시 예외 없이 정상 종료되도록 설정
+                given(s3Client.headBucket(any(HeadBucketRequest.class)))
+                                .willReturn(HeadBucketResponse.builder().build());
+
+                // 2. EC2 Mocking: 구조화된 가짜 Response 생성
+                InstanceState instanceState = InstanceState.builder()
+                                .name(InstanceStateName.RUNNING)
+                                .build();
+
+                software.amazon.awssdk.services.ec2.model.Instance instance = software.amazon.awssdk.services.ec2.model.Instance
+                                .builder()
+                                .state(instanceState)
+                                .build();
+
+                Reservation reservation = Reservation.builder()
+                                .instances(Collections.singletonList(instance))
+                                .build();
+
+                DescribeInstancesResponse mockEc2Response = DescribeInstancesResponse.builder()
+                                .reservations(Collections.singletonList(reservation))
+                                .build();
+
+                given(ec2Client.describeInstances(any(DescribeInstancesRequest.class)))
+                                .willReturn(mockEc2Response);
+
+                // when
+                Map<String, Object> result = awsHealthCheckService.checkAwsStatus();
+
+                // then
+                assertThat(result).containsKey("s3").containsKey("ec2");
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> s3Result = (Map<String, Object>) result.get("s3");
+                assertThat(s3Result.get("status")).isEqualTo("UP");
+                assertThat(s3Result.get("message")).isEqualTo("S3 Bucket access successful.");
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> ec2Result = (Map<String, Object>) result.get("ec2");
+                assertThat(ec2Result.get("status")).isEqualTo("UP");
+                assertThat(ec2Result.get("instanceState")).isEqualTo("running");
+        }
+
+        @Test
+        @DisplayName("AWS 자격 증명 또는 권한 이슈로 SDK 예외 발생 시 DOWN 반환")
+        void checkAwsStatus_Failure_WhenAwsException() {
+                // given
+                // S3Exception Mocking
+                AwsErrorDetails s3ErrorDetails = AwsErrorDetails.builder()
+                                .errorMessage("Access Denied")
+                                .build();
+                S3Exception s3Exception = (S3Exception) S3Exception.builder()
+                                .awsErrorDetails(s3ErrorDetails)
+                                .build();
+                given(s3Client.headBucket(any(HeadBucketRequest.class))).willThrow(s3Exception);
+
+                // Ec2Exception Mocking
+                AwsErrorDetails ec2ErrorDetails = AwsErrorDetails.builder()
+                                .errorMessage("The instance ID does not exist")
+                                .build();
+                Ec2Exception ec2Exception = (Ec2Exception) Ec2Exception.builder()
+                                .awsErrorDetails(ec2ErrorDetails)
+                                .build();
+                given(ec2Client.describeInstances(any(DescribeInstancesRequest.class))).willThrow(ec2Exception);
+
+                // when
+                Map<String, Object> result = awsHealthCheckService.checkAwsStatus();
+
+                // then
+                @SuppressWarnings("unchecked")
+                Map<String, Object> s3Result = (Map<String, Object>) result.get("s3");
+                assertThat(s3Result.get("status")).isEqualTo("DOWN");
+                assertThat(s3Result.get("message").toString()).contains("S3 Error: Access Denied");
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> ec2Result = (Map<String, Object>) result.get("ec2");
+                assertThat(ec2Result.get("status")).isEqualTo("DOWN");
+                assertThat(ec2Result.get("message").toString()).contains("EC2 Error: The instance ID does not exist");
+        }
+
+        @Test
+        @DisplayName("예기치 않은 일반 런타임 예외 발생 시 DOWN 반환")
+        void checkAwsStatus_Failure_WhenUnexpectedException() {
+                // given
+                given(s3Client.headBucket(any(HeadBucketRequest.class)))
+                                .willThrow(new RuntimeException("Connection Timeout"));
+                given(ec2Client.describeInstances(any(DescribeInstancesRequest.class)))
+                                .willThrow(new RuntimeException("Internal Service Error"));
+
+                // when
+                Map<String, Object> result = awsHealthCheckService.checkAwsStatus();
+
+                // then
+                @SuppressWarnings("unchecked")
+                Map<String, Object> s3Result = (Map<String, Object>) result.get("s3");
+                assertThat(s3Result.get("status")).isEqualTo("DOWN");
+                assertThat(s3Result.get("message").toString()).contains("Unexpected Error: Connection Timeout");
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> ec2Result = (Map<String, Object>) result.get("ec2");
+                assertThat(ec2Result.get("status")).isEqualTo("DOWN");
+                assertThat(ec2Result.get("message").toString()).contains("Unexpected Error: Internal Service Error");
+        }
+}

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/AwsConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/AwsConfigTest.java
@@ -1,0 +1,46 @@
+package com.finance.finportfolio.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class AwsConfigTest {
+
+    // 스프링 컨텍스트의 생성, 빈 등록 및 프로퍼티 주입을 고속으로 테스트할 수 있는 유틸리티
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(AwsConfig.class);
+
+    @Test
+    @DisplayName("정상적인 프로퍼티가 제공되면 AWS 관련 Bean들이 정상적으로 등록된다")
+    void awsBeans_ShouldBeCreated_WhenPropertiesPresent() {
+        contextRunner
+                // 가상의 application.properties 환경변수 주입
+                .withPropertyValues(
+                        "spring.cloud.aws.region.static=ap-northeast-2",
+                        "spring.cloud.aws.credentials.access-key=test-access-key",
+                        "spring.cloud.aws.credentials.secret-key=test-secret-key")
+                .run(context -> {
+                    // StaticCredentialsProvider Bean 검증
+                    assertThat(context).hasSingleBean(StaticCredentialsProvider.class);
+                    StaticCredentialsProvider credentialsProvider = context.getBean(StaticCredentialsProvider.class);
+                    assertThat(credentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("test-access-key");
+                    assertThat(credentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo("test-secret-key");
+
+                    // S3Client Bean 검증
+                    assertThat(context).hasSingleBean(S3Client.class);
+                    S3Client s3Client = context.getBean(S3Client.class);
+                    assertThat(s3Client.serviceClientConfiguration().region()).isEqualTo(Region.AP_NORTHEAST_2);
+
+                    // Ec2Client Bean 검증
+                    assertThat(context).hasSingleBean(Ec2Client.class);
+                    Ec2Client ec2Client = context.getBean(Ec2Client.class);
+                    assertThat(ec2Client.serviceClientConfiguration().region()).isEqualTo(Region.AP_NORTHEAST_2);
+                });
+    }
+}

--- a/finance-portfolio-frontend/package-lock.json
+++ b/finance-portfolio-frontend/package-lock.json
@@ -4925,12 +4925,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {

--- a/finance-portfolio-frontend/src/api/adminApi.js
+++ b/finance-portfolio-frontend/src/api/adminApi.js
@@ -5,3 +5,9 @@ export const getDashboardSummary = async () => {
     const response = await axiosInstance.get('/admin/summary');
     return response.data; // AdminResponseDto 가 들어옴
 };
+
+// AWS 상태 체크
+export const getAwsStatus = async () => {
+    const response = await axiosInstance.get('/admin/awsHealth');
+    return response.data; // s3와 ec2 상태가 담긴 Map 이 들어옴
+};

--- a/finance-portfolio-frontend/src/pages/admins/AdminDashboard.jsx
+++ b/finance-portfolio-frontend/src/pages/admins/AdminDashboard.jsx
@@ -1,23 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getDashboardSummary } from '../../api/adminApi';
+import { getAwsStatus, getDashboardSummary } from '../../api/adminApi';
 import LoadingPage from '../common/LoadingPage';
 
 const AdminDashboard = () => {
     const navigate = useNavigate();
 
     const [dashboardData, setDashboardData] = useState(null);
+    const [awsStatus, setAwsStatus] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
     useEffect(() => {
-        getDashboardSummary()
-            .then((data) => {
-                setDashboardData(data);
+        Promise.all([getDashboardSummary(), getAwsStatus()])
+            .then(([dashboardRes, awsRes]) => {
+                setDashboardData(dashboardRes);
+                setAwsStatus(awsRes);
                 setLoading(false);
             })
             .catch((err) => {
-                console.error('대시보드 데이터 로드 실패:', err);
+                console.error('데이터 로드 실패:', err);
                 setError('데이터를 불러오는 중 오류가 발생했습니다.');
                 setLoading(false);
             });
@@ -27,6 +29,20 @@ const AdminDashboard = () => {
         { title: '총 게시글', count: dashboardData?.totalPostCount ?? 0, unit: '개', color: 'text-primary' },
         { title: 'S3 오브젝트', count: dashboardData?.totalImageCount ?? 0, unit: '개', color: 'text-warning' },
         { title: '총 회원 수', count: dashboardData?.totalMemberCount ?? 0, unit: '명', color: 'text-success' },
+        {
+            title: "AWS S3",
+            count: awsStatus?.s3?.status || "DOWN",
+            unit: awsStatus?.s3?.status === "UP" ? "정상" : "점검필요",
+            color: awsStatus?.s3?.status === "UP" ? "text-success" : "text-danger",
+            isStatus: true
+        },
+        {
+            title: "AWS EC2",
+            count: awsStatus?.ec2?.instanceState?.toUpperCase() || "UNKNOWN",
+            unit: awsStatus?.ec2?.status === "UP" ? "연결됨" : "연결안됨",
+            color: awsStatus?.ec2?.instanceState === "running" ? "text-info" : "text-warning",
+            isStatus: true
+        },
     ];
 
     if (loading) return <LoadingPage />;
@@ -52,8 +68,12 @@ const AdminDashboard = () => {
                             <div className="card-body">
                                 <h6 className="card-subtitle mb-2 text-muted fw-bold">{item.title}</h6>
                                 <div className={`h3 mb-0 fw-bold ${item.color}`}>
-                                    {/* 1,000 단위 콤마 포맷팅 */}
-                                    {Number(item.count).toLocaleString()}
+                                    {item.isStatus ? (
+                                        <span>{item.count}</span>
+                                    ) : (
+                                        // 1000 단위 콤마
+                                        <span>{Number(item.count).toLocaleString()}</span>
+                                    )}
                                     <small className="fs-6 text-muted ms-1">{item.unit}</small>
                                 </div>
                             </div>


### PR DESCRIPTION
## 개요
- AWS SDK를 도입하여 관리자 대시보드 내에 EC2 인스턴스 및 S3 버킷의 상태를 실시간으로 모니터링할 수 있는 기능을 구현.
- AWS 관련 설정 및 프로필 구조를 정비하여 설정 관리의 일관성 향상.

## 작업내용
- 🍃서버
  - **AWS SDK 의존성 추가**:
    - `build.gradle`: `software.amazon.awssdk:bom:2.44.12` 및 관련 라이브러리 추가.
  - **AWS 상태 확인 및 API**:
    - `AdminContrller`: `/awsHealth`엔드포인트 구현.
    - `AwsHeathCheckService`: s3 버킷, ec2 인스턴스 상태 추출 및 전달.
  - **AWS 클라이언트 빈 등록**
    - `AwsConfig`: `s3Client`, `ec2Client` 빈 등록.
  - `application.yml` 리펙토링:
    - 분리되어있던 `cloud.aws.region`를 각 profile의 `cloud.aws` 하위로 통합.
    - EC2 모니터링을 위한 `cloud.aws.ec2.intance-id` 속성 추가.

- ⚛️프론트
- **API 모듈 수정**:
  - `adminApi`: 관리자 전용 API 수신부 추가.
- **대시보드 페이지**:
  - `AdminDashboard`: 상태 데이터를 수신하여 결과 카드로 시각화하는 컴포넌트 구현.

## 결과
- **동적 관리**: 관리자 대시보드 페이지에서 AWS S3 및 EC2 인스턴스의 활성화 상태를 시각적으로 확인 가능.

<img width="1064" height="546" alt="image" src="https://github.com/user-attachments/assets/08cd3f84-c869-4977-a2ed-0ba1dc25ad5d" />

## 향후 고려사항
- **모니터링 주체 및 목적 재검토**
  - 현재 해당 애플리케이션 **서버 자체의 정상 여부를 동일한 서버 내부에서 전달**받고 있어 **모니터링 목적이 모호**함.
  - 향후 EC2의 **세부 메트릭**을 추가로 전달받도록 확장하거나, **외부 모니터링 도구**로 이관하는 방안 고려.
- **모니터링 대상 확장**
  - CloudFront 등 활용 중인 다른 AWS 자원에 대한 모니터링 포인트 추가 검토.
- 환경변수 관리 최적화
  -현재 `application.yml`에 EC2 인스턴스 ID가 하드코딩되어 있는 상태임. 당장의 보안 위험은 낮으나, 추후 환경변수 재정비 작업(#54) 진행 시 외부 환경변수로 분리 예정.

## 관련이슈
- #134
- #54