### PR TITLE
[Feat] 관리자 회원 관리 기능 및 대시보드 구현

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/controller/AdminController.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/admin/controller/AdminController.java
@@ -2,14 +2,26 @@ package com.finance.finportfolio.domain.admin.controller;
 
 import java.util.Map;
 
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
 import com.finance.finportfolio.domain.admin.service.AdminService;
 import com.finance.finportfolio.domain.admin.service.AwsHealthCheckService;
+import com.finance.finportfolio.domain.member.dto.MemberAdminResponseDto;
+import com.finance.finportfolio.domain.member.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +30,10 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
     private final AdminService adminService;
+    private final MemberService memberService;
     private final AwsHealthCheckService awsHealthCheckService;
 
     // 총 게시글, s3오브젝트, 총 회원 수 종합 전달
@@ -35,5 +49,34 @@ public class AdminController {
         Map<String, Object> response = awsHealthCheckService.checkAwsStatus();
 
         return ResponseEntity.ok(response);
+    }
+
+    // 전체 회원 조회(페이징)
+    @GetMapping("/members")
+    public ResponseEntity<Page<MemberAdminResponseDto>> getMemberList(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) @NonNull Pageable pageable) {
+
+        Page<MemberAdminResponseDto> members = memberService.getMembersForAdmin(pageable);
+        return ResponseEntity.ok(members);
+    }
+
+    // 회원 정지(Ban) 해제(Unban) 토글
+    @PatchMapping("/members/{memberId}/ban")
+    public ResponseEntity<Void> toggleBanStatus(
+            @NonNull @PathVariable("memberId") Long memberId,
+            @RequestParam("status") boolean shouldBan) {
+
+        log.info("사용자 계정 수동 잠금:{},{}", memberId, shouldBan);
+        memberService.updateBanStatus(memberId, shouldBan);
+        return ResponseEntity.noContent().build(); // 244 No Content 반환
+    }
+
+    // 회원 계정 임시 잠금 수동 해제
+    @PostMapping("/members/{memberId}/unlock")
+    public ResponseEntity<Void> unlockMember(
+            @NonNull @PathVariable("memberId") Long memberId) {
+
+        memberService.releaseMemberLock(memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/dto/MemberAdminResponseDto.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/dto/MemberAdminResponseDto.java
@@ -1,0 +1,29 @@
+package com.finance.finportfolio.domain.member.dto;
+
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.entity.Role;
+
+public record MemberAdminResponseDto(
+                Long id,
+                String loginId,
+                String nickname,
+                Role role,
+                boolean isBanned,
+                int loginFailCount) {
+
+        // 내부 생성자
+        private MemberAdminResponseDto(Member member) {
+                this(
+                                member.getId(),
+                                member.getLoginId(),
+                                member.getNickname(),
+                                member.getRole(),
+                                member.isBanned(),
+                                member.getLoginFailCount());
+        }
+
+        // 정적 팩토리 메서드
+        public static MemberAdminResponseDto from(Member member) {
+                return new MemberAdminResponseDto(member);
+        }
+}

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/entity/Member.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/entity/Member.java
@@ -38,6 +38,18 @@ public class Member {
     @Column(nullable = false)
     private Role role;
 
+    @Column(nullable = false)
+    private boolean isBanned = false;
+
+    // 관리자 제어
+    public void ban() {
+        this.isBanned = true;
+    }
+
+    public void unban() {
+        this.isBanned = false;
+    }
+
     // [무차별대입방어]
     @Column(nullable = false)
     private int loginFailCount = 0; // 로그인 실패 횟수
@@ -83,6 +95,7 @@ public class Member {
 
     public void loginSuccess() {
         // 성공시 초기화
+        // 관리자 수동 잠금 해제로 사용 가능
         this.loginFailCount = 0;
         this.lockedUntil = null;
     }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/repository/MemberRepository.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/repository/MemberRepository.java
@@ -3,7 +3,10 @@ package com.finance.finportfolio.domain.member.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import com.finance.finportfolio.domain.member.entity.Member;
@@ -15,4 +18,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByLoginId(String loginId);
 
     List<Member> findAllByNickname(String nickname);
+
+    @Override
+    @NonNull
+    Page<Member> findAll(@NonNull Pageable pageable);
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.finance.finportfolio.domain.member.service;
 
 import com.finance.finportfolio.domain.member.dto.LoginResultDto;
+import com.finance.finportfolio.domain.member.dto.MemberAdminResponseDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
@@ -13,7 +14,11 @@ import com.finance.finportfolio.global.error.exception.DuplicateResourceExceptio
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,6 +26,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -33,14 +39,21 @@ public class MemberService {
         private final JwtTokenProvider jwtTokenProvider;
         private final LoginAttemptService loginAttemptService;
 
-        @Transactional(readOnly = true)
-        public long getTotalMemberCount() {
-                return memberRepository.count();
+        // ID 기반 회원 조회
+        private Member findMemberById(@NonNull Long memberId) {
+                return memberRepository.findById(memberId)
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
         }
 
+        // LoginId 기반 회원 조회
         private Member findMemberByLoginId(String loginId) {
                 return memberRepository.findByLoginId(loginId)
                                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+        }
+
+        @Transactional(readOnly = true)
+        public long getTotalMemberCount() {
+                return memberRepository.count();
         }
 
         // ── 회원가입 ───────────────────────────────────────────────
@@ -174,5 +187,36 @@ public class MemberService {
                                 .refreshToken(newRefreshToken)
                                 .memberResponseDto(memberResponseDto)
                                 .build();
+        }
+
+        // [관리자] 전체 회원 조회(페이징)
+        @Transactional(readOnly = true)
+        public Page<MemberAdminResponseDto> getMembersForAdmin(@NonNull Pageable pageable) {
+                return memberRepository.findAll(pageable)
+                                .map(MemberAdminResponseDto::from);
+        }
+
+        // [관리자] 사용자 계정 수동 잠금, 잠금 해제
+        @Transactional
+        public void updateBanStatus(@NonNull Long memberId, boolean shouldBan) {
+
+                log.info("사용자 계정 수동 잠금:{},{}", memberId, shouldBan);
+                Member member = findMemberById(memberId);
+
+                if (shouldBan) {
+                        member.ban();
+                        // [보안 필수 조치] 사용자를 정지할 때 세션(Refresh Token)을 날려 즉시 튕겨냄
+                        refreshTokenRepository.deleteByMember(member);
+                } else {
+                        member.unban();
+                }
+        }
+
+        // [관리자] 사용자 임시 잠금(비밀번호 5회 오류) 수동 해제
+        @Transactional
+        public void releaseMemberLock(@NonNull Long memberId) {
+                Member member = findMemberById(memberId);
+
+                member.loginSuccess();
         }
 }

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/JwtAuthenticationFilter.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/global/security/filter/JwtAuthenticationFilter.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import java.io.IOException;
@@ -25,6 +27,7 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -36,14 +39,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             try {
                 if (jwtTokenProvider.validateToken(token)) {
+                    String loginId = jwtTokenProvider.getLoginId(token);
+
+                    // DB에서 실시간 정지 여부 검증
+                    boolean isBanned = memberRepository.findByLoginId(loginId)
+                            .map(Member::isBanned)
+                            .orElse(false);
+
+                    if (isBanned) {
+                        log.warn("정지된 사용자의 접근 차단: {}", loginId);
+                        sendErrorResponse(response, HttpServletResponse.SC_FORBIDDEN, "BANNED_USER");
+                        return; // 필터 체인 중단
+                    }
+
                     // 1. 인증 정보 설정 시 발생할 수 있는 예외 방지
                     setAuthentication(token);
                 }
             } catch (ExpiredJwtException e) {
                 log.warn("만료된 Access Token: {}", request.getRequestURI());
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.setContentType("application/json;charset=UTF-8");
-                response.getWriter().write("{\"error\": \"ACCESS_TOKEN_EXPIRED\"}");
+                sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "ACCESS_TOKEN_EXPIRED");
                 return; // 만료 시 여기서 종료
             } catch (Exception e) {
                 // 2. 그 외 모든 예외는 로그를 남기고 인증되지 않은 상태로 진행 (500 에러 방어)
@@ -81,5 +95,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+    }
+
+    // 예외 발생 시 일관된 JSON 응답을 전송하기 위한 헬퍼 메서드
+    private void sendErrorResponse(HttpServletResponse response, int status, String errorCode) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(String.format("{\"error\": \"%s\"}", errorCode));
     }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/controller/AdminControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/admin/controller/AdminControllerTest.java
@@ -1,11 +1,17 @@
 package com.finance.finportfolio.domain.admin.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,6 +22,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -27,6 +38,9 @@ import org.springframework.context.annotation.FilterType;
 import com.finance.finportfolio.domain.admin.dto.AdminResponseDto;
 import com.finance.finportfolio.domain.admin.service.AdminService;
 import com.finance.finportfolio.domain.admin.service.AwsHealthCheckService;
+import com.finance.finportfolio.domain.member.dto.MemberAdminResponseDto;
+import com.finance.finportfolio.domain.member.entity.Role;
+import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.security.filter.JwtAuthenticationFilter;
 
 @WebMvcTest(value = AdminController.class, excludeFilters = {
@@ -39,6 +53,9 @@ class AdminControllerTest {
 
     @MockitoBean
     private AdminService adminService;
+
+    @MockitoBean
+    private MemberService memberService;
 
     @MockitoBean
     private AwsHealthCheckService awsHealthCheckService;
@@ -132,6 +149,94 @@ class AdminControllerTest {
     void getAwsStatus_Unauthorized_WhenAnonymous() throws Exception {
         // when & then
         mockMvc.perform(get("/api/admin/awsHealth")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 전체 회원 페이징 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void getMemberList_Success_WhenAdmin() throws Exception {
+        // given
+        MemberAdminResponseDto memberDto = new MemberAdminResponseDto(1L, "user@test.com", "홍길동", Role.ADMIN, false, 0);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "id"));
+        Page<MemberAdminResponseDto> mockPage = new PageImpl<>(Collections.singletonList(memberDto), pageable, 1);
+
+        given(memberService.getMembersForAdmin(any(Pageable.class))).willReturn(mockPage);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/members")
+                .param("page", "0")
+                .param("size", "10")
+                .param("sort", "id,desc")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].loginId").value("user@test.com"))
+                .andExpect(jsonPath("$.content[0].nickname").value("홍길동"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("권한이 없는 일반 사용자가 전체 회원 조회 시 403 Forbidden 반환")
+    @WithMockUser(roles = "USER")
+    void getMemberList_Forbidden_WhenUser() throws Exception {
+        mockMvc.perform(get("/api/admin/members")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 회원 정지 상태 변경 토글 성공 및 204 No Content 반환")
+    @WithMockUser(roles = "ADMIN")
+    void toggleBanStatus_Success_WhenAdmin() throws Exception {
+        // given
+        Long memberId = 1L;
+        boolean shouldBan = true;
+        willDoNothing().given(memberService).updateBanStatus(eq(memberId), eq(shouldBan));
+
+        // when & then
+        mockMvc.perform(patch("/api/admin/members/{memberId}/ban", memberId)
+                .param("status", String.valueOf(shouldBan))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent()); // 204 No Content
+    }
+
+    @Test
+    @DisplayName("권한이 없는 일반 사용자가 회원 정지 토글 시 403 Forbidden 반환")
+    @WithMockUser(roles = "USER")
+    void toggleBanStatus_Forbidden_WhenUser() throws Exception {
+        mockMvc.perform(patch("/api/admin/members/1/ban")
+                .param("status", "true")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 회원 계정 잠금 수동 해제 성공 및 204 No Content 반환")
+    @WithMockUser(roles = "ADMIN")
+    void unlockMember_Success_WhenAdmin() throws Exception {
+        // given
+        Long memberId = 1L;
+        willDoNothing().given(memberService).releaseMemberLock(eq(memberId));
+
+        // when & then
+        mockMvc.perform(post("/api/admin/members/{memberId}/unlock", memberId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("권한이 없는 일반 사용자가 회원 임시 잠금 해제 요청 시 403 Forbidden 반환")
+    @WithMockUser(roles = "USER")
+    void unlockMember_Forbidden_WhenUser() throws Exception {
+        mockMvc.perform(post("/api/admin/members/1/unlock")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isForbidden());

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/MemberControllerTest.java
@@ -5,7 +5,9 @@ import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
+import com.finance.finportfolio.domain.member.entity.Member;
 import com.finance.finportfolio.domain.member.entity.Role;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
 import com.finance.finportfolio.global.security.filter.IpRateLimitFilter;
@@ -33,12 +35,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
 
 @WebMvcTest(MemberController.class)
 @Import({ SecurityConfig.class, TokenCookieManager.class })
@@ -52,6 +57,9 @@ class MemberControllerTest {
 
     @MockitoBean
     private MemberService memberService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
 
     @MockitoSpyBean
     private TokenCookieManager tokenCookieManager;
@@ -78,6 +86,10 @@ class MemberControllerTest {
             chain.doFilter(req, res);
             return null;
         }).when(ipRateLimitFilter).doFilter(any(), any(), any());
+
+        Member mockMember = mock(Member.class);
+        given(mockMember.isBanned()).willReturn(false);
+        given(memberRepository.findByLoginId(any())).willReturn(Optional.of(mockMember));
     }
 
     @Test

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/controller/TokenReissueControllerTest.java
@@ -3,6 +3,7 @@ package com.finance.finportfolio.domain.member.controller;
 import com.finance.finportfolio.domain.member.dto.LoginResultDto;
 import com.finance.finportfolio.domain.member.dto.MemberResponseDto;
 import com.finance.finportfolio.domain.member.entity.Role;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.global.config.SecurityConfig;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
@@ -43,6 +44,9 @@ class TokenReissueControllerTest {
 
         @MockitoBean
         private MemberService memberService;
+
+        @MockitoBean
+        private MemberRepository memberRepository;
 
         @MockitoSpyBean
         private TokenCookieManager tokenCookieManager;

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/domain/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.finance.finportfolio.domain.member.service;
 
 import com.finance.finportfolio.domain.member.dto.LoginResultDto;
+import com.finance.finportfolio.domain.member.dto.MemberAdminResponseDto;
 import com.finance.finportfolio.domain.member.dto.MemberJoinRequestDto;
 import com.finance.finportfolio.domain.member.dto.MemberLoginRequestDto;
 import com.finance.finportfolio.domain.member.entity.Member;
@@ -302,5 +303,88 @@ class MemberServiceTest {
                 assertThatThrownBy(() -> memberService.reissue("refreshToken"))
                                 .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("로그인 상태가 아닙니다.");
+        }
+
+        // ── [관리자] 회원 관리 기능 ─────────────────────────────────────────
+
+        @Test
+        @DisplayName("전체 회원 페이징 조회 성공 - 엔티티가 DTO로 정확히 변환된다")
+        void getMembersForAdmin_Success() {
+                // given
+                org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(0,
+                                10);
+                Member member = createMember("testId");
+                org.springframework.data.domain.Page<Member> mockPage = new org.springframework.data.domain.PageImpl<>(
+                                List.of(member), pageable, 1);
+
+                given(memberRepository.findAll(pageable)).willReturn(mockPage);
+
+                // when
+                org.springframework.data.domain.Page<MemberAdminResponseDto> result = memberService
+                                .getMembersForAdmin(pageable);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+
+                MemberAdminResponseDto dto = result.getContent().get(0);
+                assertThat(dto.id()).isEqualTo(member.getId());
+                assertThat(dto.loginId()).isEqualTo(member.getLoginId());
+                assertThat(dto.nickname()).isEqualTo(member.getNickname());
+                assertThat(dto.role()).isEqualTo(member.getRole());
+
+                verify(memberRepository, times(1)).findAll(pageable);
+        }
+
+        @Test
+        @DisplayName("사용자 정지 성공 - 계정이 정지 상태로 변경되고 Refresh Token이 즉시 삭제된다")
+        void updateBanStatus_Ban_Success() {
+                // given
+                Long memberId = 1L;
+                Member member = spy(createMember("testId")); // 내부 상태 변경(ban) 검증을 위해 spy 사용
+
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+                // when
+                memberService.updateBanStatus(memberId, true);
+
+                // then
+                verify(member, times(1)).ban();
+                verify(refreshTokenRepository, times(1)).deleteByMember(member);
+                verify(member, never()).unban();
+        }
+
+        @Test
+        @DisplayName("사용자 정지 해제 성공 - 계정이 활성화 상태로 변경되고 토큰 삭제는 호출되지 않는다")
+        void updateBanStatus_Unban_Success() {
+                // given
+                Long memberId = 1L;
+                Member member = spy(createMember("testId"));
+
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+                // when
+                memberService.updateBanStatus(memberId, false);
+
+                // then
+                verify(member, times(1)).unban();
+                verify(member, never()).ban();
+                verify(refreshTokenRepository, never()).deleteByMember(any());
+        }
+
+        @Test
+        @DisplayName("사용자 임시 잠금 수동 해제 성공 - 로그인 성공 처리 로직이 실행된다")
+        void releaseMemberLock_Success() {
+                // given
+                Long memberId = 1L;
+                Member member = spy(createMember("testId"));
+
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+                // when
+                memberService.releaseMemberLock(memberId);
+
+                // then
+                verify(member, times(1)).loginSuccess(); // 실패 카운트 초기화 및 잠금 해제 검증
         }
 }

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/config/SecurityConfigTest.java
@@ -6,6 +6,8 @@ import com.finance.finportfolio.domain.category.dto.CategoryRequestDto;
 import com.finance.finportfolio.domain.category.service.CategoryService;
 import com.finance.finportfolio.domain.member.controller.MemberController;
 import com.finance.finportfolio.domain.member.controller.TokenCookieManager;
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
 import com.finance.finportfolio.domain.member.service.MemberService;
 import com.finance.finportfolio.domain.post.controller.PostController;
 import com.finance.finportfolio.domain.post.dto.PostResponseDto;
@@ -14,6 +16,7 @@ import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,12 +35,14 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * SecurityConfig의 authenticationEntryPoint 동작 검증 테스트
@@ -66,6 +71,9 @@ class SecurityConfigTest {
         private MemberService memberService;
 
         @MockitoBean
+        private MemberRepository memberRepository;
+
+        @MockitoBean
         private CategoryService categoryService;
 
         @MockitoBean
@@ -79,6 +87,14 @@ class SecurityConfigTest {
 
         @Autowired
         private ObjectMapper objectMapper;
+
+        // JwtAuthenticationFilter 내부 DB 실시간 정지 여부 조회를 위한 공통 Mock 설정
+        @BeforeEach
+        void setUp() {
+                Member mockMember = mock(Member.class);
+                given(mockMember.isBanned()).willReturn(false); // 정지되지 않은 정상 사용자로 세팅
+                given(memberRepository.findByLoginId(any())).willReturn(Optional.of(mockMember));
+        }
 
         // CloudFrontHeaderFilter
         @Test

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/global/security/filter/JwtAuthenticationFilterTest.java
@@ -14,6 +14,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
 import com.finance.finportfolio.global.security.jwt.JwtTokenProvider;
 
 import java.io.IOException;
@@ -30,6 +31,9 @@ class JwtAuthenticationFilterTest {
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     @Mock
     private FilterChain filterChain;
@@ -151,5 +155,67 @@ class JwtAuthenticationFilterTest {
         assertThat(SecurityContextHolder.getContext().getAuthentication()
                 .getAuthorities().iterator().next().getAuthority())
                 .isEqualTo("ROLE_ADMIN");
+    }
+
+    // ── 실시간 정지 여부 검증 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("정지된 사용자의 토큰이면 403과 BANNED_USER 에러를 반환하고 필터 체인을 중단한다")
+    void doFilter_BannedUser_Returns403AndAborts() throws ServletException, IOException {
+        // given
+        request.addHeader("Authorization", "Bearer bannedToken");
+
+        given(jwtTokenProvider.validateToken("bannedToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("bannedToken")).willReturn("bannedUser");
+
+        // DB 조회 시 정지된 사용자(isBanned = true) 상태 모킹
+        com.finance.finportfolio.domain.member.entity.Member mockMember = mock(
+                com.finance.finportfolio.domain.member.entity.Member.class);
+        given(mockMember.isBanned()).willReturn(true);
+        given(memberRepository.findByLoginId("bannedUser")).willReturn(java.util.Optional.of(mockMember));
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        // 403 Forbidden 반환 확인
+        assertThat(response.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN);
+
+        // 응답 바디에 BANNED_USER 포함 확인
+        assertThat(response.getContentAsString()).contains("BANNED_USER");
+
+        // SecurityContext에 인증 정보가 저장되지 않아야 함
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+
+        // 필터 체인이 중단되어 다음 필터가 호출되지 않아야 함
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("정지되지 않은 정상 사용자의 토큰이면 정상적으로 인증 정보가 저장되고 다음 필터로 진행한다")
+    void doFilter_NotBannedUser_SetsAuthenticationAndPassesThrough() throws ServletException, IOException {
+        // given
+        request.addHeader("Authorization", "Bearer normalToken");
+
+        given(jwtTokenProvider.validateToken("normalToken")).willReturn(true);
+        given(jwtTokenProvider.getLoginId("normalToken")).willReturn("normalUser");
+        given(jwtTokenProvider.getRole("normalToken")).willReturn("ROLE_USER");
+
+        // DB 조회 시 정상 사용자(isBanned = false) 상태 모킹
+        com.finance.finportfolio.domain.member.entity.Member mockMember = mock(
+                com.finance.finportfolio.domain.member.entity.Member.class);
+        given(mockMember.isBanned()).willReturn(false);
+        given(memberRepository.findByLoginId("normalUser")).willReturn(java.util.Optional.of(mockMember));
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        // SecurityContext 인증 저장 확인
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("normalUser");
+
+        // 다음 필터로 정상 진행 확인
+        verify(filterChain, times(1)).doFilter(request, response);
     }
 }

--- a/finance-portfolio-frontend/src/App.jsx
+++ b/finance-portfolio-frontend/src/App.jsx
@@ -19,6 +19,7 @@ import ErrorPage from './pages/common/ErrorPage';
 import LoadingPage from './pages/common/LoadingPage';
 import AdminDashboard from './pages/admins/AdminDashboard';
 import AdminCategoryManager from './pages/admins/AdminCategoryManager';
+import AdminMemberManager from './pages/admins/AdminMemberManager';
 
 
 function App() {
@@ -65,6 +66,7 @@ function App() {
           <Route element={<AdminLayout />}>
             <Route path="/admin/dashboard" element={<AdminDashboard />} />
             <Route path="/admin/categoryManager" element={<AdminCategoryManager />} />
+            <Route path="/admin/memberManager" element={<AdminMemberManager />} />
           </Route>
         </Route>
 

--- a/finance-portfolio-frontend/src/api/adminApi.js
+++ b/finance-portfolio-frontend/src/api/adminApi.js
@@ -11,3 +11,25 @@ export const getAwsStatus = async () => {
     const response = await axiosInstance.get('/admin/awsHealth');
     return response.data; // s3와 ec2 상태가 담긴 Map 이 들어옴
 };
+
+// 전체 회원 페이징 조회
+export const getAdminMembers = async (page = 0, size = 10) => {
+    const response = await axiosInstance.get('/admin/members', {
+        params: { page, size }
+    });
+    return response.data; // Page<MemberAdminResponseDto>가 들어옴
+};
+
+// 회원 정지 및 해제 처리
+export const toggleMemberBan = async (memberId, shouldBan) => {
+    const response = await axiosInstance.patch(`/admin/members/${memberId}/ban`, null, {
+        params: { status: shouldBan }
+    });
+    return response.status; // 244 No Content 가 들어옴
+};
+
+// 회원 임시 잠금 수동 해제
+export const unlockMemberAccount = async (memberId) => {
+    const response = await axiosInstance.post(`/admin/members/${memberId}/unlock`);
+    return response.status; // 244 No Content 가 들어옴
+};

--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -63,6 +63,9 @@ const isTokenExpiredError = (error) =>
     error.response?.data?.error === 'ACCESS_TOKEN_EXPIRED' &&
     !error.config._retry;
 
+// 알림 중복 방지 전역 상태 제어 변수
+let isBannedAlertShowing = false;
+
 // 전역 에러 처리(각 코드에 맞게)
 const handleGlobalError = (error) => {
     const { status, data, headers } = error.response || {};
@@ -74,9 +77,28 @@ const handleGlobalError = (error) => {
     if (error.config?.url?.includes('/image/upload')) return;
 
     switch (status) {
-        case 403:
-            alert("권한이 없습니다.");
+        case 403: {
+            // 정지 유저 분기 처리
+            if (data?.error === 'BANNED_USER') {
+                if (!isBannedAlertShowing) {
+                    isBannedAlertShowing = true;
+                    alert("해당 계정은 정지되었습니다. 로그인 페이지로 이동합니다.");
+
+                    // 토큰 파기 및 강제 페이지 리다이렉트
+                    authStore.clearToken();
+                    history.push('/login');
+                }
+                break;
+            }
+
+            // 일반 권한 부족
+            if (!isBannedAlertShowing) {
+                isBannedAlertShowing = true;
+                alert("권한이 없습니다.");
+                setTimeout(() => { isBannedAlertShowing = false; }, 1000);
+            }
             break;
+        }
         case 429: {
             const retryAfter = Number.parseInt(headers?.['retry-after'] || '60', 10);
             history.push('/error?status=429', {

--- a/finance-portfolio-frontend/src/components/layout/AdminNavbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/AdminNavbar.jsx
@@ -30,6 +30,18 @@ const AdminNavbar = () => {
                             카테고리 관리
                         </NavLink>
                     </li>
+                    {/* 회원 관리 */}
+                    <li className="nav-item">
+                        <NavLink
+                            to="/admin/memberManager"
+                            end
+                            className={({ isActive }) =>
+                                `nav-link btn-sm border-0 ${isActive ? 'bg-theme-custom' : 'card-theme-custom'}`
+                            }
+                        >
+                            회원 관리
+                        </NavLink>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/finance-portfolio-frontend/src/components/layout/Navbar.jsx
+++ b/finance-portfolio-frontend/src/components/layout/Navbar.jsx
@@ -29,14 +29,8 @@ const Navbar = () => {
                 alert(errorMessage);
             }
         } finally {
-            // 로그아웃은 에러가 나도 클라이언트 상태는 정리
+            // 토큰 파기 및 강제 페이지 리다이렉트
             authStore.clearToken();
-
-            // 비보안 플래그 쿠키들 직접 제거 (클라이언트 사이드에서도 정리)
-            Cookies.remove('userNickname');
-            Cookies.remove('userRole');
-            Cookies.remove('isLoggedIn');
-
             navigate('/', { replace: true });
         }
     };

--- a/finance-portfolio-frontend/src/pages/admins/AdminCategoryManager.jsx
+++ b/finance-portfolio-frontend/src/pages/admins/AdminCategoryManager.jsx
@@ -1,33 +1,41 @@
 import React, { useState, useEffect } from 'react';
-// 작성하신 API 함수들을 import 한다고 가정합니다.
 import { getCategories, createCategory, updateCategory, deleteCategory } from '../../api/categoryApi';
+import LoadingPage from '../common/LoadingPage';
 
 const AdminCategoryManager = () => {
     const [categories, setCategories] = useState([]);
-    const [isLoading, setIsLoading] = useState(false);
+    const [isInitialLoading, setIsInitialLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false); // 버튼 중복 클릭 방지
 
     // 입력 폼 상태
     const [formData, setFormData] = useState({ name: '', sortOrder: 0 });
     const [editingId, setEditingId] = useState(null);
 
     // 카테고리 목록 GET
-    const fetchCategories = async () => {
-        setIsLoading(true);
+    const fetchCategories = async (showGlobalLoading = false) => {
+        if (showGlobalLoading) setIsInitialLoading(true);
         try {
             const data = await getCategories();
-            // order 순으로 정렬하여 표시
-            const sortedData = data.sort((a, b) => a.sortOrder - b.sortOrder);
+            // order 순으로 정렬하여 복사
+            const sortedData = [...data].sort((a, b) => a.sortOrder - b.sortOrder);
             setCategories(sortedData);
         } catch (error) {
             console.error("카테고리 로드 실패:", error);
             alert("카테고리 목록을 불러오는 데 실패했습니다.");
         } finally {
-            setIsLoading(false);
+            setIsInitialLoading(false);
         }
     };
 
+    // 메모리 누수 방지 및 초기 로드 트랙킹
     useEffect(() => {
-        fetchCategories();
+        let isMounted = true;
+        if (isMounted) {
+            fetchCategories(true);
+        }
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     // 입력 핸들러
@@ -39,24 +47,31 @@ const AdminCategoryManager = () => {
         }));
     };
 
+    // 폼 초기화
+    const handleResetForm = () => {
+        setFormData({ name: '', sortOrder: 0 });
+        setEditingId(null);
+    };
+
     // 생성 및 수정 처리
     const handleSubmit = async (e) => {
         e.preventDefault();
-        if (!formData.name.trim()) return;
+        if (!formData.name.trim() || isSubmitting) return;
 
+        setIsSubmitting(true);
         try {
             if (editingId) {
                 await updateCategory(editingId, formData);
             } else {
                 await createCategory(formData);
             }
-            // 폼 초기화 및 새로고침
-            setFormData({ name: '', sortOrder: 0 });
-            setEditingId(null);
-            fetchCategories();
+            handleResetForm();
+            await fetchCategories(); // 최신 목록 갱신
         } catch (error) {
             console.error("저장 실패:", error);
             alert("저장에 실패했습니다.");
+        } finally {
+            setIsSubmitting(false);
         }
     };
 
@@ -66,40 +81,25 @@ const AdminCategoryManager = () => {
         setFormData({ name: category.name, sortOrder: category.sortOrder });
     };
 
+
     // 삭제 처리
     const handleDelete = async (id) => {
         if (!globalThis.confirm("정말 삭제하시겠습니까?")) return;
 
         try {
             await deleteCategory(id);
-            fetchCategories();
+            alert("삭제되었습니다.");
+            await fetchCategories();
         } catch (error) {
             console.error("삭제 실패:", error);
             alert("삭제에 실패했습니다.");
         }
     };
 
-    // 카테고리 목록 렌더
+    if (isInitialLoading) return <LoadingPage />;
+
     const renderContent = () => {
-        // 1. 로딩 중인 경우
-        if (isLoading) {
-            return (
-                <tr>
-                    <td colSpan="3" className="text-center py-4">로딩 중...</td>
-                </tr>
-            );
-        }
 
-        // 2. 데이터가 없는 경우
-        if (categories.length === 0) {
-            return (
-                <tr>
-                    <td colSpan="3" className="text-center py-4">등록된 카테고리가 없습니다.</td>
-                </tr>
-            );
-        }
-
-        // 3. 정상 데이터 출력
         return categories.map((category) => (
             <tr key={category.id}>
                 <td>{category.sortOrder}</td>
@@ -108,12 +108,14 @@ const AdminCategoryManager = () => {
                     <button
                         className="btn btn-outline-secondary btn-sm me-2"
                         onClick={() => handleEdit(category)}
+                        disabled={isSubmitting}
                     >
                         수정
                     </button>
                     <button
                         className="btn btn-outline-danger btn-sm"
                         onClick={() => handleDelete(category.id)}
+                        disabled={isSubmitting}
                     >
                         삭제
                     </button>
@@ -143,6 +145,7 @@ const AdminCategoryManager = () => {
                                 onChange={handleInputChange}
                                 placeholder="예: 공지사항"
                                 required
+                                disabled={isSubmitting}
                             />
                         </div>
                         <div className="col-md-3">
@@ -155,17 +158,27 @@ const AdminCategoryManager = () => {
                                 value={formData.sortOrder}
                                 onChange={handleInputChange}
                                 required
+                                disabled={isSubmitting}
                             />
                         </div>
                         <div className="col-md-4">
-                            <button type="submit" className={`btn ${editingId ? 'btn-warning' : 'btn-primary'} w-100`}>
-                                {editingId ? '수정 완료' : '새 카테고리 추가'}
+                            <button type="submit" className={`btn ${editingId ? 'btn-warning' : 'btn-primary'} w-100`} disabled={isSubmitting}>
+                                {(() => {
+                                    if (isSubmitting) {
+                                        return '처리 중...';
+                                    } else if (editingId) {
+                                        return '수정 완료';
+                                    } else {
+                                        return '새 카테고리 추가';
+                                    }
+                                })()}
                             </button>
                             {editingId && (
                                 <button
                                     type="button"
                                     className="btn btn-link btn-sm w-100 mt-1"
-                                    onClick={() => { setEditingId(null); setFormData({ name: '', sortOrder: 0 }); }}
+                                    onClick={handleResetForm}
+                                    disabled={isSubmitting}
                                 >
                                     취소
                                 </button>

--- a/finance-portfolio-frontend/src/pages/admins/AdminMemberManager.jsx
+++ b/finance-portfolio-frontend/src/pages/admins/AdminMemberManager.jsx
@@ -1,0 +1,197 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAdminMembers, toggleMemberBan, unlockMemberAccount } from '../../api/adminApi';
+import LoadingPage from '../common/LoadingPage';
+
+const AdminMemberManager = () => {
+    const navigate = useNavigate();
+    const [memberPage, setMemberPage] = useState({ content: [], totalPages: 0, number: 0 });
+    const [isInitialLoading, setIsInitialLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false); // 가드 상태 일치
+    const [currentPage, setCurrentPage] = useState(0);
+
+    // 회원 목록 GET
+    const fetchMembers = useCallback(async (page, showGlobalLoading = false) => {
+        if (showGlobalLoading) setIsInitialLoading(true);
+        try {
+            const data = await getAdminMembers(page, 10);
+            setMemberPage(data);
+        } catch (error) {
+            console.error("회원 목록 로드 실패:", error);
+            alert("회원 목록을 불러오는 데 실패했습니다.");
+            navigate('/login');
+        } finally {
+            setIsInitialLoading(false);
+        }
+    }, []);
+
+    // 메모리 누수 방지 및 초기 로드 트랙킹
+    useEffect(() => {
+        let isMounted = true;
+        if (isMounted) {
+            fetchMembers(currentPage, true);
+        }
+        return () => {
+            isMounted = false;
+        };
+    }, [currentPage, fetchMembers]);
+
+    // 회원 정지 / 해제 처리
+    const handleBanToggle = async (memberId, currentBanStatus) => {
+        if (isSubmitting) return;
+        const actionText = currentBanStatus ? "해제" : "정지";
+        if (!globalThis.confirm(`해당 회원을 정말 ${actionText}하시겠습니까?`)) return;
+
+        setIsSubmitting(true);
+        try {
+            await toggleMemberBan(memberId, !currentBanStatus);
+            alert(`${actionText}되었습니다.`);
+            await fetchMembers(currentPage);
+        } catch (error) {
+            console.error("정지 상태 변경 실패:", error);
+            alert("상태 변경에 실패했습니다.");
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    // 잠금 계정 수동 해제 처리
+    const handleUnlock = async (memberId) => {
+        if (isSubmitting) return;
+        if (!globalThis.confirm("이 계정의 로그인 실패 횟수를 초기화하고 잠금을 해제하시겠습니까?")) return;
+
+        setIsSubmitting(true);
+        try {
+            await unlockMemberAccount(memberId);
+            alert("계정 잠금이 해제되었습니다.");
+            await fetchMembers(currentPage);
+        } catch (error) {
+            console.error("잠금 해제 실패:", error);
+            alert("잠금 해제에 실패했습니다.");
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    // 공통 가드 조건 적용
+    if (isInitialLoading) return <LoadingPage />;
+    if (!memberPage?.content) return null;
+
+    const renderContent = () => {
+        if (memberPage.content.length === 0) {
+            return (
+                <tr>
+                    <td colSpan="6" className="text-center py-4">가입된 회원이 없습니다.</td>
+                </tr>
+            );
+        }
+
+        return memberPage.content.map((member) => (
+            <tr key={member.id} className={member.isBanned ? 'table-light text-muted' : ''}>
+                <td>{member.id}</td>
+                <td>{member.loginId}</td>
+                <td><strong>{member.nickname}</strong></td>
+                <td>
+                    <span className={`badge ${member.role === 'ADMIN' ? 'bg-danger' : 'bg-primary'}`}>
+                        {member.role}
+                    </span>
+                </td>
+                <td>
+                    {member.loginFailCount >= 5 ? (
+                        <div className="d-flex align-items-center gap-2">
+                            <span className="badge bg-warning text-dark">잠김 ({member.loginFailCount}회)</span>
+                            <button
+                                className="btn btn-sm btn-outline-warning"
+                                onClick={() => handleUnlock(member.id)}
+                                disabled={isSubmitting}
+                            >
+                                해제
+                            </button>
+                        </div>
+                    ) : (
+                        <span className="text-secondary">{member.loginFailCount} / 5</span>
+                    )}
+                </td>
+                <td className="text-center">
+                    {/* [변경 사항] ADMIN 권한인 경우 정지/해제 제어 버튼 미출력 */}
+                    {member.role === 'ADMIN' ? (
+                        <span className="text-muted small">-</span>
+                    ) : (
+                        <button
+                            className={`btn btn-sm ${member.isBanned ? 'btn-outline-success' : 'btn-outline-danger'}`}
+                            onClick={() => handleBanToggle(member.id, member.isBanned)}
+                            disabled={isSubmitting}
+                        >
+                            {member.isBanned ? '정지 해제' : '회원 정지'}
+                        </button>
+                    )}
+                </td>
+            </tr>
+        ));
+    };
+
+    return (
+        <div className="container py-4">
+            <div className="d-flex justify-content-between align-items-center mb-4">
+                <h2 className="mb-0">회원 관리</h2>
+            </div>
+
+            <div className="table-responsive card mb-4">
+                <table className="table table-hover align-middle mb-0">
+                    <thead className="table-light">
+                        <tr>
+                            <th style={{ width: '10%' }}>No</th>
+                            <th style={{ width: '25%' }}>아이디</th>
+                            <th style={{ width: '25%' }}>닉네임</th>
+                            <th style={{ width: '15%' }}>권한</th>
+                            <th style={{ width: '15%' }}>로그인 실패</th>
+                            <th style={{ width: '10%' }} className="text-center">제어</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {renderContent()}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* 페이지네이션 인터페이스 */}
+            {memberPage.totalPages > 1 && (
+                <nav className="d-flex justify-content-center mt-4">
+                    <ul className="pagination shadow-sm">
+                        <li className={`page-item ${currentPage === 0 ? 'disabled' : ''}`}>
+                            <button
+                                className="page-link"
+                                onClick={() => setCurrentPage(prev => Math.max(0, prev - 1))}
+                                disabled={isSubmitting}
+                            >
+                                이전
+                            </button>
+                        </li>
+                        {[...new Array(memberPage.totalPages).keys()].map((pageIndex) => (
+                            <li key={pageIndex} className={`page-item ${currentPage === pageIndex ? 'active' : ''}`}>
+                                <button
+                                    className="page-link"
+                                    onClick={() => setCurrentPage(pageIndex)}
+                                    disabled={isSubmitting}
+                                >
+                                    {pageIndex + 1}
+                                </button>
+                            </li>
+                        ))}
+                        <li className={`page-item ${currentPage === memberPage.totalPages - 1 ? 'disabled' : ''}`}>
+                            <button
+                                className="page-link"
+                                onClick={() => setCurrentPage(prev => Math.min(memberPage.totalPages - 1, prev + 1))}
+                                disabled={isSubmitting}
+                            >
+                                다음
+                            </button>
+                        </li>
+                    </ul>
+                </nav>
+            )}
+        </div>
+    );
+};
+
+export default AdminMemberManager;

--- a/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostDetail.jsx
@@ -39,6 +39,7 @@ const PostDetail = () => {
                 navigate('/posts');
             } catch (error) {
                 console.error("삭제 중 오류 발생:", error);
+                alert("삭제에 실패했습니다.");
             }
         }
     };

--- a/finance-portfolio-frontend/src/store/authStore.js
+++ b/finance-portfolio-frontend/src/store/authStore.js
@@ -19,6 +19,7 @@ const authStore = {
 
     clearToken: () => {
         accessToken = null;
+        Cookies.remove('userNickname');
         Cookies.remove('isLoggedIn');
         Cookies.remove('userRole');
     },


### PR DESCRIPTION
## 개요
- **목적**: 대시보드 통계 연동 후속 작업으로, 세부 회원 제어 및 인프라(AWS) 가용성 실시간 모니터링 기능 구축
- **개선사항**:
  - **회원 관리 대시보드 UI 구현**
  - **회원정지 기능 추가**: 백엔드에서는 메서드 보안 및 JWT 검증 단계에서의 실시간 정지 유저 차단 로직 구현.
  - **안정성, UX 개선**: 비동기 요청 최적화 및 에러 인터셉터 연동
  - 결과적으로 비정상 유저에 대한 동적 제어권을 확보하고, 관리자 기능 확장을 위한 토대를 마련.

## 작업내용
- 🍃서버
  - `AdminController`
    - **인가 보안 강화**: `@PreAuthorize("hasRole('ADMIN')")` 적용.
    - **회원 관리 API 구현**: 전체 조회(페이징), 정지/해제 토글, 계정 잠금 수동 해제.
  - `Member` 엔티티
    - `isBanned` 필드 및 상태 제어 메서드(`ban`, `unban`) 추가.
  - `MemberRepository`
    - 회원 관리를 위한 페이징 조회(`findAll`) 구현.
  - `MemberAdminResponseDto`
    - **대시보드 전달용 필드 구성**: `id, loginId, nickname, role, isBanned, loginFailCount`.
  - `MemberService`
    - **리팩토링**: 중복된 `id`m `loginId` 기반 조회 로직을 공통 메서드로 분리.
    - 회원 관리 비즈니스 로직(페이징 조회, 정지 토글, 잠금 해제) 구현.
  - `JwtAuthenticationFilter`
    - 토큰 검증 시 DB 조회를 통한 실시간 회원 정지 여부 확인 및 차단 로직 추가.
- ⚛️프론트
  - **라우팅 및 UI**
    - `App.jsx`, `AdminNavbar.jsx`: 회원 관리(AdminMemberManager) 라우트 및 링크 등록.
  - **API 및 통신**
    - `adminApi`: 회원 관리 API 송수신 함수 추가.
    - `axios` 인터셉터: `403 BANNED_USER` 에러 발생 시 알림 출력 및 토큰 파기, 리다이렉트 처리.
    - `AdminCategoryManager` (리팩토링)
      - **UX 개선**: 데이터 조회 시 전체 로딩 대신 기존 데이터 유지 후 교체 방식 적용.
      - **안정성 확보**: isMounted로 메모리 누수 방지, isSubmitting으로 버튼 중복 클릭 차단.
    - `AdminMemberManager` (신규)
      - 회원 관리 페이지 구현: 페이징 목록 조회, 정지/해제 토글, 계정 잠금 해제 기능 연동.
  -  **추가 리팩토링**: `Navbar.jsx`: 불필요한 중복 쿠키 삭제 로직 제거.
  
## 결과
- **보안강화**: 관리자 컨트롤러 파트의 `@PreAuthorize` 검증 및 실시간 JWT 차단 필터 도입을 통해 정지 사용자의 API 접근을 원천 차단.
- **동적관리**: 회원 관리가 가능한 페이징 API와 정지/잠금 해제 등의 상태 제어 기능을 어드민 UI와 유기적으로 연동.
- **사용자경험(UX)**:
  - `403 BANNED_USER` 전역 에러 핸들링을 통해 정지 유저의 세션 파기 및 리다이렉트 처리를 자동화하여 계정 정지 여부를 로그인 시점에 alert으로 확인가능.
  - 프론트엔드 컴포넌트의 중복 요청 차단 및 백그라운드 데이터 갱신 로직을 반영하여 불필요한 리소스 낭비를 막고 화면 깜빡임 방지.
 
<img width="567" height="327" alt="image" src="https://github.com/user-attachments/assets/51ffc844-8e6c-45e2-93ca-e5754c7df8ec" />
  
## 추가 고려사항
- **현황**: 매 api 호출 시 `JwtAuthenticationFilter`에서 밴 여부를 확인하기 위해 `findByLoginId`를 통한 전체 DB 조회가 발생.
- **문제상황**: 현 프로젝트 DB 규모 상 비효율이 크게 발생하지 않지만 트래픽이 커지는 실제 운영 환경에서는 상당한 비효율이 발생하는 구조.
- **개선방안1**: 로컬 캐시를 통해 DB 조회 비효율을 제거.
  - 장점: 인프라 비용 없음, 조회 속도 최상.
  - 단점: 캐시 만료 전까지 지연 발생.
  - 소규모 프로젝트에 유리
- **개선방안2**: `Redis` 글로벌 캐시를 통해 DB 조회 비효율을 제거.
  - 장점: 정확성(실시간성)이 100%에 가까움.
  - 단점: AWS ElastiCache등 기본 비용 발생.
  - 대규모 트래픽 처리에 유리.

## 관련이슈
- Closes #134