### PR TITLE
[Feat] CKEditor md 코드블록 추가

### DIFF
--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImpl.java
@@ -55,7 +55,10 @@ public class S3FileServiceImpl implements FileService {
             // 테이블(표) 서식 보존을 위한 속성 추가 허용
             .addAttributes("table", "border", "cellspacing", "cellpadding")
             .addAttributes("td", "colspan", "rowspan")
-            .addAttributes("th", "colspan", "rowspan");
+            .addAttributes("th", "colspan", "rowspan")
+            // 코드 블록(pre, code) 클래스(언어 지정용) 허용
+            .addAttributes("pre", "class")
+            .addAttributes("code", "class");
 
     // 용량, 해상도 제한
     private static final long MAX_FILE_SIZE = 1L * 1024 * 1024;

--- a/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
+++ b/finance-portfolio-backend/src/test/java/com/finance/finportfolio/infrastructure/file/S3FileServiceImplTest.java
@@ -220,6 +220,22 @@ class S3FileServiceImplTest {
                     .contains("img src=\"" + pureKey + "\"")
                     .doesNotContain("<script>"); // XSS 방어 살균 검증
         }
+
+        @Test
+        @DisplayName("본문을 저장용으로 전환 시 코드 블록(pre, code)의 class 속성을 유지한다")
+        void removeCdnUrlsCodeBlockClassTest() {
+            // given
+            String inputHtml = "<pre><code class=\"language-javascript\">console.log('test');</code></pre>";
+
+            // when
+            String result = s3FileService.removeCdnUrls(inputHtml);
+
+            // then
+            assertThat(result)
+                    .contains("<pre>")
+                    .contains("<code class=\"language-javascript\">")
+                    .contains("console.log('test');");
+        }
     }
 
     @Nested

--- a/finance-portfolio-frontend/src/pages/posts/PostEditor.jsx
+++ b/finance-portfolio-frontend/src/pages/posts/PostEditor.jsx
@@ -13,7 +13,9 @@ import {
     Image,
     ImageUpload,
     Heading,
-    Autoformat
+    Autoformat,
+    CodeBlock,
+    Code
 } from 'ckeditor5';
 import 'ckeditor5/ckeditor5.css';
 
@@ -128,8 +130,8 @@ const PostEditor = () => {
                         }}
                         config={{
                             licenseKey: 'GPL',
-                            plugins: [Essentials, Bold, Italic, Paragraph, Link, List, Image, ImageUpload, Autoformat, Heading],
-                            toolbar: ['heading', 'undo', 'redo', '|', 'bold', 'italic', '|', 'link', 'bulletedList', 'numberedList', '|', 'imageUpload'],
+                            plugins: [Essentials, Bold, Italic, Paragraph, Link, List, Image, ImageUpload, Autoformat, Heading, CodeBlock, Code],
+                            toolbar: ['heading', 'undo', 'redo', '|', 'bold', 'italic', 'code', '|', 'link', 'bulletedList', 'numberedList', '|', 'imageUpload', 'codeBlock'],
                             placeholder: "내용을 입력하세요..."
                         }}
                         onChange={(event, editor) => {


### PR DESCRIPTION
## 개요
- **현황**: CKEditor의 md 태그 중 `heading` 등 플러그인은 추가되었지만 백틱을 사용하는 `CodeBlock`과 `Code`가 허가되지 않아 사용성이 저하.
- **개선방안**: CKEditor에 `CodeBlock`, `Code` 플러그인을 추가하고 Jsoup에서 `pre`, `code` 클래스를 허용하여 살균되는 사태 방지.

## 작업내용
- 🍃서버
  - `S3FileServiceImpl`: 코드블록 클래스 허용 - Jsoup 살균 방지.

- ⚛️프론트
  - `PostEditor`: `CodeBlock`, `Code` 플러그인 추가.

## 결과
- **사용성 개선**: md의 핵심 기능 중 하나인 백틱을 통한 코드블록 생성을 활성화하여 편의성 증대.

## 관련PR
- #151 