### PR TITLE
[Fix] frontend-ci 워크플로우 PR 이벤트 브랜치 분기처리 수정

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -53,18 +53,28 @@ jobs:
           -Dsonar.qualitygate.wait=true \
           -Dsonar.qualitygate.timeout=300
 
-    # 품질 게이트 통과 후 빌드 수행 (main 브랜치일 경우 PROD_API_URL, 그 외 브랜치일 경우 DEV_API_URL 사용)
+    # 품질 게이트 통과 후 빌드 수행
     # 검증되지 않은 브랜치에서 빌드 시도 시 에러 발생
     - name: Build Project
       run: |
-        if [ "${{ github.base_ref }}" == "develop" ] || [ "${{ github.ref }}" == "refs/heads/develop" ]; then
+        # 브랜치명 추출 (PR일 경우 base_ref인 develop/main 사용, push일 경우 ref에서 브랜치명만 잘라냄)
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          TARGET_BRANCH="${{ github.base_ref }}"
+        else
+          TARGET_BRANCH="${{ github.ref_name }}"
+        fi
+
+        echo "Target Branch evaluated as: $TARGET_BRANCH"
+
+        # 추출한 대상 브랜치 기준으로 빌드 환경 분기
+        if [ "$TARGET_BRANCH" == "develop" ]; then
           echo "Detected DEV Environment. Building with DEV_API_URL..."
           VITE_API_BASE_URL=${{ secrets.DEV_API_URL }} npm run build
-        elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
+        elif [ "$TARGET_BRANCH" == "main" ]; then
           echo "Detected PROD Environment. Building with PROD_API_URL..."
           VITE_API_BASE_URL=${{ secrets.PROD_API_URL }} npm run build
         else
-          echo "CRITICAL ERROR: Unrecognized branch [${{ github.ref }}]. Build blocked for safety to prevent production environment contamination."
+          echo "CRITICAL ERROR: Unrecognized branch [$TARGET_BRANCH]. Build blocked for safety to prevent production environment contamination."
           exit 1
         fi
 

--- a/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/entity/Member.java
+++ b/finance-portfolio-backend/src/main/java/com/finance/finportfolio/domain/member/entity/Member.java
@@ -80,7 +80,7 @@ public class Member {
             ZonedDateTime nowInSeoul = ZonedDateTime.now(seoulZone);
             // 기존 LocalDateTime 타입 필드에 서울 시간대(KST) 정보를 명시적으로 결합하여 ZonedDateTime으로 변환
             ZonedDateTime lockedUntilWithZone = this.lockedUntil.atZone(seoulZone);
-            // 시간대 정보가 포함된 두 인자 간의 기간 계산 (소나 경고 해결)
+            // 시간대 정보가 포함된 두 인자 간의 기간 계산
             long remainingMinutes = Duration.between(nowInSeoul, lockedUntilWithZone).toMinutes();
             
             StringBuilder message = new StringBuilder("인증에 5회 이상 실패했습니다. ");

--- a/finance-portfolio-frontend/README.md
+++ b/finance-portfolio-frontend/README.md
@@ -3,4 +3,4 @@
 - 백엔드 finance-portfolio(java spring)와 연결된
 React(+ vite) 프론트 프로젝트입니다. 
 
-- AWS S3를 통해 배포할 예정입니다.
+- AWS S3를 통해 배포할 예정입니다. 


### PR DESCRIPTION
## 개요 
- **문제상황**: 프론트엔드 CI 워크플로우의 Build 단계에서 브랜치 검사 조건문을 통과하지 못하고 빌드가 블록되는 현상 발생.
<img width="680" height="166" alt="image" src="https://github.com/user-attachments/assets/0bf94be9-b8d0-4534-9a88-3a0df76417c5" />

- **원인**: push 이벤트와 달리 PR 이벤트 시에는 GitHub의 내부 임시 머지 브랜치 경로인 `refs/pull/[PR_NUMBER]/merge`가 `${{ github.ref }}` 값으로 주입되어 기존 조건문이 이를 인식하지 못함.
- **개선방안**: 이벤트 종류에 따라 순수 브랜치명만 정확히 추출하도록 $TARGET_BRANCH 변수 할당 로직을 추가하여, 이벤트 환경 변화에 영향을 받지 않도록 분기 구조 개선.

## 작업내용
- `frontend-ci.yml`: 이벤트 형태(`push / pull_request`)별 브랜치명 추출 과정을 추가하고, 해당 환경 변수를 기반으로 DEV/PROD 빌드 환경을 분기 처리하도록 스크립트 수정.

## 결과
- **빌드 안정성**: 가변적인 Git 참조 경로 대신 정제된 브랜치명을 기준으로 환경을 평가함으로써, 향후 CI 과정에서 발생할 수 있는 빌드 차단 이슈를 방지.
