### PR TITLE
[Security] GitHub Actions 라이브러리 참조 방식 변경 (태그 -> SHA hash)

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -26,7 +26,7 @@ jobs:
 
     # [보안] AWS Credentials 설정 (보안 그룹 제어용)
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@f79bc868ee9ca4687c7db10f05fe6a46cdcda892 # v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
     # [배포] docker-compose.yml 파일을 EC2로 전송 (SCP)
     - name: Copy docker-compose.yml to EC2
-      uses: appleboy/scp-action@master
+      uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
       with:
         host: ${{ secrets.EC2_HOST }}
         username: ${{ secrets.EC2_USERNAME }}
@@ -54,7 +54,7 @@ jobs:
 
     # [배포] EC2에 접속해서 배포 실행 (SSH)
     - name: Deploy to EC2
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
       with:
         host: ${{ secrets.EC2_HOST }}
         username: ${{ secrets.EC2_USERNAME }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,18 +65,18 @@ jobs:
 
     # [DOCKER] Hub 로그인
     - name: Login to Docker Hub
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     # [DOCKER][성능] Buildx: Docker에 type=gha 캐싱 등 확장 기능 추가
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
     # [DOCKER] 이미지 빌드 복사 및 푸시
     - name: Build and Push Docker Image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: ./finance-portfolio-backend
         push: true

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -22,17 +22,14 @@ jobs:
     # 검증되지 않은 브랜치에서 배포 시도 시 에러 발생
     - name: Set Environment Variables
       run: |
-        if [ "${{ github.base_ref }}" == "develop" ] || [ "${{ github.ref }}" == "refs/heads/develop" ]; then
-          echo "Detected DEV Environment. Setting DEV variables..."
-          echo "S3_BUCKET=${{ secrets.DEV_S3_BUCKET_NAME }}" >> $GITHUB_ENV
-          echo "CF_ID=${{ secrets.DEV_CF_DISTRIBUTION_ID }}" >> $GITHUB_ENV
-        elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
+        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
           echo "Detected PROD Environment. Setting PROD variables..."
           echo "S3_BUCKET=${{ secrets.PROD_S3_BUCKET_NAME }}" >> $GITHUB_ENV
           echo "CF_ID=${{ secrets.PROD_CF_DISTRIBUTION_ID }}" >> $GITHUB_ENV
         else
-          echo "CRITICAL ERROR: Unrecognized branch [${{ github.ref }}]. Variable injection blocked for safety."
-          exit 1
+          echo "Detected Test/DEV Environment (${{ github.ref }}). Setting DEV variables..."
+          echo "S3_BUCKET=${{ secrets.DEV_S3_BUCKET_NAME }}" >> $GITHUB_ENV
+          echo "CF_ID=${{ secrets.DEV_CF_DISTRIBUTION_ID }}" >> $GITHUB_ENV
         fi
 
     # [AWS] 권한 설정

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -37,7 +37,7 @@ jobs:
 
     # [AWS] 권한 설정
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@f79bc868ee9ca4687c7db10f05fe6a46cdcda892 # v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## 개요
- **문제 상황**: 현재 워크플로우에서 외부 GitHub Actions 라이브러리 및 플러그인을 가져올 때 `v4` 등의 태그 방식을 사용 중임.
- **위험성**: 메인테이너의 계정 탈취나 외부 저장소 오염으로 인해 동일한 태그에 악성 코드가 업데이트될 경우, 공급망 공격에 무방비로 노출되어 당사 파이프라인까지 즉각적으로 오염될 위험이 존재.
- **개선방안**: 라이브러리 참조 방식을 태그 -> SHA hash 방식으로 전환.

## 작업내용
- **참조방식 전환**
  - `backend-cd.yml`:
    - aws-actions/configure-aws-credentials
    - appleboy/scp-action
    - appleboy/ssh-action
  - `backend-ci.yml`:
    - docker/login-action
    - docker/setup-buildx-action
    - docker/build-push-action
  - `frontend-cd.yml`:
    - aws-actions/configure-aws-credentials
- **브랜치별 배포 분기처리 완화**
  - `frontend-cd.yml`: `main`일 경우 PROD 환경, `develop`일 경우 DEV 환경에 배포 방식에서 `main`일 경우 PROD 환경, 그 외 DEV 환경에 배포되도록 조건을 완화.

## 결과
- **보안 무결성 확보**: 외부 라이브러리의 악의적인 코드 변경이나 변질로부터 파이프라인 격리.
- **워크플로우 처리 유연화**: 과도하게 엄격한 브랜치별 배포조건을 완화하여 `workflow_dispatch`를 통한 수동 배포 시에도 워크플로우가 예상치 못한 정지를 발생시키는 사례 최소화.

## 관련이슈
- Closes #160