### PR TITLE
[Docs] 깃 협업 및 테스트 가이드라인 전면 개편 및 독립성 강화

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -22,3 +22,5 @@ bfg-*.jar
 .idea/
 .DS_Store
 Thumbs.db
+
+docs/draft/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 .env
 
 bfg-*.jar
+
+docs/draft/

--- a/docs/git-commit-guide.md
+++ b/docs/git-commit-guide.md
@@ -7,7 +7,6 @@ You are a Senior Software Engineer specializing in Git workflow management. Your
 ## 📌 Commit Message Format
 
 Format: `[<Type>] <emoji> <subject>`
-*(Note: Leave a blank line and provide a detailed 'Body' if the work requires deeper technical context.)*
 
 ### 1. Available Types
 
@@ -31,12 +30,12 @@ Format: `[<Type>] <emoji> <subject>`
 | Backend only | 🍃 | `[Feat] 🍃 로그인 API 구현` |
 | Frontend only | ⚛️ | `[Feat] ⚛️ 로그인 UI 컴포넌트 추가` |
 | Infrastructure only | ☁️ | `[Infra] ☁️ S3 버킷 생성 및 환경변수 주입` |
-| Cross-functional / Full-Stack | (omit) | `[Feat] 포트폴리오 분석 페이지 전체 구현` |
+| Cross-functional / Full-Stack | (omit) | `[Feat] 포트폴리오 자산 분석 페이지 기능 전체 구현` |
 
-### 3. Subject & Body Language Constraints
-- **Language:** The `<subject>` and optional `<body>` MUST be written in **Korean** (한국어).
+### 3. Subject Language Constraints
+- **Language:** The `<subject>` MUST be written in **Korean** (한국어).
 - **Tone/Style:** Use the clear, concise imperative mood (명령조/명사형 마무리: e.g., "~ 구현", "~ 수정", "~ 추가").
-- **Length:** Keep the subject line under 50 characters. Provide rich, natural language context in the body to explain *what* and *why* the code changed.
+- **Length:** Keep the subject line under 20 characters.
 
 ---
 
@@ -58,6 +57,4 @@ Format: `[<Type>] <emoji> <subject>`
 
 ## 🤖 Core Agent Instructions
 1. **Dedicated Responsibility:** This file defines the rules **ONLY for commit messages**. Do not apply these rules to branch names, PR descriptions, or issues.
-2. **Context-Driven Detail:** Unlike brief branch names, the commit subject/body should be descriptive enough in natural Korean to serve as clear code review history.
-3. **Body 작성 기준:** 단순 기능 추가는 subject만으로 충분. 설계 변경, 성능 개선, 보안 패치처럼 *왜* 변경했는지 맥락이 필요한 경우에만 body를 추가.
-4. **Output Format:** Output ONLY the final recommended commit message(s). If a body is necessary, separate subject and body with a blank line.
+2. **Output Format:** Output ONLY the final recommended commit message (the single-line subject). Never include any body, extra commentary, or formatting wrapper.

--- a/docs/git-description-guide.md
+++ b/docs/git-description-guide.md
@@ -1,82 +1,62 @@
-# Git Issue & PR Description Generation Guide (Optimized for CLI/LLM)
+# Git Description Core Generation Guide (Optimized for CLI/LLM)
 
-You are a Senior Software Engineer specializing in Git workflow management. Your sole responsibility is to analyze the user's "Work Details" and fill out the appropriate template below.
+You are a Senior Software Engineer specializing in Git workflow management. Your sole responsibility is to analyze the user's "Work Details" and generate highly professional Git descriptions.
+
+This file acts as the **central repository for all shared styling and generation rules**. The actual markdown templates reside in dedicated files: `git-issue-guide.md` (for Issues) and `git-pr-guide.md` (for Pull Requests).
 
 ---
 
-## 📌 Language & Content Constraints (User Preferences)
+## 📌 Shared Language & Content Constraints (Mandatory)
 - **Language:** All outputs MUST be written in **Korean** (한국어).
-- **Tone:** Use an extremely concise, brief, and punchy natural language style.
-- **Terminology:** Avoid unnecessary technical jargon. Use professional terms only when absolutely required for context.
-- **File-Centric Mapping (CRITICAL):** In the **"작업내용" (or "변경사항")** section, you MUST strictly group the details by **Target File Names(Exclude path)** followed by their specific changes, matching the user's preferred format.
-- **Manual Fields:** Do not invent or hallucinate data for fields like `관련PR`, `관련이슈`, `closes #`, or image links. Leave them in their default template format (`- #`, `- closes #`) as the user will fill them manually.
+- **Tone:** Use a highly professional, business-like, and engineering-oriented tone. Use **noun-based / command-style endings** (명사형/명령조 마감: e.g., '~부적합', '~적용', '~제거', '~확보'). Do NOT use verbose or conversational endings like '~했습니다' or '~있었습니다'.
+- **Terminology:** Actively use rigorous, professional, and standard engineering and architectural terms (e.g., '하이브리드 문서 파이프라인 구축', '동적 데이터 바인딩', '결함 제거', '아키텍처 정렬 유지') rather than simple colloquial phrasing.
+- **Manual Fields:** Do not invent or hallucinate data for fields like `관련PR`, `관련이슈`, `closes #`, or `Closes #`. Leave them in their default template format (`- #`, `- closes #`, `- Closes #`) as the user will fill them manually.
 
 ---
 
-## 📌 Issue Templates
+## 📌 Context-Specific Rules
 
-### General Issue (Feat / Refactor / Chore / Docs / Security / Ci / Infra)
+### 1. File-Centric Mapping (PR Only - CRITICAL)
+- In the **"작업내용"** section of a PR Description, you MUST group details by **Target File Names (Exclude path)**.
+- **Tree-Style Formatting with Bullets (`-` - CRITICAL):**
+  - Basically, organize the work details into a hierarchical tree structure using bullet points (`-`). Do NOT use H3 headings (`###`) for standard file or directory groupings.
+  - **Structure Pattern:**
+    ```markdown
+    - <Scope/Directory/Category>
+      - <Logical Category/Topic>
+        - `<File Name>`: <Detailed work content in Korean (noun-style endings)>
+    ```
+  - **Actual Example:**
+    ```markdown
+    - 프론트
+      - 보안강화
+        - `private.js`: Jsoup 기반 XSS 필터 통합 및 검증 로직 고도화
+    ```
+- **H3 Header (`###`) Usage Constraint:**
+  - H3 headings (`###`) must NOT be used for listing regular files or change details.
+  - Only use `###` headings for **additional notes, structural highlights, or critical emphasis points** outside the main tree structure.
 
-```markdown
-## 개요
-- **현황**:
-- **문제상황**:
-- **개선방안**:
-
-## 작업내용
-- 
-
-## 기대효과
-- 
-
-## 관련PR
-- #
-```
-
-### Fix Issue (버그 수정 전용)
-
-```markdown
-## 개요
-- **현황**: 
-- **문제상황**: 
-- **에러메시지**: 
-- **원인**: 
-- **개선방안**: 
-
-## 작업내용
-- 
-
-## 기대효과
-- 
-
-## 관련PR
-- #
-```
+### 2. "결과" Section Guidance (PR Only - CRITICAL)
+- Do not write simple build success checks. Instead, structure the "결과" section to focus on the **architectural impact, design values, and structural alignment** (e.g., how the changes align with existing pipelines or improve long-term system maintainability), using punchy bold headers (e.g., `- **보안강화**: ...`, `- **사용자경험(UX)**: ...`).
 
 ---
 
-## 📌 PR Description Template
+## 📌 Template Routing & Orchestration
 
-```markdown
-## 개요
-- **현황**: 
-- **문제상황**: 
-- **개선방안**: 
+Depending on the user's intent, you must pull the exact raw template from its respective guide and fill it out using the shared rules in this file:
 
-## 작업내용
-- 
-
-## 결과
--
-
-## 관련이슈
-- Closes #
-```
+1. **For Issue Descriptions (Case 4):**
+   - Reference [`git-issue-guide.md`](./git-issue-guide.md) to retrieve the raw **Issue Template**.
+   - Apply the rules from this document to populate the template.
+2. **For Pull Request Descriptions (Case 3):**
+   - Reference [`git-pr-guide.md`](./git-pr-guide.md) to retrieve the raw **PR Templates** (General vs Fix).
+   - Detect the work type and select the appropriate PR template.
+   - Apply the rules from this document (including File-Centric Mapping and "결과" Section Guidance) to populate the template.
+3. **For Integrated Issue & PR Descriptions (Case 6):**
+   - Reference both files and produce both outputs using their respective templates.
 
 ---
 
 ## 🤖 Core Agent Instructions
-1. **Dedicated Responsibility:** This file defines the rules **ONLY for Issue and PR descriptions**. Do not apply these rules to branch names or commit messages.
-2. **Template Selection:** Detect the work type from "Work Details" and automatically select the correct Issue template (General vs Fix). If ambiguous, default to General Issue.
-3. **Omit Irrelevant Fields:** If a section is not applicable to the context (e.g., no error message exists for a Fix Issue), remove that field entirely rather than leaving it blank.
-4. **Output Format:** Output ONLY the filled-out template. Do not include any explanation or preamble.
+1. **Dedicated Responsibility:** This file defines the styling rules and orchestration. Do not apply these rules to branch names, commit messages, or test code.
+2. **Output Format:** Output ONLY the final populated markdown template. Do not include any explanations, preambles, or routing notes in the output.

--- a/docs/git-issue-guide.md
+++ b/docs/git-issue-guide.md
@@ -1,0 +1,25 @@
+# Git Issue Template
+
+This file contains the standardized Issue description template. For styling, language constraints, and generation rules, refer to [`git-description-guide.md`](./git-description-guide.md).
+
+---
+
+## 📌 Issue Template (Feat / Refactor / Chore / Docs / Security / Ci / Infra / Bug Fix)
+
+```markdown
+## 개요
+- **현황**:
+- **문제상황**:
+  - 
+- **개선방안**:
+  - 
+
+## 작업내용
+- 
+
+## 기대효과
+- 
+
+## 관련PR
+- #
+```

--- a/docs/git-pr-guide.md
+++ b/docs/git-pr-guide.md
@@ -1,0 +1,51 @@
+# Git Pull Request Templates
+
+This file contains the standardized Pull Request (PR) description templates. For styling, language constraints, and generation rules, refer to [`git-description-guide.md`](./git-description-guide.md).
+
+---
+
+## 📌 PR Templates
+
+### 1. General PR Template (Feat / Refactor / Chore / Docs / Security / Ci / Infra)
+
+```markdown
+## 개요
+- **현황**: 
+- **문제상황**: 
+  - 
+- **개선방안**: 
+  - 
+
+## 작업내용
+- 
+
+## 결과
+- 
+
+## 관련이슈
+- Closes #
+```
+
+### 2. Fix PR Template (버그 수정 전용)
+
+```markdown
+## 개요
+- **현황**: 
+- **문제상황**: 
+  - 
+- **에러메시지**: 
+  - 
+- **원인**: 
+  - 
+- **개선방안**: 
+  - 
+
+## 작업내용
+- 
+
+## 결과
+- 
+
+## 관련이슈
+- Closes #
+```

--- a/docs/git-routing-guide.md
+++ b/docs/git-routing-guide.md
@@ -1,11 +1,11 @@
 # Git Workflow Routing Guide (Optimized for CLI/LLM)
 
-This document functions as the core routing controller for all Git-related assistance.
-Analyze the user's Korean prompt, identify the corresponding intent, and reference ONLY the specified target file.
+This document functions as the core routing controller and output coordinator for all Git-related assistance.
+Analyze the user's Korean prompt, identify the corresponding intent, reference the correct child files, and orchestrate the final output format.
 
 ---
 
-## 📌 Routing Rules
+## 📌 Routing & Orchestration Rules
 
 ### Case 1: Branch Name Only
 - **User Intent:** Requests for a new branch name based on current work or issue.
@@ -17,18 +17,22 @@ Analyze the user's Korean prompt, identify the corresponding intent, and referen
 
 ### Case 3: Pull Request Description
 - **User Intent:** Requests to generate a PR summary, change logs, or description templates.
-- **Reference File:** [`./git-description-guide.md`](./git-description-guide.md)
+- **Reference Files:** 
+  1. [`./git-description-guide.md`](./git-description-guide.md) (For common rules, language & content constraints)
+  2. [`./git-pr-guide.md`](./git-pr-guide.md) (For the raw PR templates: General vs Fix)
 
 ### Case 4: Issue Description
 - **User Intent:** Requests to define requirements or create a new issue task before coding.
-- **Reference File:** [`./git-issue-guide.md`](./git-issue-guide.md)
+- **Reference Files:** 
+  1. [`./git-description-guide.md`](./git-description-guide.md) (For common rules, language & content constraints)
+  2. [`./git-issue-guide.md`](./git-issue-guide.md) (For the raw Issue template)
 
 ### Case 5: Branch Name + Commit Message (Simultaneous)
 - **User Intent:** Requests for BOTH a branch name AND a commit message in a single prompt.
 - **Action:**
   1. Reference `git-branch-guide.md` and generate the branch name first.
   2. Reference `git-commit-guide.md` and generate the commit message second.
-  3. Apply the **Cross-Reference Sync Rule** below to ensure consistency between the two outputs.
+  3. Apply the **Cross-Reference Sync Rule** below to ensure consistency.
 
 #### Cross-Reference Sync Rule
 Both artifacts MUST be synchronized:
@@ -36,12 +40,30 @@ Both artifacts MUST be synchronized:
 - **Scope Alignment:** Branch prefix → commit emoji mapping is defined in `git-commit-guide.md` Section 2.
 
 ### Case 6: Issue & PR Description Integration (Comprehensive)
-- **User Intent:** Requests to generate both Issue and PR descriptions, or generic description templates.
-- **Reference File:** [`./git-description-guide.md`](./git-description-guide.md)
+- **User Intent:** Requests to generate both Issue and PR descriptions simultaneously, or generic description templates.
+- **Action:** Reference [`./git-description-guide.md`](./git-description-guide.md), [`./git-issue-guide.md`](./git-issue-guide.md), and [`./git-pr-guide.md`](./git-pr-guide.md). Follow the respective guidelines and templates to generate both filled-out templates.
+
+---
+
+## 📌 Draft Generation & File Output Rule (CRITICAL)
+
+For cases where description drafts are generated (specifically **Case 3, Case 4, Case 5, and Case 6**):
+1. **No Direct Chat Output:** Do NOT output the complete generated markdown content (PR description, Issue template, etc.) directly as the main chat response.
+2. **File Creation:** Automatically write the generated markdown content to a new file in the `docs/draft/` directory.
+3. **Naming Convention:** Use the exact pattern: `docs/draft/<branch-name>_<YYYYMMDD>.md`
+   - *Example:* If the branch name is `docs/add-and-simplify-git-workflow-guides`, and the date is June 20, 2026, the file must be: `docs/draft/docs-add-and-simplify-git-workflow-guides_20260620.md`
+   - *Constraint:* Slashes (`/`) in the branch name must be replaced with hyphens (`-`) to form a valid filename.
+4. **Ultra-Concise Chat Response (CRITICAL - Token Saving & Readability):**
+   - The chat response MUST be extremely brief. Do NOT output, list, or repeat any part of the generated file's written content (e.g., do not print the templates, change lists, or descriptions).
+   - The response must strictly contain only:
+     - **확인 메시지**: `"요청하신 작업이 <생성된_파일_경로> 파일에 성공적으로 저장되었습니다."`
+     - **특이사항**: Any unique conditions, context-driven alerts, or highlights.
+     - **규칙 예외 알림**: Notification if the generated output deviates significantly from standard rules.
 
 ---
 
 ## 🤖 Core Agent Instructions
 1. **Language Handling:** The user will prompt in Korean. Parse these English guidelines to process the logic.
-2. **Context Isolation:** For Cases 1–4, open and read ONLY the `.md` file mapped to the detected case. Do not mix rules from different files.
+2. **Context Isolation:** For Case 1 and Case 2, open and read ONLY the `.md` file mapped to the detected case. For Case 3, Case 4, and Case 6, read the combined reference files listed. Do not mix rules from other unmapped files.
 3. **Case 5 Priority:** If both a branch name and a commit message are requested, always treat it as Case 5 and apply the Cross-Reference Sync Rule. Do not process them as two separate Case 1 + Case 2 requests.
+4. **File Generation Enforcement:** Always adhere strictly to the **Draft Generation & File Output Rule** for any description generation tasks (Cases 3, 4, 5, 6).

--- a/docs/git-test-guide.md
+++ b/docs/git-test-guide.md
@@ -1,0 +1,149 @@
+# Git Test Code Development Guide (Optimized for CLI/LLM)
+
+You are a Senior Software Engineer specializing in quality assurance and automated testing. Your sole responsibility is to analyze the user's testing requirements and generate/review test code that strictly conforms to the standardized rules below.
+
+---
+
+## 📌 Language & Tone Constraints (User Preferences)
+- **Language:** All annotations, display names, and test scenario descriptions MUST be written in **Korean** (한국어).
+- **Tone:** Use a highly professional, engineering-oriented, and concise tone. Use **noun-based / command-style endings** (명사형/명령조 마감: e.g., '~검증', '~성공', '~실패', '~확인', '~동작'). Do NOT use verbose or conversational endings like '~했습니다' or '~테스트합니다'.
+
+---
+
+## 📌 Test File Naming & Package Rules
+
+### 1. File Naming Convention
+- **Unit/Integration Test Files:** MUST suffix the target class name with `Test.java`.
+  - *Example:* `AdminController` ➔ `AdminControllerTest.java`
+  - *Example:* `S3FileServiceImpl` ➔ `S3FileServiceImplTest.java`
+
+### 2. Directory & Package Symmetry
+- Test files MUST reside in the `src/test/java` directory, mirroring the exact package structure of the production class in `src/main/java`.
+  - *Main Class Path:* `src/main/java/com/finance/finportfolio/domain/admin/service/AdminService.java`
+  - *Test Class Path:* `src/test/java/com/finance/finportfolio/domain/admin/service/AdminServiceTest.java`
+
+---
+
+## 📌 Import Optimization & Library Conventions
+
+### 1. Avoid Wildcard Imports
+- Do NOT use wildcard imports for test APIs (e.g., `import org.junit.jupiter.api.*;`).
+- Explicitly import only the required annotations and assertions to maintain static analysis and build optimization.
+
+### 2. Static Imports for Readability
+- Use static imports for standard assertion and mock verification libraries to ensure clean and readable DSLs.
+  - *AssertJ:* `import static org.assertj.core.api.Assertions.assertThat;`
+  - *AssertJ Throwing:* `import static org.assertj.core.api.Assertions.assertThatThrownBy;`
+  - *Mockito:* `import static org.mockito.Mockito.*;`
+  - *Mockito BDDAssertions:* `import static org.mockito.BDDMockito.*;`
+
+---
+
+## 📌 Standard Test Scenario Structure (Given-When-Then)
+
+All test methods must follow the structured **Given-When-Then (GWT)** design pattern, separated clearly with code comments or logical blocks.
+
+### 1. BDD-Style Structure Template
+
+```java
+@Test
+@DisplayName("동작_조건_결과_명사형_종결")
+void testMethodName() {
+    // given (준비 단계: Mock 데이터 세팅, 상태 전제 조건 설정)
+    
+    // when (실행 단계: 테스트 대상 메서드 호출)
+    
+    // then (검증 단계: AssertJ를 이용한 행위 및 결과 상태 단언)
+}
+```
+
+### 2. Display Name Rules
+- Every test method MUST be annotated with `@DisplayName`.
+- Use snake_case or clean space formatting to separate contextual components: `[대상클래스_메서드]_[시나리오/상태]_[기대결과]`
+- *Correct Example:* `@DisplayName("AdminService_회원탈퇴_성공")`
+- *Incorrect Example:* `@DisplayName("회원탈퇴가 성공적으로 끝나는지 확인하는 테스트입니다")`
+
+### 3. Comprehensive Coverage Guidelines
+- **Happy Path:** Verify that the code behaves as expected under normal conditions.
+- **Edge/Failure Cases:** Explicitly verify error propagation and exception handling. Use `assertThatThrownBy()` to assert exact exception types and custom error response formats.
+- **Hierarchical Contexts:** Use JUnit 5's `@Nested` annotation to group tests logically (e.g., grouping by API endpoint or service method) to improve test report readability.
+
+---
+
+## 📝 Test Code Implementation Example
+
+```java
+package com.finance.finportfolio.domain.admin.service;
+
+import com.finance.finportfolio.domain.member.entity.Member;
+import com.finance.finportfolio.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminService 단위 테스트")
+class AdminServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Nested
+    @DisplayName("회원 비활성화 로직 검증")
+    class DisableMemberTest {
+
+        @Test
+        @DisplayName("존재하는_회원_비활성화_성공")
+        void givenExistingMember_whenDisableMember_thenStatusChangesToInactive() {
+            // given
+            Long memberId = 1L;
+            Member member = Member.builder()
+                    .id(memberId)
+                    .active(true)
+                    .build();
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            adminService.disableMember(memberId);
+
+            // then
+            assertThat(member.isActive()).isFalse();
+            verify(memberRepository).findById(memberId);
+        }
+
+        @Test
+        @DisplayName("존재하지_않는_회원_조회시_예외발생")
+        void givenNonExistingMember_whenDisableMember_thenThrowException() {
+            // given
+            Long memberId = 99L;
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> adminService.disableMember(memberId))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("존재하지 않는 회원");
+        }
+    }
+}
+```
+
+---
+
+## 🤖 Core Agent Instructions
+1. **Dedicated Responsibility:** This file defines the rules **ONLY for generating or auditing test files**. Do not apply these rules to production logic.
+2. **Strict Conformance:** When generating test code, ensure imports are minimized, DisplayNames strictly follow the 명사형/명령조 style, and GWT blocks are clearly delineated.
+3. **Output Format:** When asked to generate or review a test file, explain the design choice briefly according to this guide, then output the compliant test class.


### PR DESCRIPTION
## 개요
- **현황**: 일관성 없는 깃 이력 관리와 테스트 코드 품질 격차를 해소하기 위해 가이드라인 제정을 시도함.
- **문제상황**:
  - 기존 협업 가이드라인 간의 역할 중복 및 불명확한 데이터 흐름으로 인해 에이전트 생성 품질의 안정성 저하.
  - 독립적인 성격을 지닌 테스트 작성 가이드라인이 라우팅 시스템에 바인딩되어 아키텍처적 결합도 가중.
  - 설명 초안 생성 시 대규모 텍스트가 화면에 반복 출력되어 토큰 낭비 및 가독성 저해 초래.
- **개선방안**:
  - 라우팅 가이드를 전면 재구조화하여 각 가이드 간의 위상 정립 및 결합 관계 최적화.
  - 테스트 코드 가이드를 라우팅 제어 대상에서 제외하여 독자적인 표준으로 기획 및 독립화 적용.
  - 드래프트 출력 시 화면 중복 전송을 전면 금지하고 마크다운 파일 영구 저장 및 확인형 초간결 응답 템플릿 강제화.
  - 작업 내용 서술 스타일을 `###` 제목 대신 리스트 트리(`-`) 형식으로 통일하여 가독성 상향 평준화.

## 작업내용
- 문서 (docs)
  - 깃 협업 표준 정립 및 라우팅 컨트롤러 개선
    - `git-routing-guide.md`: 중복 제거를 통한 컨트롤러-차일드 위상 확립, 테스트 가이드라인 완전 Decouple 처리 및 드래프트 결과물의 세션 대답 초간결화(Token-saving) 룰 추가
    - `git-description-guide.md`: 작업내용 기술 방식을 `-` 트리 형태로 표준화하고 `###` 헤더를 특이사항 전용으로 제한하는 마크다운 규약 세분화
    - `git-commit-guide.md`: 한 줄짜리 제목(Subject) 작성에 집중할 수 있도록 복잡한 커밋 본문(Body) 제약조건 완전 제거 및 슬림화
    - `git-issue-guide.md`: 정형화된 마크다운 포맷의 표준 이슈 템플릿 구축
    - `git-pr-guide.md`: 작업 성격별(일반/버그 수정) 표준 PR 템플릿 2종 신설 및 양식 통일
  - 테스트 품질 규정 및 가이드 분리
    - `git-test-guide.md`: JUnit 5 기반 명명 규칙, 패키지 대칭성, GWT 구조 및 `@DisplayName` 명사형 종결 표준을 담은 독립 가이드 확립

## 결과
- **토큰 효율성 극대화**: 드래프트 결과를 파일 저장 방식으로 일원화하고 화면 출력을 배제함으로써 대화 히스토리의 가독성을 확보하고 토큰 낭비 원인을 원천 차단함.
- **구조적 아키텍처 결합 차단**: 테스트 가이드라인을 라우팅 가이드라인에서 완전히 격리하여 상호 변경 전파를 제어하고, 독립적인 기술 아티팩트로서의 활용도를 보장함.
- **가독성 및 일관성 확보**: 설명서 계층형 트리 서술 표준 및 한 줄 커밋 원칙을 수립하여 협업을 위한 깃 히스토리 품질 수준을 대폭 향상함.

## 관련PR/이슈
- #149
- Closes #150 