### PR TITLE
[Refactor] Frontend CD 워크플로우 리팩토링 및 캐싱 전략 최적화

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -57,22 +57,22 @@ jobs:
         SSM_PATH="/finance-portfolio/${{ env.ENV_TYPE }}/backend/"
 
         aws ssm get-parameters-by-path \
-          --path "$SSM_PATH" \
+          --path "\$SSM_PATH" \
           --with-decryption \
           --region ap-northeast-2 \
           --query "Parameters[*].[Name,Value]" \
           --output text | while read -r name value; do
             # 파라미터 키 이름에서 최하위 변수명만 추출 (ex: /.../DB_PASSWORD -> DB_PASSWORD)
-            var_name=$(basename "$name")
-            echo "${var_name}=${value}" >> .env
+            var_name=\$(basename "\$name")
+            echo "\${var_name}=\${value}" >> .env
         done
 
         # [보안] Docker Hub 로그인 (SSM에서 수집한 계정 정보 활용)
-        DOCKER_USER=$(grep '^DOCKER_USERNAME=' .env | cut -d '=' -f2-)
-        DOCKER_PASS=$(grep '^DOCKER_PASSWORD=' .env | cut -d '=' -f2-)
+        DOCKER_USER=\$(grep '^DOCKER_USERNAME=' .env | cut -d '=' -f2-)
+        DOCKER_PASS=\$(grep '^DOCKER_PASSWORD=' .env | cut -d '=' -f2-)
 
-        if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ]; then
-          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+        if [ -n "\$DOCKER_USER" ] && [ -n "\$DOCKER_PASS" ]; then
+          echo "\$DOCKER_PASS" | docker login -u "\$DOCKER_USER" --password-stdin
         fi
 
         # [배포 Target] 브랜치 및 태그에 따라 배포 대상 서비스 결정
@@ -83,10 +83,10 @@ jobs:
         fi
 
         # [성능] 지정된 타깃 서비스의 이미지만 pull 진행
-        docker compose pull $TARGET_SERVICES
+        docker compose pull \$TARGET_SERVICES
 
         # [배포] 해당 서비스만 컨테이너 재생성 및 백그라운드 실행
-        docker compose up -d --force-recreate $TARGET_SERVICES
+        docker compose up -d --force-recreate \$TARGET_SERVICES
 
         # [보안] 임시 생성된 환경변수 파일 삭제
         rm -f .env

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -27,7 +27,7 @@ jobs:
           echo "ENV_TYPE=dev" >> $GITHUB_ENV
         fi
 
-    # [보안] AWS Credentials 설정 (CI 빌드 시 SSM 조회용)
+    # [보안] AWS Credentials 설정 (CI 빌드 시 SSM 조회용, OIDC 토큰 기반 인증)
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@f79bc868ee9ca4687c7db10f05fe6a46cdcda892 # v6
       with:

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -25,7 +25,7 @@ jobs:
     # [ENV] 환경 변수 설정 (브랜치에 따라 목적지 S3와 CDN ID 결정, main 브랜치: PROD, 이외 브랜치: DEV)
     - name: Set Environment Variables
       run: |
-        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+        if [ "${{ github.base_ref }}" == "main" ] || [ "${{ github.ref }}" == "refs/heads/main" ]; then
           echo "Detected PROD Environment. Setting PROD variables..."
           echo "S3_BUCKET=${{ secrets.PROD_S3_BUCKET_NAME }}" >> $GITHUB_ENV
           echo "CF_ID=${{ secrets.PROD_CF_DISTRIBUTION_ID }}" >> $GITHUB_ENV
@@ -45,7 +45,18 @@ jobs:
     # [AWS] S3에 빌드 결과물 업로드 
     # Sync: 차이점만 반영, --delete: 삭제된 구 파일은 삭제
     - name: Upload to S3
-      run: aws s3 sync dist/ s3://${{ env.S3_BUCKET }} --delete
+      run: |
+        # 1. index.html 제외 자산: 1년 장기 캐싱 (Vite 해시 파일 재활용)
+        aws s3 sync dist/ s3://${{ env.S3_BUCKET }} \
+          --exclude "index.html" \
+          --cache-control "max-age=31536000, immutable" \
+          --delete
+
+        # 2. index.html: 무캐싱 (항상 원본 서버 검증)
+        aws s3 sync dist/ s3://${{ env.S3_BUCKET }} \
+          --exclude "*" \
+          --include "index.html" \
+          --cache-control "no-cache, no-store, must-revalidate"
 
     # [AWS] CloudFront 캐시 무효화 (빌드 시 캐시 삭제로 구 버전 호출 방지)
     - name: CloudFront Invalidation


### PR DESCRIPTION
## 개요
- **현황**:
  - 브랜치 판별 조건이 변경된 백엔드 CD와 다르게 레거시 상태로 운영 중.
  - `aws s3 sync dist/ s3://${{ env.S3_BUCKET }} --delete` 구문으로 인해 모든 파일에 동일한 기본 Cache-Control이 적용.

## 작업내용
- `frontend-cd.yml`:
  - 브랜치 판별 비교 조건 강화:
    - `github.base_ref` 조건을 추가하여 PR 트리거 시점에서도 main 브랜치 타깃 여부를 정확히 감지하도록 수정(백엔드 CD와 조건 통일).
  - 정적 자산 캐싱 전략 적용:
    - `index.html`을 제외한 파일들: 1년 장기 캐싱.
    - `index.html`: 무캐싱 (항상 최신 빌드 결과물 참조)
- `backend-cd.yml`:
  - 이스케이프처리: `$` -> `\$` 이스케이프 처리를 통한 문자열 치환 이슈 방지

## 결과
- **안정성**: `github.base_ref` 적용으로 PR 및 Merge 이벤트 시 환경변수 바인딩 오작동 방지.
- **성능**: 해시명이 부여되는 JS/CSS의 브라우저 및 CDN 장기 재사용으로 초기 로딩 속도 향상.
- **비용**: 불필요한 CloudFront 데이터 전송량 및 Origin 요청 건수 감소.

<img width="724" height="489" alt="image" src="https://github.com/user-attachments/assets/dd444080-7254-4f76-824d-675f14deb0ca" />


## 관련이슈
- Closes #176 