### PR TITLE
[Refactor] AWS SSM Parameter Store 기반 환경변수 이관 및 계층화

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -15,8 +15,10 @@ jobs:
       run: |
         if [ "${{ github.base_ref }}" == "main" ] || [ "${{ github.ref }}" == "refs/heads/main" ]; then
           echo "TAG=latest" >> $GITHUB_ENV
+          echo "ENV_TYPE=prod" >> $GITHUB_ENV
         else
           echo "TAG=dev" >> $GITHUB_ENV
+          echo "ENV_TYPE=dev" >> $GITHUB_ENV
         fi
 
     # [보안] GitHub Actions 서버의 공인 IP 가져오기
@@ -62,20 +64,33 @@ jobs:
         script: |
           mkdir -p ~/finance-portfolio
           cd ~/finance-portfolio
+
+          # 기존 환경변수 파일 초기화
+          > .env 
+
+          # (AWS) SSM Parameter Store 환경변수 수집
+          SSM_PATH="/finance-portfolio/${{ env.ENV_TYPE }}/backend/"
+
+          aws ssm get-parameters-by-path \
+            --path "$SSM_PATH" \
+            --with-decryption \
+            --region ap-northeast-2 \
+            --query "Parameters[*].[Name,Value]" \
+            --output text | while read -r name value; do
+              # 파라미터 키 이름에서 최하위 변수명만 추출 (ex: /.../DB_PASSWORD -> DB_PASSWORD)
+              var_name=$(basename "$name")
+              echo "${var_name}=${value}" >> .env
+          done
           
-          # 환경변수 파일(.env) 동적 생성
-          cat <<EOF > .env
-          DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
-          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          CF_SECRET_KEY=${{ secrets.CF_SECRET_KEY }}
-          JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
-          EOF
+          # Docker 로그인 (SSM | GitHub Secretes)
+          DOCKER_USER=$(grep '^DOCKER_USERNAME=' .env | cut -d '=' -f2-)
+          DOCKER_PASS=$(grep '^DOCKER_PASSWORD=' .env | cut -d '=' -f2-)
           
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ]; then
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          fi
           
-          // 브랜치에 따라 배포할 서비스 결정
+          # 브랜치에 따라 배포할 서비스 결정
           if [ "${{ env.TAG }}" == "latest" ]; then
             TARGET_SERVICES="app-prod db-prod"
           else
@@ -87,6 +102,9 @@ jobs:
           
           # 해당 서비스만 컨테이너 재생성 및 백그라운드 실행
           docker-compose up -d --force-recreate $TARGET_SERVICES
+
+          # [보안] 임시 생성된 환경변수 파일 삭제
+          rm -f .env
           
           # [안정성] 디스크 용량 부족 방지
           docker image prune -f

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,11 +17,43 @@ jobs:
       run: |
         if [ "${{ github.base_ref }}" == "main" ] || [ "${{ github.ref }}" == "refs/heads/main" ]; then
           echo "TAG=latest" >> $GITHUB_ENV
+          echo "ENV_TYPE=prod" >> $GITHUB_ENV
         else
           echo "TAG=dev" >> $GITHUB_ENV
+          echo "ENV_TYPE=dev" >> $GITHUB_ENV
         fi
 
-    # JDK 세팅 [SONAR]
+    # [보안] AWS Credentials 설정 (CI 빌드 시 SSM 조회용)
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@f79bc868ee9ca4687c7db10f05fe6a46cdcda892 # v6
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-northeast-2
+
+    # [보안] SSM Parameter Store 환경변수 가져오기
+    - name: Export SSM Parameters to GITHUB_ENV
+      run: |
+        SSM_PATH="/finance-portfolio/${{ env.ENV_TYPE }}/backend/"
+        
+        while read -r name value; do
+          if [ -n "$name" ]; then
+            var_name=$(basename "$name")
+            
+            # 특수문자 및 줄바꿈 대응을 위한 Delimiter 설정
+            DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "${var_name}<<${DELIMITER}" >> $GITHUB_ENV
+            echo "${value}" >> $GITHUB_ENV
+            echo "${DELIMITER}" >> $GITHUB_ENV
+          fi
+        done < <(aws ssm get-parameters-by-path \
+          --path "$SSM_PATH" \
+          --with-decryption \
+          --region ap-northeast-2 \
+          --query "Parameters[*].[Name,Value]" \
+          --output text)
+
+    # [SONAR] JDK 세팅
     - name: (Sonar) Set up JDK 21 
       uses: actions/setup-java@v5
       with:


### PR DESCRIPTION
## 개요
- **배경**:
  - 배포 시 EC2 디스크에 `.env` 평문 파일을 영구 보관하여 발생하던 보안 유출 위험 차단 필요.
  - 환경변수 추가/변경 시 GitHub Secrets 및 배포 스크립트를 매번 수정해야 하는 관리 오버헤드 존재.
- **목적**:
  - AWS SSM Parameter Store 도입을 통한 환경변수 중앙 집중 관리 및 보안성 강화.
  - CI/CD 파이프라인 연동 및 배포 시 `.env` 디스크 영구 저장 방식 제거.

## 작업내용
- ☁️AWS
  - **AWS SSM Parameter Store 파라미터 계층화 등록**
    - `/finance-portfolio/prod/backend/` 계층 구조 설계 및 런타임 환경변수 이관.
    - `DOCKER_USERNAME` (`String`), `DB_PASSWORD`, `JWT_SECRET_KEY`,  `CF_SECRET_KEY` (`SecureString` - KMS 암호화) 등록.
  - **EC2 최소 권한 IAM Role 구축 및 연결**
    - `FinancePortfolioEC2Role` 생성 및 인스턴스 연결 (기존 CloudWatch 권한 통합: #167 ).
    - 해당 경로(`/finance-portfolio/prod/backend/*`)만 접근 허용하는 최소 권한 Inline Policy 작성.
    - EC2 내 AWS Access Key/Secret Key 평문 의존성 완전 제거.

- CI/CD 
  - **워크플로우(Github Actions) 고도화**
    - **CI (`Backend CI`)**: 빌드 시 SSM Parameter Store에서 환경변수를 수집하여 `GITHUB_ENV`에 안전하게 주입하는 Step 구축.
    - **CD (`Backend CD`)**: SSH 실행 단계에서 SSM 기반 임시 `.env` 수집 -> 컨테이너 주입 -> 배포 즉시 `.env` 삭제(`rm -f`) 흐름 적용.

## 결과
- **디스크 잔재 Zero화**: EC2 서버 디스크 내 민감 평문 파일(`.env`) 영구 방치 문제 완전 해결.
- **자격 증명 노출 차단**: EC2 및 GitHub Secrets 내 AWS Access Key 평문 저장 의존성 제거.
- **검증 완료**: EC2 내 IAM Role을 통한 `aws ssm get-parameter` 복호화 조회 및 CI/CD 자동 배포 정상 동작 확인.

## 관련이슈/PR
- Closes #170
- #167