### PR TITLE
[Refactor] ⚛️reissue 무한루프 요청 방지를 위한 Axios 인스턴스 분리

### DIFF
--- a/finance-portfolio-frontend/src/api/axios.js
+++ b/finance-portfolio-frontend/src/api/axios.js
@@ -2,7 +2,17 @@ import axios from 'axios';
 import authStore from '../store/authStore';
 import { history } from '../utils/history';
 
-// 1. axios 인스턴스 생성
+// 순수 axios 인스턴스 (인터셉터X, 현재 토큰 재발급만 담당)
+const pureApi = axios.create({
+    baseURL: '/api',
+    timeout: 5000,
+    withCredentials: true,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+// 메인 애플리케이션용 axios 인스턴스
 const axiosInstance = axios.create({
     // 환경 변수에서 기본 주소를 가져옵니다.
     baseURL: '/api',
@@ -15,27 +25,13 @@ const axiosInstance = axios.create({
     },
 });
 
-// ── 요청 인터셉터(REQUEST): Access Token 자동 첨부 ──────────────────
-axiosInstance.interceptors.request.use(
-    (config) => {
-        // reissue 요청일 때는 기존 토큰을 첨부하지 않음
-        if (config.url?.includes('/member/reissue')) {
-            return config;
-        }
-
-        const token = authStore.getToken();
-        if (token && token !== 'null' && token !== 'undefined') {
-            config.headers['Authorization'] = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => Promise.reject(error)
-);
-
-// ── 재발급 중복 호출 방지 플래그 ───────────────────────────
+// 동시성 제어 
+let pendingQueue = [];
+// 전역 상태 관리
 let isRefreshing = false;
-let pendingQueue = []; // 재발급 중 들어온 요청들을 대기
+let isBannedAlertShowing = false;
 
+// 비동기 대기열 처리
 const processPendingQueue = (error, token = null) => {
     pendingQueue.forEach(({ resolve, reject }) => {
         if (error) {
@@ -47,34 +43,43 @@ const processPendingQueue = (error, token = null) => {
     pendingQueue = [];
 };
 
-
 // 로그아웃
 const handleLogout = () => {
+    // 토큰 파기
     authStore.clearToken();
+    // 전역 플래그 초기화 
     isRefreshing = false;
+    isBannedAlertShowing = false;
+    // 동시성 큐 초기화
+    pendingQueue = [];
+    // 강제 페이지 리다이렉트
     history.push('/login');
 };
 
 // 판별함수
-const isReissueRequest = (config) => config.url === '/member/reissue';
-const isLoginRequest = (config) => config.url.includes('/member/login');
-const isTokenExpiredError = (error) =>
-    error.response?.status === 401 &&
-    error.response?.data?.error === 'ACCESS_TOKEN_EXPIRED' &&
-    !error.config._retry;
+const isLoginRequest = (config) => !!config?.url?.includes('/member/login');
+const isTokenExpiredError = (error) => {
+    const { response, config } = error;
+    return (
+        response?.status === 401 &&
+        response?.data?.error === 'ACCESS_TOKEN_EXPIRED' &&
+        !config?._retry
+    );
+};
 
-// 알림 중복 방지 전역 상태 제어 변수
-let isBannedAlertShowing = false;
 
-// 전역 에러 처리(각 코드에 맞게)
+// 전역 에러 처리(각 코드에 맞게, 인증 만료 외 스펙 처리)
 const handleGlobalError = (error) => {
-    const { status, data, headers } = error.response || {};
+    const { response, config } = error;
+    if (!response || !config) return;
+
+    const { status, data, headers } = response;
     const message = data?.message || '알 수 없는 오류가 발생했습니다.';
 
-    if (isLoginRequest(error.config)) return;
+    if (isLoginRequest(config)) return;
 
     // 이미지 업로드 실패는 호출한 쪽(어댑터)에서 처리
-    if (error.config?.url?.includes('/image/upload')) return;
+    if (config.url?.includes('/image/upload')) return;
 
     switch (status) {
         case 403: {
@@ -84,9 +89,7 @@ const handleGlobalError = (error) => {
                     isBannedAlertShowing = true;
                     alert("해당 계정은 정지되었습니다. 로그인 페이지로 이동합니다.");
 
-                    // 토큰 파기 및 강제 페이지 리다이렉트
-                    authStore.clearToken();
-                    history.push('/login');
+                    handleLogout();
                 }
                 break;
             }
@@ -120,11 +123,19 @@ const handleGlobalError = (error) => {
 
 // 토큰 재발급 핵심 로직
 const handleTokenRefresh = async (originalRequest) => {
+    // 재시도 플래그를 통한 루프 차단(방어)
+    if (originalRequest._retry) {
+        handleLogout();
+        throw new Error('Token refresh looped detected. Forced logout.');
+    }
+
     if (isRefreshing) {
         return new Promise((resolve, reject) => {
             pendingQueue.push({ resolve, reject });
         }).then((token) => {
-            originalRequest.headers['Authorization'] = `Bearer ${token}`;
+            if (originalRequest.headers) {
+                originalRequest.headers['Authorization'] = `Bearer ${token}`;
+            }
             return axiosInstance(originalRequest);
         });
     }
@@ -133,18 +144,24 @@ const handleTokenRefresh = async (originalRequest) => {
     isRefreshing = true;
 
     try {
-        const response = await axiosInstance.post('/member/reissue');
+        // 재인증 요청은 - 인터셉터가 없는 순수 인스턴스(**pureApi**)를 사용하여 호출 (순환 참조 차단)
+        const response = await pureApi.post('/member/reissue');
+
         const authHeader = response.headers['authorization'] || response.headers['Authorization'];
         const newToken = authHeader?.replace('Bearer ', '');
 
-        if (!newToken) throw new Error('No Token');
+        if (!newToken) throw new Error('No Token in response headers');
 
         authStore.setToken(newToken);
         processPendingQueue(null, newToken);
 
-        originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+        // 실패했던 원본 요청 헤더 갱신 후 재요청
+        if (originalRequest.headers) {
+            originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+        }
         return axiosInstance(originalRequest);
     } catch (reissueError) {
+        // 리프레시 토큰 자체 만료 등으로 재발급 실패 시 동시성 큐 전원 에러처리 + 로그아웃
         processPendingQueue(reissueError);
         handleLogout();
         throw reissueError;
@@ -152,6 +169,23 @@ const handleTokenRefresh = async (originalRequest) => {
         isRefreshing = false;
     }
 };
+
+// ── 요청 인터셉터(REQUEST): Access Token 자동 첨부 ──────────────────
+axiosInstance.interceptors.request.use(
+    (config) => {
+        // reissue 요청일 때는 기존 토큰을 첨부하지 않음
+        if (config.url?.includes('/member/reissue')) {
+            return config;
+        }
+
+        const token = authStore.getToken();
+        if (token && token !== 'null' && token !== 'undefined') {
+            config.headers['Authorization'] = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
 
 // ── 응답 인터셉터(RESPONSE): 에러 처리, 만료 토큰 재발급 ───────────────
 axiosInstance.interceptors.response.use(
@@ -161,11 +195,7 @@ axiosInstance.interceptors.response.use(
     async (error) => {
         const { config } = error;
 
-        // reissue 요청 자체가 실패했을 때
-        if (isReissueRequest(config)) {
-            handleLogout();
-            // 대기 중인 다른 요청들 종료
-            processPendingQueue(error);
+        if (!config) {
             throw error;
         }
 


### PR DESCRIPTION
## 개요
- **현황**: Axios 재인증 처리를 요청 인터셉터를 지나는 인스턴스로 수행, 재발급 실패 시 리프레시 토큰까지 만료된 경우 재발급 요청 자체가 `401`에러를 유발하는 순환참조 위험성이 존재.
  - 만료된 일반 API가 `401`에러 -> 인터셉터가 `reissue API` 호출 -> 리프레시 토큰까지 만료된 경우 `reissue`rk `401`에러 -> ...
- **개선방안**: 인터셉터를 지나지 않는 순수 인스턴스를 추가하고 `reissue`의 경우 해당 인스턴스를 통하여 순환참조 가능성 제거.

## 작업내용
- **무한 요청 방지: Axios 분리**
  - 인터셉터를 통하지 않는 순수 axios 인스턴스 `pureApi`추가.
  - `/member/reissue` `post` 요청을 `pureApi`로 호출하여  인터셉터의 재개입 없이 `catch` 블록으로 수렴하도록 수정.
  - 기존 리퀘스트 인터셉터의 불필요한 `reissue` 요청 실패 예외처리 삭제.
- **리팩토링**
  - **자원 관리**: 로그아웃 시 동시성 큐 `pendingQueue`를 초기화 하여 메모리 효율 개선.
  - **타입 방어**: 판별 함수 `isLoginRequest`에 이중 부정연산자 `!!` 처리를 통해  `config` 부재 시 강제 `boolean`타입을 반환하도록 보완.
  - **중복 제거**: 에러처리 `403`의 경우 불필요하게 반복된 토큰 파기 및 강제 페이지 리다이렉트를 공통 함수 `handleLogout()`로 통합.
  - 토큰 재발급 로직 `handleTokenRefresh`의 진입부 상단에 재시도 플래그(`_retry`)를 배치하여, 비정상 흐름 즉시 예외처리.

## 결과
- **순환 참조 가능성 제거**: 장기 미접속 유저가 진입하더라도 오버플로우로 인한 브라우저 크래시 및 서버 API 무한 호출 과부하 리스크를 원천 제거하여 시스템 안정성 확보.
- **메모리 누수 방지**: 동시 API 요청 대기열인 pendingQueue를 처리 직후 및 세션 만료 시 명시적으로 초기화함으로써 메모리 누수 유발 가능성 제거.
- **작업 효율성 개선**: 공통 핸들러들을 상단으로 배치하고 인터셉터 코드를 하단으로 재배치하여 전반적인 가독성을 개선.

## 관련이슈
- Closes #142
